### PR TITLE
revisit MPNN

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2187,9 +2187,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
  "regex-automata 0.4.9",
@@ -2911,9 +2911,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -5881,9 +5881,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -6148,9 +6148,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -9887,7 +9887,7 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.3",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -12992,9 +12992,9 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b940ebc25896e71dd073bad2dbaa2abfe97b0a391415e22ad1326d9c54e3c4"
+checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
 
 [[package]]
 name = "xmlwriter"

--- a/crates/ferritin-examples/examples/ligandmpnn/Readme.md
+++ b/crates/ferritin-examples/examples/ligandmpnn/Readme.md
@@ -1,5 +1,9 @@
 # ligandmpnn
 
 ```sh
+# this will run but slowly as its on the CPU
 cargo run --example ligandmpnn
+
+# this has some issues with F64/F32
+cargo run --example ligandmpnn --features metal
 ```

--- a/crates/ferritin-examples/examples/ligandmpnn/Readme.md
+++ b/crates/ferritin-examples/examples/ligandmpnn/Readme.md
@@ -1,0 +1,5 @@
+# ligandmpnn
+
+```sh
+cargo run --example ligandmpnn
+```

--- a/crates/ferritin-examples/examples/ligandmpnn/main.rs
+++ b/crates/ferritin-examples/examples/ligandmpnn/main.rs
@@ -1,0 +1,27 @@
+use anyhow::Result;
+use candle_core::pickle::PthTensors;
+use candle_core::{DType, Device, Error};
+use candle_nn::VarBuilder;
+use ferritin_core::load_structure;
+use ferritin_plms::{LMPNNFeatures, ProteinMPNN, ProteinMPNNConfig};
+use ferritin_test_data::TestFile;
+
+fn main() -> Result<()> {
+    println!("Loading the Model and Tokenizer.......");
+    let (protfile, _handle) = TestFile::protein_01().create_temp()?;
+    let ac = load_structure(protfile)?;
+
+    let (mpnn_file, _handle) = TestFile::ligmpnn_pmpnn_01().create_temp()?;
+    let pth = PthTensors::new(mpnn_file, Some("model_state_dict"))?;
+    let vb = VarBuilder::from_backend(Box::new(pth), DType::F32, Device::Cpu);
+    let pconf = ProteinMPNNConfig::proteinmpnn();
+    let pmpnn = ProteinMPNN::load(vb, &pconf)?;
+
+    let features = ac.featurize(&candle_core::Device::Cpu)?;
+    let encoded = pmpnn.encode(&features)?;
+    // let model = LigandMPNN::new()?;
+    // let logits = model.run_model(ac, 10, 0.1)?;
+    // println!("{:?}", logits);
+
+    Ok(())
+}

--- a/crates/ferritin-examples/examples/ligandmpnn/main.rs
+++ b/crates/ferritin-examples/examples/ligandmpnn/main.rs
@@ -18,7 +18,9 @@ fn main() -> Result<()> {
     let pmpnn = ProteinMPNN::load(vb, &pconf)?;
 
     let features = ac.featurize(&candle_core::Device::Cpu)?;
+    println!("Features");
     let encoded = pmpnn.encode(&features)?;
+    println!("Encoded");
     // let model = LigandMPNN::new()?;
     // let logits = model.run_model(ac, 10, 0.1)?;
     // println!("{:?}", logits);

--- a/crates/ferritin-examples/examples/ligandmpnn/main.rs
+++ b/crates/ferritin-examples/examples/ligandmpnn/main.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
 use candle_core::pickle::PthTensors;
-use candle_core::{DType, Device, Error};
+use candle_core::{DType, Device};
 use candle_nn::VarBuilder;
 use ferritin_core::load_structure;
-use ferritin_plms::{LMPNNFeatures, ProteinMPNN, ProteinMPNNConfig};
+use ferritin_plms::{LMPNNFeatures, ProteinMPNN, ProteinMPNNConfig, device};
 use ferritin_test_data::TestFile;
 
 fn main() -> Result<()> {
@@ -17,7 +17,8 @@ fn main() -> Result<()> {
     let pconf = ProteinMPNNConfig::proteinmpnn();
     let pmpnn = ProteinMPNN::load(vb, &pconf)?;
 
-    let features = ac.featurize(&candle_core::Device::Cpu)?;
+    // let features = ac.featurize(&candle_core::Device::Cpu)?;
+    let features = ac.featurize(&device(false)?)?;
     println!("Features");
     let encoded = pmpnn.encode(&features)?;
     println!("Encoded");

--- a/crates/ferritin-plms/src/ligandmpnn/model.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/model.rs
@@ -383,7 +383,7 @@ impl ProteinMPNN {
         let features = ProteinFeaturesModel::load(vb.pp("features"), config.clone())?;
 
         Ok(Self {
-            config: config.clone(), // todo: check the\is clone later...
+            config: config.clone(),
             decoder_layers,
             device: vb.device().clone(),
             encoder_layers,
@@ -394,7 +394,7 @@ impl ProteinMPNN {
         })
     }
     fn encode(&self, features: &ProteinFeatures) -> Result<(Tensor, Tensor, Tensor)> {
-        let s_true = &features.get_sequence();
+        let s_true = features.get_sequence();
         let base_dtype = DType::F32;
         let mask = match features.get_sequence_mask() {
             Some(m) => m,
@@ -403,43 +403,47 @@ impl ProteinMPNN {
         match self.config.model_type {
             ModelTypes::ProteinMPNN => {
                 let (e, e_idx) = self.features.forward(features, &self.device)?;
-                let mut h_v = Tensor::zeros(
+
+                let h_v = Tensor::zeros(
                     (e.dim(0)?, e.dim(1)?, e.dim(D::Minus1)?),
                     base_dtype,
                     &self.device,
                 )?;
-                let mut h_e = self.w_e.forward(&e)?;
-                let mask_attend = if let Some(mask) = features.get_sequence_mask() {
-                    let mask_expanded = mask.unsqueeze(D::Minus1)?; // [B, L, 1]
-                    let mask_gathered = gather_nodes(&mask_expanded, &e_idx)?;
-                    let mask_gathered = mask_gathered.squeeze(D::Minus1)?;
-                    let mask_attend = {
-                        let mask_unsqueezed = mask.unsqueeze(D::Minus1)?; // [B, L, 1]
-                        let mask_expanded = mask_unsqueezed.expand((
+                let h_e = self.w_e.forward(&e)?;
+
+                let mask_attend = if let Some(seq_mask) = features.get_sequence_mask() {
+                    let mask_expanded = seq_mask.unsqueeze(D::Minus1)?; // [B, L, 1]
+                    let mask_gathered = gather_nodes(&mask_expanded, &e_idx)?.squeeze(D::Minus1)?;
+                    let mask_unsqueezed = mask.unsqueeze(D::Minus1)?; // [B, L, 1]
+                    mask_unsqueezed
+                        .expand((
                             mask_gathered.dim(0)?, // batch
                             mask_gathered.dim(1)?, // sequence length
                             mask_gathered.dim(2)?, // number of neighbors
-                        ))?;
-                        mask_expanded.mul(&mask_gathered)?
-                    };
-                    mask_attend
+                        ))?
+                        .mul(&mask_gathered)?
                 } else {
                     let (b, l) = mask.dims2()?;
                     Tensor::ones((b, l, e_idx.dim(2)?), DType::F32, &self.device)?
                 };
                 println!("Beginning the Encoding...");
-                for layer in self.encoder_layers.iter() {
-                    let (new_h_v, new_h_e) = layer.forward(
-                        &h_v,
-                        &h_e,
-                        &e_idx,
-                        Some(mask),
-                        Some(&mask_attend),
-                        Some(false),
-                    )?;
-                    h_v = new_h_v;
-                    h_e = new_h_e;
-                }
+
+                // Process through all encoder layers
+                let (h_v, h_e) =
+                    self.encoder_layers
+                        .iter()
+                        .fold(Ok((h_v, h_e)), |acc, layer| {
+                            let (h_v, h_e) = acc?;
+                            layer.forward(
+                                &h_v,
+                                &h_e,
+                                &e_idx,
+                                Some(mask),
+                                Some(&mask_attend),
+                                Some(false),
+                            )
+                        })?;
+
                 Ok((h_v, h_e, e_idx))
             }
             ModelTypes::LigandMPNN => {
@@ -477,6 +481,10 @@ impl ProteinMPNN {
                 //     Ok((h_v, h_e, e_idx))
             }
         }
+    }
+    fn decode(&self) {
+        // take the output from encode and decode to logits
+        todo!()
     }
     pub fn sample(
         &self,
@@ -933,9 +941,8 @@ impl ProteinMPNN {
     }
 
     pub fn score(&self, features: &ProteinFeatures, use_sequence: bool) -> Result<ScoreOutput> {
-        let sample_dtype = DType::F32;
         let ProteinFeatures { s, x_mask, .. } = &features;
-
+        let sample_dtype = DType::F32;
         let s_true = &s.clone();
         let device = s_true.device();
         let (b, l) = s_true.dims2()?;
@@ -945,7 +952,7 @@ impl ProteinMPNN {
         // Todo: This is a hack. we should be passing in encoded chains.
         // Update chain_mask to include missing regions
         let chain_mask = Tensor::zeros_like(mask.unwrap())?.to_dtype(sample_dtype)?;
-        let chain_mask = mask.unwrap().mul(&chain_mask)?;
+        let chain_mask = mask.unwrap().mul(&chain_mask)?; // does the order count here?
 
         // encode ...
         let (h_v, h_e, e_idx) = self.encode(features)?;
@@ -966,8 +973,8 @@ impl ProteinMPNN {
                 let permutation_matrix_reverse = one_hot(decoding_order.clone(), l, 1f32, 0f32)?
                     .to_dtype(sample_dtype)?
                     .contiguous()?;
-                let tril = Tensor::tril2(l, sample_dtype, device)?;
-                let tril = tril.unsqueeze(0)?;
+
+                let tril = Tensor::tril2(l, sample_dtype, device)?.unsqueeze(0)?;
                 let temp = tril
                     .matmul(&permutation_matrix_reverse.transpose(1, 2)?)?
                     .contiguous()?; // shape (b, i, q)
@@ -977,23 +984,28 @@ impl ProteinMPNN {
                 let mask_attend = order_mask_backward
                     .gather(&e_idx, 2)?
                     .unsqueeze(D::Minus1)?;
-                let mask_1d = mask.unwrap().reshape((b, l, 1, 1))?;
+
                 // Broadcast mask_1d to match mask_attend's shape
-                let mask_1d = mask_1d
+                let mask_1d = mask
+                    .unwrap()
+                    .reshape((b, l, 1, 1))?
                     .broadcast_as(mask_attend.shape())?
                     .to_dtype(sample_dtype)?;
+
                 let mask_bw = mask_1d.mul(&mask_attend)?;
                 let mask_fw = mask_1d.mul(&(mask_attend - 1.0)?.neg()?)?;
                 (mask_fw, mask_bw, e_idx, decoding_order)
             }
         };
-        let b_decoder = b_decoder;
+
         let s_true = s_true.repeat(&[b_decoder, 1])?;
         let h_v = h_v.repeat(&[b_decoder, 1, 1])?;
         let h_e = h_e.repeat(&[b_decoder, 1, 1, 1])?;
-        let mask = x_mask.as_ref().unwrap().repeat(&[b_decoder, 1])?;
+        let mask = mask.as_ref().unwrap().repeat(&[b_decoder, 1])?;
+
         let h_s = self.w_s.forward(&s_true)?; // embedding layer
         let h_es = cat_neighbors_nodes(&h_s, &h_e, &e_idx)?;
+
         // Build encoder embeddings
         let h_ex_encoder = cat_neighbors_nodes(&Tensor::zeros_like(&h_s)?, &h_e, &e_idx)?;
         let h_exv_encoder = cat_neighbors_nodes(&h_v, &h_ex_encoder, &e_idx)?;
@@ -1001,18 +1013,24 @@ impl ProteinMPNN {
             .broadcast_as(h_exv_encoder.shape())?
             .to_dtype(h_exv_encoder.dtype())?
             .mul(&h_exv_encoder)?;
-        let mut h_v = h_v;
-        if !use_sequence {
-            for layer in &self.decoder_layers {
-                h_v = layer.forward(&h_v, &h_exv_encoder_fw, Some(&mask), None, None)?;
-            }
+
+        // Apply decoder layers
+        let h_v = if !use_sequence {
+            // Simple forward pass through decoder layers
+            self.decoder_layers.iter().fold(Ok(h_v), |acc, layer| {
+                layer.forward(&acc?, &h_exv_encoder_fw, Some(&mask), None, None)
+            })?
         } else {
-            for layer in &self.decoder_layers {
-                let h_esv = cat_neighbors_nodes(&h_v, &h_es, &e_idx)?;
-                let h_esv = mask_bw.mul(&h_esv)?.add(&h_exv_encoder_fw)?;
-                h_v = layer.forward(&h_v, &h_esv, Some(&mask), None, None)?;
-            }
-        }
+            // Forward pass with sequence-aware processing
+            self.decoder_layers.iter().fold(Ok(h_v), |acc, layer| {
+                let current_h_v = acc?;
+                let h_esv = cat_neighbors_nodes(&current_h_v, &h_es, &e_idx)?
+                    .mul(&mask_bw)?
+                    .add(&h_exv_encoder_fw)?;
+                layer.forward(&current_h_v, &h_esv, Some(&mask), None, None)
+            })?
+        };
+
         let logits = self.w_out.forward(&h_v)?;
         let log_probs = log_softmax(&logits, D::Minus1)?;
 

--- a/crates/ferritin-plms/src/ligandmpnn/model.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/model.rs
@@ -65,19 +65,17 @@ pub struct ScoreOutput {
     pub(crate) logits: Tensor,
     pub(crate) decoding_order: Tensor,
 }
+///  Score dims are [Batch, seqlength]
 impl ScoreOutput {
-    // S dims are [Batch, seqlength]
     pub fn get_sequences(&self) -> Result<Vec<String>> {
         let (b, l) = self.s.dims2()?;
         let mut sequences = Vec::with_capacity(b);
         for batch_idx in 0..b {
+            let batch = self.s.get(batch_idx)?;
             let mut sequence = String::with_capacity(l);
             for pos in 0..l {
-                let aa_idx = self.s.get(batch_idx)?.get(pos)?.to_vec0::<u32>()?;
-                // println!("Position {}, Raw index: {}", pos, aa_idx);
-                let aa = int_to_aa1(aa_idx);
-                // println!("Converted to: {}", aa);
-                sequence.push(aa);
+                let aa_idx = batch.get(pos)?.to_vec0::<u32>()?;
+                sequence.push(int_to_aa1(aa_idx));
             }
             sequences.push(sequence);
         }
@@ -123,9 +121,7 @@ impl PositionWiseFeedForward {
 
 impl Module for PositionWiseFeedForward {
     fn forward(&self, x: &Tensor) -> Result<Tensor> {
-        let x = self.w1.forward(x)?;
-        let x = x.gelu()?;
-        self.w2.forward(&x)
+        self.w1.forward(x)?.gelu().and_then(|x| self.w2.forward(&x))
     }
 }
 
@@ -926,9 +922,6 @@ impl ProteinMPNN {
         }
     }
 
-    fn single_aa_score() {
-        todo!()
-    }
     pub fn score(&self, features: &ProteinFeatures, use_sequence: bool) -> Result<ScoreOutput> {
         let sample_dtype = DType::F32;
         let ProteinFeatures { s, x_mask, .. } = &features;

--- a/crates/ferritin-plms/src/ligandmpnn/model.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/model.rs
@@ -394,6 +394,7 @@ impl ProteinMPNN {
         })
     }
     pub fn encode(&self, features: &ProteinFeatures) -> Result<(Tensor, Tensor, Tensor)> {
+        println!("Encode01");
         let s_true = features.get_sequence();
         let base_dtype = DType::F32;
         let mask = match features.get_sequence_mask() {
@@ -402,15 +403,25 @@ impl ProteinMPNN {
         };
         match self.config.model_type {
             ModelTypes::ProteinMPNN => {
-                let (e, e_idx) = self.features.forward(features, &self.device)?;
+                println!("Encode02");
 
+                let (e, e_idx) = self.features.forward(features, &self.device)?;
+                println!(
+                    "Edge features dimensions: e: {:?}, e_idx: {:?}",
+                    e.dims(),
+                    e_idx.dims()
+                );
+
+                println!("Encode03");
                 let h_v = Tensor::zeros(
                     (e.dim(0)?, e.dim(1)?, e.dim(D::Minus1)?),
                     base_dtype,
                     &self.device,
                 )?;
+                println!("Encode04");
                 let h_e = self.w_e.forward(&e)?;
 
+                println!("Encode05");
                 let mask_attend = if let Some(seq_mask) = features.get_sequence_mask() {
                     let mask_expanded = seq_mask.unsqueeze(D::Minus1)?; // [B, L, 1]
                     let mask_gathered = gather_nodes(&mask_expanded, &e_idx)?.squeeze(D::Minus1)?;

--- a/crates/ferritin-plms/src/ligandmpnn/model.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/model.rs
@@ -393,7 +393,7 @@ impl ProteinMPNN {
             w_s,
         })
     }
-    fn encode(&self, features: &ProteinFeatures) -> Result<(Tensor, Tensor, Tensor)> {
+    pub fn encode(&self, features: &ProteinFeatures) -> Result<(Tensor, Tensor, Tensor)> {
         let s_true = features.get_sequence();
         let base_dtype = DType::F32;
         let mask = match features.get_sequence_mask() {

--- a/crates/ferritin-plms/src/ligandmpnn/model.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/model.rs
@@ -394,7 +394,6 @@ impl ProteinMPNN {
         })
     }
     pub fn encode(&self, features: &ProteinFeatures) -> Result<(Tensor, Tensor, Tensor)> {
-        println!("Encode01");
         let s_true = features.get_sequence();
         let base_dtype = DType::F32;
         let mask = match features.get_sequence_mask() {
@@ -403,25 +402,13 @@ impl ProteinMPNN {
         };
         match self.config.model_type {
             ModelTypes::ProteinMPNN => {
-                println!("Encode02");
-
                 let (e, e_idx) = self.features.forward(features, &self.device)?;
-                println!(
-                    "Edge features dimensions: e: {:?}, e_idx: {:?}",
-                    e.dims(),
-                    e_idx.dims()
-                );
-
-                println!("Encode03");
                 let h_v = Tensor::zeros(
                     (e.dim(0)?, e.dim(1)?, e.dim(D::Minus1)?),
                     base_dtype,
                     &self.device,
                 )?;
-                println!("Encode04");
                 let h_e = self.w_e.forward(&e)?;
-
-                println!("Encode05");
                 let mask_attend = if let Some(seq_mask) = features.get_sequence_mask() {
                     let mask_expanded = seq_mask.unsqueeze(D::Minus1)?; // [B, L, 1]
                     let mask_gathered = gather_nodes(&mask_expanded, &e_idx)?.squeeze(D::Minus1)?;
@@ -438,16 +425,9 @@ impl ProteinMPNN {
                     Tensor::ones((b, l, e_idx.dim(2)?), DType::F32, &self.device)?
                 };
                 println!("Beginning the Encoding...");
-
-                println!("h_v dtype: {:?}", h_v.dtype());
-                println!("h_e dtype: {:?}", h_e.dtype());
-                println!("e_idx dtype: {:?}", e_idx.dtype());
-                println!("mask dtype: {:?}", mask.dtype());
-                println!("mask_attend dtype: {:?}", mask_attend.dtype());
-
-                // Convert masks to F32 before passing them to the encoder layers
-                let mask_f32 = mask.to_dtype(DType::F32)?;
-                let mask_attend_f32 = mask_attend.to_dtype(DType::F32)?;
+                // todo: dtype handling not ideal
+                let mask_f32 = mask.to_dtype(base_dtype)?;
+                let mask_attend_f32 = mask_attend.to_dtype(base_dtype)?;
 
                 // Process through all encoder layers
                 let (h_v, h_e) =
@@ -459,10 +439,8 @@ impl ProteinMPNN {
                                 &h_v,
                                 &h_e,
                                 &e_idx,
-                                // Some(mask),
-                                // Some(&mask_attend),
-                                Some(&mask_f32),        // Use F32 mask
-                                Some(&mask_attend_f32), // Use F32 mask_attend
+                                Some(&mask_f32),
+                                Some(&mask_attend_f32),
                                 Some(false),
                             )
                         })?;

--- a/crates/ferritin-plms/src/ligandmpnn/model.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/model.rs
@@ -304,12 +304,14 @@ impl DecLayer {
     ) -> Result<Tensor> {
         let training_bool = training.unwrap_or(false);
 
+        // Expand node features to match edge dimensions
         let expand_shape = [
             h_e.dims()[0], // batch (1)
             h_e.dims()[1], // sequence length (93)
             h_e.dims()[2], // number of neighbors (24)
             h_v.dims()[2], // keep original hidden dim (128)
         ];
+
         let h_v_expand = h_v.unsqueeze(D::Minus2)?.expand(&expand_shape)?;
         let h_ev = Tensor::cat(&[&h_v_expand, h_e], D::Minus1)?.contiguous()?;
 
@@ -322,21 +324,24 @@ impl DecLayer {
             .apply(&self.w3)?;
 
         let h_message = self.dropout1.forward(&h_message, training_bool)?;
-        let h_message = if let Some(mask) = mask_attend {
-            mask.unsqueeze(D::Minus1)?.broadcast_mul(&h_message)?
-        } else {
-            h_message
-        };
+
+        let h_message = mask_attend
+            .map(|mask| mask.unsqueeze(D::Minus1)?.broadcast_mul(&h_message))
+            .transpose()?
+            .unwrap_or(h_message);
+
         let dh = (h_message.sum(D::Minus2)? / self.scale)?;
         let h_v = self.norm1.forward(&(h_v + dh)?)?;
         let dh = self.dense.forward(&h_v)?;
         let dh_dropout = self.dropout2.forward(&dh, training_bool)?;
         let h_v = self.norm2.forward(&(h_v + dh_dropout)?)?;
-        let h_v = if let Some(mask) = mask_v {
-            mask.unsqueeze(D::Minus1)?.broadcast_mul(&h_v)?
-        } else {
-            h_v
-        };
+
+        // Apply optional node mask
+        let h_v = mask_v
+            .map(|mask| mask.unsqueeze(D::Minus1)?.broadcast_mul(&h_v))
+            .transpose()?
+            .unwrap_or(h_v);
+
         Ok(h_v)
     }
 }

--- a/crates/ferritin-plms/src/ligandmpnn/model.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/model.rs
@@ -439,6 +439,16 @@ impl ProteinMPNN {
                 };
                 println!("Beginning the Encoding...");
 
+                println!("h_v dtype: {:?}", h_v.dtype());
+                println!("h_e dtype: {:?}", h_e.dtype());
+                println!("e_idx dtype: {:?}", e_idx.dtype());
+                println!("mask dtype: {:?}", mask.dtype());
+                println!("mask_attend dtype: {:?}", mask_attend.dtype());
+
+                // Convert masks to F32 before passing them to the encoder layers
+                let mask_f32 = mask.to_dtype(DType::F32)?;
+                let mask_attend_f32 = mask_attend.to_dtype(DType::F32)?;
+
                 // Process through all encoder layers
                 let (h_v, h_e) =
                     self.encoder_layers
@@ -449,8 +459,10 @@ impl ProteinMPNN {
                                 &h_v,
                                 &h_e,
                                 &e_idx,
-                                Some(mask),
-                                Some(&mask_attend),
+                                // Some(mask),
+                                // Some(&mask_attend),
+                                Some(&mask_f32),        // Use F32 mask
+                                Some(&mask_attend_f32), // Use F32 mask_attend
                                 Some(false),
                             )
                         })?;

--- a/crates/ferritin-plms/src/ligandmpnn/model.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/model.rs
@@ -152,22 +152,25 @@ impl EncLayer {
         let augment_eps = config.augment_eps as f64;
         let num_in = (config.hidden_dim * 2) as usize;
         let dropout_ratio = config.dropout_ratio;
-        let norm1 = layer_norm::layer_norm(num_hidden, augment_eps, vb.pp("norm1"))?;
-        let norm2 = layer_norm::layer_norm(num_hidden, augment_eps, vb.pp("norm2"))?;
-        let norm3 = layer_norm::layer_norm(num_hidden, augment_eps, vb.pp("norm3"))?;
 
-        let w1 = linear::linear(num_hidden + num_in, num_hidden, vb.pp("W1"))?;
-        let w2 = linear::linear(num_hidden, num_hidden, vb.pp("W2"))?;
-        let w3 = linear::linear(num_hidden, num_hidden, vb.pp("W3"))?;
-        let w11 = linear::linear(num_hidden + num_in, num_hidden, vb.pp("W11"))?;
-        let w12 = linear::linear(num_hidden, num_hidden, vb.pp("W12"))?;
-        let w13 = linear::linear(num_hidden, num_hidden, vb.pp("W13"))?;
+        // Create layer norms
+        let norm1 = layer_norm(num_hidden, augment_eps, vb.pp("norm1"))?;
+        let norm2 = layer_norm(num_hidden, augment_eps, vb.pp("norm2"))?;
+        let norm3 = layer_norm(num_hidden, augment_eps, vb.pp("norm3"))?;
 
+        // Create linear layers
+        let w1 = linear(num_hidden + num_in, num_hidden, vb.pp("W1"))?;
+        let w2 = linear(num_hidden, num_hidden, vb.pp("W2"))?;
+        let w3 = linear(num_hidden, num_hidden, vb.pp("W3"))?;
+        let w11 = linear(num_hidden + num_in, num_hidden, vb.pp("W11"))?;
+        let w12 = linear(num_hidden, num_hidden, vb.pp("W12"))?;
+        let w13 = linear(num_hidden, num_hidden, vb.pp("W13"))?;
+
+        // Create dropouts with same ratio
         let dropout1 = Dropout::new(dropout_ratio);
         let dropout2 = Dropout::new(dropout_ratio);
         let dropout3 = Dropout::new(dropout_ratio);
 
-        // note in the pytorch code they add the GELU activation here.
         let dense = PositionWiseFeedForward::new(vb.pp("dense"), num_hidden, num_hidden * 4)?;
 
         Ok(Self {
@@ -209,24 +212,25 @@ impl EncLayer {
             .gelu()?
             .apply(&self.w3)?;
 
-        let h_message = if let Some(mask) = mask_attend {
-            mask.unsqueeze(D::Minus1)?.broadcast_mul(&h_message)?
-        } else {
-            h_message
-        };
+        let h_message = mask_attend
+            .map(|mask| mask.unsqueeze(D::Minus1)?.broadcast_mul(&h_message))
+            .transpose()?
+            .unwrap_or(h_message);
+
         // Safe division with scale
-        let sum = h_message.sum(D::Minus2)?;
         let scale = if self.scale == 0.0 { 1.0 } else { self.scale };
-        let dh = (sum / scale)?;
+        let dh = (h_message.sum(D::Minus2)? / scale)?;
+
         let h_v = apply_dropout_and_norm(&h_v, &dh, &self.dropout1, &self.norm1, training)?;
         let dense_output = self.dense.forward(&h_v)?;
         let h_v =
             apply_dropout_and_norm(&h_v, &dense_output, &self.dropout2, &self.norm2, training)?;
-        let h_v = if let Some(mask) = mask_v {
-            mask.unsqueeze(D::Minus1)?.broadcast_mul(&h_v)?
-        } else {
-            h_v
-        };
+
+        // Apply mask if provided
+        let h_v = mask_v
+            .map(|mask| mask.unsqueeze(D::Minus1)?.broadcast_mul(&h_v))
+            .transpose()?
+            .unwrap_or(h_v);
 
         let h_ev = concat_node_tensors(&h_v, h_e, e_idx)?;
         let h_message = self
@@ -236,6 +240,7 @@ impl EncLayer {
             .apply(&self.w12)?
             .gelu()?
             .apply(&self.w13)?;
+
         let h_e = apply_dropout_and_norm(h_e, &h_message, &self.dropout3, &self.norm3, training)?;
         Ok((h_v, h_e))
     }

--- a/crates/ferritin-plms/src/ligandmpnn/proteinfeatures.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/proteinfeatures.rs
@@ -62,7 +62,8 @@ impl LMPNNFeatures for AtomCollection {
 
         // Get residue IDs for r_idx
         let residue_ids = self.get_res_index();
-        let r_idx = Tensor::from_iter(residue_ids, device)?;
+        let residue_length = residue_ids.len();
+        let r_idx = Tensor::from_iter(residue_ids, device)?.reshape((1, residue_length))?;
 
         // Extract chain information
         let chain_letters: Vec<String> = self
@@ -102,13 +103,9 @@ impl LMPNNFeatures for AtomCollection {
 
         // N/CA/C/O
         let n = x.narrow(2, 0, 1)?.squeeze(2)?.contiguous()?;
-        println!("n shape: {:?}", n.dims());
         let ca = x.narrow(2, 1, 1)?.squeeze(2)?.contiguous()?;
-        println!("ca shape: {:?}", ca.dims());
         let c = x.narrow(2, 2, 1)?.squeeze(2)?.contiguous()?;
-        println!("c shape: {:?}", c.dims());
         let o = x.narrow(2, 3, 1)?.squeeze(2)?.contiguous()?;
-        println!("o shape: {:?}", o.dims());
 
         Ok(ProteinFeatures {
             s,

--- a/crates/ferritin-plms/src/ligandmpnn/proteinfeatures.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/proteinfeatures.rs
@@ -53,14 +53,8 @@ impl LMPNNFeatures for AtomCollection {
         let x_37 = self.to_numeric_atom37(device)?;
         let x_37_m = Tensor::zeros((x_37.dim(0)?, x_37.dim(1)?), DType::F64, device)?;
         let (y, y_t, y_m) = self.to_numeric_ligand_atoms(device)?;
-
-        // get CB locations...
         let cb = calculate_cb(&x_37);
-
-        // chain_labels = np.array(CA_atoms.getChindices(), dtype=np.int32)
         let chain_labels = self.get_resids(); //  <-- need to double-check shape. I think this is all-atom
-
-        // Get residue IDs for r_idx
         let residue_ids = self.get_res_index();
         let residue_length = residue_ids.len();
         let r_idx = Tensor::from_iter(residue_ids, device)?.reshape((1, residue_length))?;
@@ -81,8 +75,6 @@ impl LMPNNFeatures for AtomCollection {
 
         // Numeric chain labels (optional)
         let chain_labels: Option<Vec<f64>> = None; // Could populate if needed
-
-        // amino acid names as int....
         let s = self.encode_amino_acids(device)?;
 
         // coordinates of the backbone atoms
@@ -93,12 +85,6 @@ impl LMPNNFeatures for AtomCollection {
         )?;
 
         let x = x_37.index_select(&indices, 2)?;
-
-        // // N/CA/C/O
-        // let n = x.narrow(2, 0, 1)?.squeeze(2)?.contiguous()?;
-        // let ca = x.narrow(2, 1, 1)?.squeeze(2)?.contiguous()?;
-        // let c = x.narrow(2, 2, 1)?.squeeze(2)?.contiguous()?;
-        // let o = x.narrow(2, 3, 1)?.squeeze(2)?.contiguous()?;
 
         Ok(ProteinFeatures {
             s,
@@ -145,7 +131,7 @@ impl LMPNNFeatures for AtomCollection {
         Tensor::from_vec(backbone_data, (1, res_count, 4, 3), device)
     }
 
-    /// create numeric Tensor of shape [<sequence-length>, 37, 3]
+    /// create numeric Tensor of shape [batch <sequence-length>, 37, 3]
     fn to_numeric_atom37(&self, device: &Device) -> Result<Tensor> {
         let res_count = self.iter_residues_aminoacid().count();
         let mut atom37_data = vec![0f32; res_count * 37 * 3];
@@ -161,7 +147,6 @@ impl LMPNNFeatures for AtomCollection {
                 }
             }
         }
-        // Create tensor with shape [residues, 37, 3]
         Tensor::from_vec(atom37_data, (1, res_count, 37, 3), device)
     }
 

--- a/crates/ferritin-plms/src/ligandmpnn/proteinfeatures.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/proteinfeatures.rs
@@ -90,8 +90,25 @@ impl LMPNNFeatures for AtomCollection {
             (4,),
             &device,
         )?;
+        println!(
+            "Initial shapes - x: {:?}, mask: {:?}, r_idx: {:?}",
+            x_37.dims(),
+            x_37_m.dims(),
+            r_idx.dims()
+        );
 
-        let x = x_37.index_select(&indices, 1)?;
+        let x = x_37.index_select(&indices, 2)?;
+        println!("After index_select - x shape: {:?}", x.dims());
+
+        // N/CA/C/O
+        let n = x.narrow(2, 0, 1)?.squeeze(2)?.contiguous()?;
+        println!("n shape: {:?}", n.dims());
+        let ca = x.narrow(2, 1, 1)?.squeeze(2)?.contiguous()?;
+        println!("ca shape: {:?}", ca.dims());
+        let c = x.narrow(2, 2, 1)?.squeeze(2)?.contiguous()?;
+        println!("c shape: {:?}", c.dims());
+        let o = x.narrow(2, 3, 1)?.squeeze(2)?.contiguous()?;
+        println!("o shape: {:?}", o.dims());
 
         Ok(ProteinFeatures {
             s,

--- a/crates/ferritin-plms/src/ligandmpnn/proteinfeatures.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/proteinfeatures.rs
@@ -91,21 +91,14 @@ impl LMPNNFeatures for AtomCollection {
             (4,),
             &device,
         )?;
-        println!(
-            "Initial shapes - x: {:?}, mask: {:?}, r_idx: {:?}",
-            x_37.dims(),
-            x_37_m.dims(),
-            r_idx.dims()
-        );
 
         let x = x_37.index_select(&indices, 2)?;
-        println!("After index_select - x shape: {:?}", x.dims());
 
-        // N/CA/C/O
-        let n = x.narrow(2, 0, 1)?.squeeze(2)?.contiguous()?;
-        let ca = x.narrow(2, 1, 1)?.squeeze(2)?.contiguous()?;
-        let c = x.narrow(2, 2, 1)?.squeeze(2)?.contiguous()?;
-        let o = x.narrow(2, 3, 1)?.squeeze(2)?.contiguous()?;
+        // // N/CA/C/O
+        // let n = x.narrow(2, 0, 1)?.squeeze(2)?.contiguous()?;
+        // let ca = x.narrow(2, 1, 1)?.squeeze(2)?.contiguous()?;
+        // let c = x.narrow(2, 2, 1)?.squeeze(2)?.contiguous()?;
+        // let o = x.narrow(2, 3, 1)?.squeeze(2)?.contiguous()?;
 
         Ok(ProteinFeatures {
             s,
@@ -183,12 +176,10 @@ impl LMPNNFeatures for AtomCollection {
     fn to_numeric_ligand_atoms(&self, device: &Device) -> Result<(Tensor, Tensor, Tensor)> {
         let (coords, elements): (Vec<[f32; 3]>, Vec<Element>) = self
             .iter_residues()
-            // keep only the non-protein, non-water residues
             .filter(|residue| {
                 let res_name = &residue.residue_name();
                 !residue.is_amino_acid() && *res_name != "HOH" && *res_name != "WAT"
             })
-            // keep only the heavy atoms
             .flat_map(|residue| {
                 residue
                     .iter_atoms()

--- a/crates/ferritin-plms/src/ligandmpnn/proteinfeatures.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/proteinfeatures.rs
@@ -10,7 +10,8 @@
 //! - Evolutionary features from MSA profiles
 
 use super::utilities::{AAAtom, aa1to_int, aa3to1};
-use candle_core::{Device, Result, Tensor};
+use crate::ligandmpnn::utilities::calculate_cb;
+use candle_core::{DType, Device, Result, Tensor};
 use ferritin_core::AtomCollection;
 use ferritin_core::info::elements::Element;
 use itertools::MultiUnzip;
@@ -28,7 +29,6 @@ pub trait LMPNNFeatures {
     fn featurize(&self, device: &Device) -> Result<ProteinFeatures>; // need more control over this featurization process
     fn get_res_index(&self) -> Vec<u32>;
     fn to_numeric_backbone_atoms(&self, device: &Device) -> Result<Tensor>; // [residues, N/CA/C/O, xyz]
-
     fn to_numeric_atom37(&self, device: &Device) -> Result<Tensor>; // [residues, N/CA/C/O....37, xyz]
     fn to_numeric_ligand_atoms(&self, device: &Device) -> Result<(Tensor, Tensor, Tensor)>; // ( positions , elements, mask )
     fn to_pdb(&self); //
@@ -49,47 +49,63 @@ impl LMPNNFeatures for AtomCollection {
         Tensor::from_iter(s, device)?.reshape((1, n))
     }
     // equivalent to protien MPNN's parse_PDB
-    fn featurize(&self, _device: &Device) -> Result<ProteinFeatures> {
-        todo!();
-        // let x_37 = self.to_numeric_atom37(device)?;
-        // let x_37_m = Tensor::zeros((x_37.dim(0)?, x_37.dim(1)?), DType::F64, device)?;
-        // let (y, y_t, y_m) = self.to_numeric_ligand_atoms(device)?;
+    fn featurize(&self, device: &Device) -> Result<ProteinFeatures> {
+        let x_37 = self.to_numeric_atom37(device)?;
+        let x_37_m = Tensor::zeros((x_37.dim(0)?, x_37.dim(1)?), DType::F64, device)?;
+        let (y, y_t, y_m) = self.to_numeric_ligand_atoms(device)?;
 
-        // // get CB locations...
-        // // although we have these already for our full set...
-        // let cb = calculate_cb(&x_37);
+        // get CB locations...
+        let cb = calculate_cb(&x_37);
 
-        // // chain_labels = np.array(CA_atoms.getChindices(), dtype=np.int32)
-        // let chain_labels = self.get_resids(); //  <-- need to double-check shape. I think this is all-atom
+        // chain_labels = np.array(CA_atoms.getChindices(), dtype=np.int32)
+        let chain_labels = self.get_resids(); //  <-- need to double-check shape. I think this is all-atom
 
-        // // R_idx = np.array(CA_resnums, dtype=np.int32)
-        // // let _r_idx = self.get_resids(); // todo()!
+        // Get residue IDs for r_idx
+        let residue_ids = self.get_res_index();
+        let r_idx = Tensor::from_iter(residue_ids, device)?;
 
-        // // amino acid names as int....
-        // let s = self.encode_amino_acids(device)?;
+        // Extract chain information
+        let chain_letters: Vec<String> = self
+            .iter_residues_aminoacid()
+            .map(|res| res.chain_id().to_string())
+            .collect();
 
-        // // coordinates of the backbone atoms
-        // let indices = Tensor::from_slice(
-        //     &[0i64, 1i64, 2i64, 4i64], // index of N/CA/C/O as integers
-        //     (4,),
-        //     &device,
-        // )?;
+        // Create a list of unique chains
+        let chain_list: Vec<String> = chain_letters
+            .clone()
+            .into_iter()
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
 
-        // let x = x_37.index_select(&indices, 1)?;
+        // Numeric chain labels (optional)
+        let chain_labels: Option<Vec<f64>> = None; // Could populate if needed
 
-        // Ok(ProteinFeatures {
-        //     s,
-        //     x,
-        //     x_mask: Some(x_37_m),
-        //     y,
-        //     y_t,
-        //     y_m: Some(y_m),
-        //     r_idx: None,
-        //     chain_labels: None,
-        //     chain_letters: None,
-        //     mask_c: None,
-        //     chain_list: None,
-        // })
+        // amino acid names as int....
+        let s = self.encode_amino_acids(device)?;
+
+        // coordinates of the backbone atoms
+        let indices = Tensor::from_slice(
+            &[0i64, 1i64, 2i64, 4i64], // index of N/CA/C/O as integers
+            (4,),
+            &device,
+        )?;
+
+        let x = x_37.index_select(&indices, 1)?;
+
+        Ok(ProteinFeatures {
+            s,
+            x,
+            x_mask: Some(x_37_m),
+            y,
+            y_t,
+            y_m: Some(y_m),
+            r_idx,
+            chain_labels,
+            chain_letters,
+            mask_c: None,
+            chain_list,
+        })
     }
     fn get_res_index(&self) -> Vec<u32> {
         self.iter_residues_aminoacid()

--- a/crates/ferritin-plms/src/ligandmpnn/proteinfeaturesmodel.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/proteinfeaturesmodel.rs
@@ -192,13 +192,9 @@ impl ProteinFeaturesModel {
 
         // N/CA/C/O
         let n = x.narrow(2, 0, 1)?.squeeze(2)?.contiguous()?;
-        println!("n shape: {:?}", n.dims());
         let ca = x.narrow(2, 1, 1)?.squeeze(2)?.contiguous()?;
-        println!("ca shape: {:?}", ca.dims());
         let c = x.narrow(2, 2, 1)?.squeeze(2)?.contiguous()?;
-        println!("c shape: {:?}", c.dims());
         let o = x.narrow(2, 3, 1)?.squeeze(2)?.contiguous()?;
-        println!("o shape: {:?}", o.dims());
 
         println!("Before _dist call");
         let (d_neighbors, e_idx) = self._dist(&ca, mask, self.augment_eps)?;

--- a/crates/ferritin-plms/src/ligandmpnn/proteinfeaturesmodel.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/proteinfeaturesmodel.rs
@@ -153,9 +153,17 @@ impl ProteinFeaturesModel {
         input_features: &ProteinFeatures,
         device: &Device,
     ) -> Result<(Tensor, Tensor)> {
-        let x = input_features.get_coords();
-        let mask = input_features.x_mask.as_ref().unwrap();
-        let r_idx = input_features.get_residue_index();
+        println!("Starting forward pass");
+        let x = input_features.get_coords(); // [1, 4, 37, 3]
+        let mask = input_features.x_mask.as_ref().unwrap(); // [1, 154]
+        let r_idx = input_features.get_residue_index(); // [154]
+
+        println!(
+            "Initial shapes - x: {:?}, mask: {:?}, r_idx: {:?}",
+            x.dims(),
+            mask.dims(),
+            r_idx.dims()
+        );
 
         // Temporary implementation until chain labels are supported
         let chain_labels = Tensor::zeros_like(r_idx)?;
@@ -183,11 +191,21 @@ impl ProteinFeaturesModel {
 
         // N/CA/C/O
         let n = x.narrow(2, 0, 1)?.squeeze(2)?.contiguous()?;
+        println!("n shape: {:?}", n.dims());
         let ca = x.narrow(2, 1, 1)?.squeeze(2)?.contiguous()?;
+        println!("ca shape: {:?}", ca.dims());
         let c = x.narrow(2, 2, 1)?.squeeze(2)?.contiguous()?;
+        println!("c shape: {:?}", c.dims());
         let o = x.narrow(2, 3, 1)?.squeeze(2)?.contiguous()?;
+        println!("o shape: {:?}", o.dims());
 
+        println!("Before _dist call");
         let (d_neighbors, e_idx) = self._dist(&ca, mask, self.augment_eps as f64)?;
+        println!(
+            "After _dist call - d_neighbors: {:?}, e_idx: {:?}",
+            d_neighbors.dims(),
+            e_idx.dims()
+        );
 
         let mut rbf_all = Vec::new();
         rbf_all.push(self._rbf(&d_neighbors, device)?);
@@ -217,6 +235,8 @@ impl ProteinFeaturesModel {
         rbf_all.push(self._get_rbf(&c, &o, &e_idx, device)?);
 
         let rbf_all = Tensor::cat(&rbf_all, D::Minus1)?;
+        println!("rbf_all shape: {:?}", rbf_all.dims());
+
         let dims = r_idx.dims();
         let target_shape = (dims[0], dims[1], dims[1]);
         let r_idx_expanded1 = r_idx
@@ -233,6 +253,10 @@ impl ProteinFeaturesModel {
         let offset = offset.squeeze(D::Minus1)?;
         let dims = chain_labels.dims();
         let target_shape = (dims[0], dims[1], dims[1]);
+        println!("target_shape: {:?}", target_shape);
+
+        //
+
         let d_chains = (&chain_labels.unsqueeze(2)?.broadcast_as(target_shape)?
             - &chain_labels.unsqueeze(1)?.broadcast_as(target_shape)?)?
             .eq(0.0)?

--- a/crates/ferritin-plms/src/ligandmpnn/proteinfeaturesmodel.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/proteinfeaturesmodel.rs
@@ -1,14 +1,16 @@
 use super::configs::ProteinMPNNConfig;
 use super::proteinfeatures::ProteinFeatures;
-use super::utilities::{compute_nearest_neighbors, cross_product, gather_edges, linspace};
+use super::utilities::{
+    compute_nearest_neighbors, cross_product, gather_edges, linspace, linspace_f32,
+};
 use candle_core::{D, DType, Device, Module, Result, Tensor};
 use candle_nn::encoding::one_hot;
 use candle_nn::{LayerNorm, LayerNormConfig, Linear, VarBuilder, layer_norm, linear};
 
 // After (at module level)
-const RBF_MIN_DISTANCE: f64 = 2.0;
-const RBF_MAX_DISTANCE: f64 = 22.0;
-const NUMERICAL_STABILITY_EPSILON: f64 = 1e-6;
+const RBF_MIN_DISTANCE: f32 = 2.0;
+const RBF_MAX_DISTANCE: f32 = 22.0;
+const NUMERICAL_STABILITY_EPSILON: f32 = 1e-6;
 
 #[derive(Clone, Debug)]
 /// https://github.com/dauparas/LigandMPNN/blob/main/model_utils.py#L669
@@ -63,8 +65,8 @@ impl ProteinFeaturesModel {
 
     /// This function calculates the nearest Ca coordinates and returns the distances and indices.
     // Todo: potential refactor
-    fn _dist(&self, x: &Tensor, mask: &Tensor, eps: f64) -> Result<(Tensor, Tensor)> {
-        compute_nearest_neighbors(x, mask, self.top_k, eps as f32)
+    fn _dist(&self, x: &Tensor, mask: &Tensor, eps: f32) -> Result<(Tensor, Tensor)> {
+        compute_nearest_neighbors(x, mask, self.top_k, eps)
     }
     /// Computes Radial Basis Function features for a given distance tensor
     ///
@@ -76,25 +78,24 @@ impl ProteinFeaturesModel {
     /// * Tensor of RBF features [batch, length, k_neighbors, num_rbf]
     fn _rbf(&self, d: &Tensor, device: &Device) -> Result<Tensor> {
         // Create centers (μ)
-        let d_mu = linspace(
+        let d_mu = linspace_f32(
             RBF_MIN_DISTANCE,
             RBF_MAX_DISTANCE,
             self.num_rbf,
             &Device::Cpu,
         )?
-        .to_dtype(DType::F32)?
         .reshape((1, 1, 1, self.num_rbf))?
         .to_device(device)?; // Move to Metal device after conversion
 
         // Calculate width (σ)
-        let d_sigma = (RBF_MAX_DISTANCE - RBF_MIN_DISTANCE) / self.num_rbf as f64;
+        let d_sigma = (RBF_MAX_DISTANCE - RBF_MIN_DISTANCE) / self.num_rbf as f32;
         let dims = d.dims();
         let d_expanded = d.unsqueeze(D::Minus1)?; // [N, N, C, 1]
         let d_mu_broadcast = d_mu.broadcast_as((dims[0], dims[1], dims[2], self.num_rbf))?;
         let d_expanded_broadcast =
             d_expanded.broadcast_as((dims[0], dims[1], dims[2], self.num_rbf))?;
         let d_sigma_tensor =
-            Tensor::new(&[d_sigma as f32], device)?.broadcast_as(d_expanded_broadcast.shape())?;
+            Tensor::new(&[d_sigma], device)?.broadcast_as(d_expanded_broadcast.shape())?;
         let diff = ((d_expanded_broadcast - d_mu_broadcast)? / d_sigma_tensor)?;
         let rbf = diff.powf(2.0)?.neg()?.exp()?;
         Ok(rbf)
@@ -200,7 +201,7 @@ impl ProteinFeaturesModel {
         println!("o shape: {:?}", o.dims());
 
         println!("Before _dist call");
-        let (d_neighbors, e_idx) = self._dist(&ca, mask, self.augment_eps as f64)?;
+        let (d_neighbors, e_idx) = self._dist(&ca, mask, self.augment_eps)?;
         println!(
             "After _dist call - d_neighbors: {:?}, e_idx: {:?}",
             d_neighbors.dims(),

--- a/crates/ferritin-plms/src/ligandmpnn/proteinfeaturesmodel.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/proteinfeaturesmodel.rs
@@ -5,6 +5,11 @@ use candle_core::{D, DType, Device, Module, Result, Tensor};
 use candle_nn::encoding::one_hot;
 use candle_nn::{LayerNorm, LayerNormConfig, Linear, VarBuilder, layer_norm, linear};
 
+// After (at module level)
+const RBF_MIN_DISTANCE: f64 = 2.0;
+const RBF_MAX_DISTANCE: f64 = 22.0;
+const NUMERICAL_STABILITY_EPSILON: f64 = 1e-6;
+
 #[derive(Clone, Debug)]
 /// https://github.com/dauparas/LigandMPNN/blob/main/model_utils.py#L669
 pub struct ProteinFeaturesModel {
@@ -61,24 +66,28 @@ impl ProteinFeaturesModel {
     fn _dist(&self, x: &Tensor, mask: &Tensor, eps: f64) -> Result<(Tensor, Tensor)> {
         compute_nearest_neighbors(x, mask, self.top_k, eps as f32)
     }
-    /// 1. It takes a tensor `d` as input and creates a set of RBF features
-    /// 2. Sets up parameters:
-    ///    - `d_min` = 2.0 (minimum distance)
-    ///    - `d_max` = 22.0 (maximum distance)
-    ///    - `d_count` = number of RBF centers
-    /// 3. Creates evenly spaced centers (μ) between d_min and d_max
-    /// 4. Calculates the width (σ) of the Gaussian functions
-    /// 5. Applies the RBF formula: exp(-(x-μ)²/σ²)
+    /// Computes Radial Basis Function features for a given distance tensor
+    ///
+    /// # Arguments
+    /// * `d` - Tensor containing distances between points [batch, length, k_neighbors]
+    /// * `device` - Device to perform calculations on
+    ///
+    /// # Returns
+    /// * Tensor of RBF features [batch, length, k_neighbors, num_rbf]
     fn _rbf(&self, d: &Tensor, device: &Device) -> Result<Tensor> {
-        const D_MIN: f64 = 2.0;
-        const D_MAX: f64 = 22.0;
         // Create centers (μ)
-        let d_mu = linspace(D_MIN, D_MAX, self.num_rbf, &Device::Cpu)? // Use CPU device
-            .to_dtype(DType::F32)? // Convert to F32 on CPU
-            .reshape((1, 1, 1, self.num_rbf))?
-            .to_device(device)?; // Move to Metal device after conversion
+        let d_mu = linspace(
+            RBF_MIN_DISTANCE,
+            RBF_MAX_DISTANCE,
+            self.num_rbf,
+            &Device::Cpu,
+        )?
+        .to_dtype(DType::F32)?
+        .reshape((1, 1, 1, self.num_rbf))?
+        .to_device(device)?; // Move to Metal device after conversion
+
         // Calculate width (σ)
-        let d_sigma = (D_MAX - D_MIN) / self.num_rbf as f64;
+        let d_sigma = (RBF_MAX_DISTANCE - RBF_MIN_DISTANCE) / self.num_rbf as f64;
         let dims = d.dims();
         let d_expanded = d.unsqueeze(D::Minus1)?; // [N, N, C, 1]
         let d_mu_broadcast = d_mu.broadcast_as((dims[0], dims[1], dims[2], self.num_rbf))?;
@@ -147,9 +156,8 @@ impl ProteinFeaturesModel {
         let x = input_features.get_coords();
         let mask = input_features.x_mask.as_ref().unwrap();
         let r_idx = input_features.get_residue_index();
-        // let chain_labels = input_features.chain_labels.as_ref();
-        // todo: fix
-        // let chain_labels = input_features.get_chain_labels();
+
+        // Temporary implementation until chain labels are supported
         let chain_labels = Tensor::zeros_like(r_idx)?;
         let x = if self.augment_eps > 0.0 {
             let noise = x.randn_like(0.0, self.augment_eps as f64)?;

--- a/crates/ferritin-plms/src/ligandmpnn/proteinfeaturesmodel.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/proteinfeaturesmodel.rs
@@ -236,8 +236,10 @@ impl ProteinFeaturesModel {
 
         let rbf_all = Tensor::cat(&rbf_all, D::Minus1)?;
         println!("rbf_all shape: {:?}", rbf_all.dims());
-
+        println!("r_idx shape: {:?}", r_idx.dims());
         let dims = r_idx.dims();
+
+        // index out of bounds: the len is 1 but the index is 1
         let target_shape = (dims[0], dims[1], dims[1]);
         let r_idx_expanded1 = r_idx
             .unsqueeze(2)?
@@ -251,6 +253,7 @@ impl ProteinFeaturesModel {
         let offset = (r_idx_expanded1 - r_idx_expanded2)?;
         let offset = gather_edges(&offset.unsqueeze(D::Minus1)?, &e_idx)?;
         let offset = offset.squeeze(D::Minus1)?;
+
         let dims = chain_labels.dims();
         let target_shape = (dims[0], dims[1], dims[1]);
         println!("target_shape: {:?}", target_shape);

--- a/crates/ferritin-plms/src/ligandmpnn/utilities.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/utilities.rs
@@ -72,15 +72,13 @@ pub fn compute_nearest_neighbors(
     k: usize,
     eps: f32,
 ) -> Result<(Tensor, Tensor)> {
-    // Todo: fix the F32/F64 issue
     let (_batch_size, seq_len, _) = coords.dims3()?;
-
     // broadcast_matmul handles broadcasting automatically
     // [2, 3, 1] × [2, 1, 3] -> [2, 3, 3]
     let mask_2d = mask
         .unsqueeze(2)?
         .broadcast_matmul(&mask.unsqueeze(1)?)?
-        .to_dtype(DType::F32)?; // Convert to f64 once, at the start
+        .to_dtype(DType::F32)?;
 
     // Compute pairwise distances with broadcasting
     let distances = (coords
@@ -88,7 +86,7 @@ pub fn compute_nearest_neighbors(
         .broadcast_sub(&coords.unsqueeze(1)?)?
         .powf(2.)?
         .sum(D::Minus1)?
-        + eps as f64)?
+        + eps as f64)? // also  doesn't have add
         .sqrt()?
         .to_dtype(DType::F32)?;
 

--- a/crates/ferritin-plms/src/ligandmpnn/utilities.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/utilities.rs
@@ -431,7 +431,13 @@ fn get_score(s: &Tensor, log_probs: &Tensor, mask: &Tensor) -> Result<(Tensor, T
     Ok((average_loss, loss_per_residue))
 }
 
-pub fn linspace(start: f64, stop: f64, steps: usize, device: &Device) -> Result<Tensor> {
+pub fn linspace(
+    start: f64,
+    stop: f64,
+    steps: usize,
+    device: &Device,
+    return_type: DType,
+) -> Result<Tensor> {
     if steps == 0 {
         Tensor::from_vec(Vec::<f64>::new(), steps, device)
     } else if steps == 1 {
@@ -440,6 +446,25 @@ pub fn linspace(start: f64, stop: f64, steps: usize, device: &Device) -> Result<
         let delta = (stop - start) / (steps - 1) as f64;
         let vs = (0..steps)
             .map(|step| start + step as f64 * delta)
+            .collect::<Vec<_>>();
+        Tensor::from_vec(vs, steps, device)?.to_dtype(return_type)
+    }
+}
+
+pub fn linspace_f32(
+    start: f32, // Changed to f32
+    stop: f32,  // Changed to f32
+    steps: usize,
+    device: &Device,
+) -> Result<Tensor> {
+    if steps == 0 {
+        Tensor::from_vec(Vec::<f32>::new(), steps, device) // Changed to f32
+    } else if steps == 1 {
+        Tensor::from_vec(vec![start], steps, device)
+    } else {
+        let delta = (stop - start) / (steps - 1) as f32; // Changed to f32
+        let vs = (0..steps)
+            .map(|step| start + step as f32 * delta)
             .collect::<Vec<_>>();
         Tensor::from_vec(vs, steps, device)
     }


### PR DESCRIPTION
- restore candle example.
-  get encoding to work
- try with Metal
- hit a few issues related to Candle/Metal incompatability.
- basically: metal has no native F64 types. But Candle defaults everythign to F64 and doesn't have `powf` or ADD functionality for F32.
- I raised the issue with the Candle team.