### PR TITLE
fix(ferritin-plms): three correctness fixes for ProteinMPNN inference

### DIFF
--- a/crates/ferritin-plms/src/featurize/structure_features.rs
+++ b/crates/ferritin-plms/src/featurize/structure_features.rs
@@ -102,7 +102,7 @@ impl StructureFeatures for AtomCollection {
     // Convert AtomCollection to ProteinFeatures
     fn featurize_lmpnn(&self, device: &Device) -> Result<ProteinFeatures> {
         let x_37 = self.to_numeric_atom37(device)?;
-        let x_37_m = Tensor::zeros((x_37.dim(0)?, x_37.dim(1)?), DType::F32, device)?;
+        let x_37_m = Tensor::ones((x_37.dim(0)?, x_37.dim(1)?), DType::F32, device)?;
         let (y, y_t, y_m) = self.to_numeric_ligand_atoms(device)?;
         let _cb = self.create_cb(device);
         let _chain_labels = self.get_resids(); //  <-- need to double-check shape. I think this is all-atom
@@ -208,6 +208,18 @@ impl StructureFeatures for AtomCollection {
                 coords.push(*atom.coords());
                 elements.push(*atom.element());
             }
+        }
+
+        // When there are no ligand atoms, backends like Metal cannot allocate zero-size
+        // buffers. Return a single dummy ligand slot with a zeroed mask so it has no
+        // effect on the model output.
+        if coords.is_empty() {
+            let cb = self.create_cb(device)?;
+            let (batch, res_num, _) = cb.dims3()?;
+            let y = Tensor::zeros((batch, res_num, 1, 3), DType::F32, device)?;
+            let y_t = Tensor::zeros((batch, res_num, 1), DType::I64, device)?;
+            let y_m = Tensor::zeros((batch, res_num, 1), DType::F32, device)?;
+            return Ok((y, y_t, y_m));
         }
 
         // raw starting tensors

--- a/crates/ferritin-plms/src/ligandmpnn/pmpnn_runner.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/pmpnn_runner.rs
@@ -24,8 +24,8 @@ impl ProteinMPNNModels {
         // (owner, repo, revision, filename)
         match self {
             Self::V48_020 => (
-                "dauparas",
-                "LigandMPNN",
+                "zcpbx",
+                "ligandmpnn-weights",
                 "main",
                 "model_params/proteinmpnn_v_48_020.pt",
             ),


### PR DESCRIPTION
## Summary

- **`featurize_lmpnn`: sequence mask initialized to ones, not zeros** — `x_37_m` was `Tensor::zeros(...)`, marking every residue as invalid padding. This zeroed out all neighbor messages via `mask_attend`, leaving `h_v` all-zeros going into LayerNorm. LayerNorm then divided by `std=0`, producing NaN throughout the encoder and decoder. In `get_pseudo_probabilities`, `NaN > 0.01` is always `false`, silently returning an empty Vec with no error.

- **`to_numeric_ligand_atoms`: guard against zero-size Metal buffer** — when a protein has no ligand atoms the function previously tried to allocate a zero-length tensor. Metal (and some other backends) cannot allocate zero-size buffers, causing a hard crash on any ligand-free input. Now returns a single dummy ligand slot with a zeroed mask (`y_m = 0`) so it has no effect on model output.

- **`ProteinMPNNModels::V48_020`: correct HF Hub repo** — was pointing at `dauparas/LigandMPNN` (private, file not present). Updated to `zcpbx/ligandmpnn-weights` which hosts all `.pt` weight files.

## Test plan

- [ ] Load a ligand-free protein (e.g. a plain alpha-helix or any PDB without HETATM ligands) — should featurize and run without crashing
- [ ] Call `get_pseudo_probabilities` on the output — should return a non-empty Vec with valid per-residue amino acid probabilities
- [ ] Load a protein with ligand atoms — existing path should still work
- [ ] Model weights download successfully from `zcpbx/ligandmpnn-weights`

🤖 Generated with [Claude Code](https://claude.com/claude-code)