### PR TITLE
Shared golden-fixture parity harness for PLM ports (ferritin-100.1)

### DIFF
--- a/crates/ferritin-plms/tests/support/mod.rs
+++ b/crates/ferritin-plms/tests/support/mod.rs
@@ -1,1 +1,2 @@
 pub mod model_harness;
+pub mod parity;

--- a/crates/ferritin-plms/tests/support/model_harness.rs
+++ b/crates/ferritin-plms/tests/support/model_harness.rs
@@ -1,3 +1,7 @@
+// Shared across integration-test binaries; not every binary exercises every
+// helper, so unused-in-this-binary items are expected.
+#![allow(dead_code)]
+
 use anyhow::{Result, anyhow};
 use candle_core::pickle::PthTensors;
 use candle_core::{DType, Device, Error};

--- a/crates/ferritin-plms/tests/support/parity.rs
+++ b/crates/ferritin-plms/tests/support/parity.rs
@@ -1,0 +1,320 @@
+//! Shared golden-fixture parity harness for the PLM Candle ports.
+//!
+//! Every parity test compares a Rust forward pass against a Python reference
+//! tensor stored in `tests/fixtures/<name>.safetensors`. Before this module
+//! each test hand-rolled its own fixture loader and comparison logic
+//! (`test_plm_ligandmpnn.rs` had a private `kl_divergence`, `test_plm_amplify`
+//! and `test_plm_esm2` each repeated a load-safetensors-and-max-diff block).
+//! This module centralises:
+//!
+//!   * [`ParityFixture`] — resolve and load a fixture, with a clear
+//!     "run scripts/generate_X_fixtures.py" error when it is missing.
+//!   * [`assert_logits_close`] — max-absolute-difference, reports the offending
+//!     `(position, vocab_index)` on failure.
+//!   * [`assert_distribution_close`] — per-position KL divergence, reports the
+//!     max KL and the position at which it occurred.
+//!   * [`assert_embeddings_close`] — per-residue cosine similarity, for models
+//!     whose meaningful output is an embedding rather than a distribution
+//!     (ESMC, ESM3).
+//!
+//! ## Special-token alignment
+//!
+//! The reference tensors are **not** all laid out the same way, because the
+//! tokenizers do not agree on which special tokens they prepend/append:
+//!
+//!   * **AMPLIFY** and **ESM2** wrap the sequence in BOS + `L` residues + EOS.
+//!     Their fixture generators (`generate_amplify_fixtures.py`,
+//!     `generate_esm2_fixtures.py`) strip BOS/EOS and save only the `L`
+//!     interior rows, so the reference is `(L, V)` with **no** special tokens.
+//!   * **ProteinMPNN / LigandMPNN** have no special tokens at all; the
+//!     reference `log_probs` is `(L, 21)` one row per residue.
+//!   * **ESMC** and **ESM3** wrap the sequence in BOS + `L` + EOS and their
+//!     embedding references keep those two rows, so the reference is
+//!     `(L + 2, D)`.
+//!
+//! A silent off-by-one in that alignment would make a genuinely broken port
+//! look correct, so the Rust side must be trimmed to match the reference
+//! explicitly. Use [`SpecialTokens`] + [`align_rows`] to describe how many
+//! leading/trailing rows to drop from the Rust output rather than open-coding a
+//! `narrow` at each call site.
+#![allow(dead_code)]
+
+use anyhow::{Result, bail};
+use candle_core::{Device, Tensor};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// A loaded parity fixture: the safetensors key→tensor map plus the fixture
+/// name, used for good error messages.
+#[derive(Debug)]
+pub struct ParityFixture {
+    name: String,
+    tensors: HashMap<String, Tensor>,
+}
+
+impl ParityFixture {
+    /// Load `tests/fixtures/<name>.safetensors` into memory.
+    ///
+    /// On absence, returns an error naming the generator script to run, rather
+    /// than a bare "file not found". `name` is the fixture stem without the
+    /// `.safetensors` extension (e.g. `"esm2_parity"`); the generator script is
+    /// inferred as `generate_<stem>_fixtures.py` where `<stem>` drops a trailing
+    /// `_parity`. When that inference is wrong (e.g. the ProteinMPNN fixture is
+    /// `1BC8_log_probs` but the script is `generate_proteinmpnn_fixtures.py`),
+    /// use [`ParityFixture::load_with_generator`].
+    pub fn load(name: &str, device: &Device) -> Result<Self> {
+        Self::load_with_generator(name, script_stem(name), device)
+    }
+
+    /// Like [`load`](Self::load) but names the generator script explicitly, for
+    /// fixtures whose file stem does not match their `generate_<X>_fixtures.py`
+    /// script. `generator` is the `<X>` in that filename.
+    pub fn load_with_generator(name: &str, generator: &str, device: &Device) -> Result<Self> {
+        let path = fixture_path(name);
+        if !path.exists() {
+            bail!(
+                "Parity fixture not found at {}.\n\
+                 Generate it with: python scripts/generate_{}_fixtures.py \
+                 --output crates/ferritin-plms/tests/fixtures/",
+                path.display(),
+                generator,
+            );
+        }
+        let tensors = candle_core::safetensors::load(&path, device)?;
+        Ok(Self {
+            name: name.to_string(),
+            tensors,
+        })
+    }
+
+    /// Fetch a tensor by key, erroring (with the fixture name and the keys that
+    /// *are* present) when it is absent.
+    pub fn tensor(&self, key: &str) -> Result<&Tensor> {
+        self.tensors.get(key).ok_or_else(|| {
+            let mut keys: Vec<&str> = self.tensors.keys().map(String::as_str).collect();
+            keys.sort_unstable();
+            anyhow::anyhow!(
+                "fixture '{}' has no tensor '{}'; present keys: [{}]",
+                self.name,
+                key,
+                keys.join(", ")
+            )
+        })
+    }
+
+    /// The fixture stem, for diagnostics.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// Resolve a fixture stem to an absolute path under `tests/fixtures/`.
+pub fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(format!("{name}.safetensors"))
+}
+
+/// Map a fixture stem to its generator-script stem for error messages.
+/// `esm2_parity` -> `esm2`, `amplify_parity` -> `amplify`, etc.
+fn script_stem(name: &str) -> &str {
+    name.strip_suffix("_parity").unwrap_or(name)
+}
+
+/// Describes how many special-token rows the **Rust** output carries relative
+/// to the reference tensor, so [`align_rows`] can trim the Rust side to match.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SpecialTokens {
+    /// Leading special-token rows in the Rust output not present in the
+    /// reference (e.g. BOS = 1 for ESM2/AMPLIFY interior-only references).
+    pub leading: usize,
+    /// Trailing special-token rows in the Rust output not present in the
+    /// reference (e.g. EOS = 1).
+    pub trailing: usize,
+}
+
+impl SpecialTokens {
+    /// No special tokens to strip; Rust and reference rows already align.
+    /// (ProteinMPNN/LigandMPNN, and any reference that keeps BOS/EOS.)
+    pub const NONE: Self = Self {
+        leading: 0,
+        trailing: 0,
+    };
+    /// Strip one leading BOS and one trailing EOS from the Rust output — the
+    /// AMPLIFY / ESM2 interior-only reference layout.
+    pub const BOS_EOS: Self = Self {
+        leading: 1,
+        trailing: 1,
+    };
+}
+
+/// Reduce a Rust model output to a 2D `(rows, features)` tensor aligned to the
+/// reference, dropping `special.leading`/`special.trailing` rows.
+///
+/// Accepts either a batched `(1, L, F)` tensor (the common runner output) or an
+/// already-2D `(L, F)` tensor. The batch dimension, if present, must be 1.
+pub fn align_rows(rust: &Tensor, special: SpecialTokens) -> Result<Tensor> {
+    let t = match rust.dims() {
+        [1, _, _] => rust.squeeze(0)?,
+        [_, _] => rust.clone(),
+        other => bail!(
+            "align_rows expects (1, L, F) or (L, F); got shape {:?}",
+            other
+        ),
+    };
+    let (rows, _feats) = t.dims2()?;
+    if special.leading + special.trailing >= rows {
+        bail!(
+            "align_rows: stripping {} leading + {} trailing rows leaves nothing of {} rows",
+            special.leading,
+            special.trailing,
+            rows
+        );
+    }
+    let kept = rows - special.leading - special.trailing;
+    Ok(t.narrow(0, special.leading, kept)?)
+}
+
+/// Assert that two logit tensors agree to within `tol` in max-absolute
+/// difference. Both must be 2D `(L, V)` and identically shaped.
+///
+/// On failure the error names the exact `(position, vocab_index)` at which the
+/// largest disagreement occurred, not just "assertion failed".
+pub fn assert_logits_close(rust: &Tensor, reference: &Tensor, tol: f32) -> Result<()> {
+    let rust_rows = rows2(rust, "rust logits")?;
+    let ref_rows = rows2(reference, "reference logits")?;
+    check_same_shape(&rust_rows, &ref_rows, "logits")?;
+
+    let mut worst = 0.0f32;
+    let mut worst_at = (0usize, 0usize);
+    for (pos, (rrow, prow)) in rust_rows.iter().zip(ref_rows.iter()).enumerate() {
+        for (vi, (&r, &p)) in rrow.iter().zip(prow.iter()).enumerate() {
+            let d = (r - p).abs();
+            if d > worst {
+                worst = d;
+                worst_at = (pos, vi);
+            }
+        }
+    }
+    if worst > tol {
+        let (pos, vi) = worst_at;
+        bail!(
+            "logit parity broke at (position {pos}, vocab_index {vi}): \
+             |rust {} - ref {}| = {worst:.6e} exceeds tol {tol:.1e}",
+            rust_rows[pos][vi],
+            ref_rows[pos][vi],
+        );
+    }
+    Ok(())
+}
+
+/// Assert that two probability distributions agree to within `kl_threshold` in
+/// per-position KL divergence. Both must be 2D `(L, V)` where each row is a
+/// probability vector (non-negative, ideally summing to 1).
+///
+/// KL(P‖Q) is computed with P = reference, Q = rust. On failure the error names
+/// the position of the largest KL. Lifts the implementation that previously
+/// lived in `test_plm_ligandmpnn.rs`.
+pub fn assert_distribution_close(
+    rust: &Tensor,
+    reference: &Tensor,
+    kl_threshold: f64,
+) -> Result<()> {
+    let rust_rows = rows2(rust, "rust distribution")?;
+    let ref_rows = rows2(reference, "reference distribution")?;
+    check_same_shape(&rust_rows, &ref_rows, "distribution")?;
+
+    let mut max_kl = 0.0f64;
+    let mut max_at = 0usize;
+    for (pos, (q, p)) in rust_rows.iter().zip(ref_rows.iter()).enumerate() {
+        let kl = kl_divergence(p, q);
+        if kl > max_kl {
+            max_kl = kl;
+            max_at = pos;
+        }
+    }
+    if max_kl > kl_threshold {
+        bail!(
+            "distribution parity broke at position {max_at}: \
+             KL = {max_kl:.6} exceeds threshold {kl_threshold}"
+        );
+    }
+    Ok(())
+}
+
+/// Assert that per-residue embeddings agree, i.e. every row's cosine similarity
+/// to the reference is at least `cosine_floor`. Both must be 2D `(L, D)` and
+/// identically shaped.
+///
+/// On failure the error names the position with the lowest cosine similarity.
+pub fn assert_embeddings_close(rust: &Tensor, reference: &Tensor, cosine_floor: f32) -> Result<()> {
+    let rust_rows = rows2(rust, "rust embeddings")?;
+    let ref_rows = rows2(reference, "reference embeddings")?;
+    check_same_shape(&rust_rows, &ref_rows, "embeddings")?;
+
+    let mut min_cos = f32::INFINITY;
+    let mut min_at = 0usize;
+    for (pos, (r, p)) in rust_rows.iter().zip(ref_rows.iter()).enumerate() {
+        let cos = cosine_similarity(r, p);
+        if cos < min_cos {
+            min_cos = cos;
+            min_at = pos;
+        }
+    }
+    if min_cos < cosine_floor {
+        bail!(
+            "embedding parity broke at position {min_at}: \
+             cosine similarity {min_cos:.6} is below floor {cosine_floor}"
+        );
+    }
+    Ok(())
+}
+
+// ── internals ──────────────────────────────────────────────────────────────
+
+/// KL(P‖Q) = Σ P_i · ln(P_i / Q_i). Both slices must be probability vectors.
+fn kl_divergence(p: &[f32], q: &[f32]) -> f64 {
+    p.iter()
+        .zip(q.iter())
+        .filter(|(pi, _)| **pi > 1e-9)
+        .map(|(pi, qi)| {
+            let qi = qi.max(1e-9_f32);
+            (*pi as f64) * ((*pi as f64).ln() - (qi as f64).ln())
+        })
+        .sum()
+}
+
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let na: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let nb: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na * nb)
+}
+
+/// Convert a 2D tensor to row-major `Vec<Vec<f32>>`, with a labelled error.
+fn rows2(t: &Tensor, what: &str) -> Result<Vec<Vec<f32>>> {
+    let dims = t.dims();
+    if dims.len() != 2 {
+        bail!("{what} must be a 2D (L, F) tensor; got shape {dims:?}");
+    }
+    Ok(t.to_dtype(candle_core::DType::F32)?.to_vec2::<f32>()?)
+}
+
+fn check_same_shape(rust: &[Vec<f32>], reference: &[Vec<f32>], what: &str) -> Result<()> {
+    if rust.len() != reference.len() {
+        bail!(
+            "{what}: sequence length mismatch (rust {} rows vs reference {} rows)",
+            rust.len(),
+            reference.len()
+        );
+    }
+    let rust_f = rust.first().map(Vec::len).unwrap_or(0);
+    let ref_f = reference.first().map(Vec::len).unwrap_or(0);
+    if rust_f != ref_f {
+        bail!("{what}: feature-dim mismatch (rust {rust_f} vs reference {ref_f})");
+    }
+    Ok(())
+}

--- a/crates/ferritin-plms/tests/test_parity_harness.rs
+++ b/crates/ferritin-plms/tests/test_parity_harness.rs
@@ -1,0 +1,126 @@
+//! Unit tests for the shared parity harness (`tests/support/parity.rs`).
+//!
+//! These need no model weights or fixtures — they build small tensors by hand
+//! and check that each assertion helper accepts matching data, rejects
+//! mismatched data, and names the offending position in its error.
+
+mod support;
+
+use candle_core::{Device, Tensor};
+use support::parity::{
+    SpecialTokens, align_rows, assert_distribution_close, assert_embeddings_close,
+    assert_logits_close, fixture_path,
+};
+
+fn t2(rows: &[&[f32]], device: &Device) -> Tensor {
+    let l = rows.len();
+    let v = rows[0].len();
+    let flat: Vec<f32> = rows.iter().flat_map(|r| r.iter().copied()).collect();
+    Tensor::from_vec(flat, (l, v), device).unwrap()
+}
+
+#[test]
+fn logits_close_accepts_within_tolerance() {
+    let d = Device::Cpu;
+    let a = t2(&[&[1.0, 2.0, 3.0], &[4.0, 5.0, 6.0]], &d);
+    let b = t2(&[&[1.0005, 2.0, 3.0], &[4.0, 5.0005, 6.0]], &d);
+    assert_logits_close(&a, &b, 1e-3).expect("within tolerance should pass");
+}
+
+#[test]
+fn logits_close_reports_offending_position() {
+    let d = Device::Cpu;
+    let a = t2(&[&[1.0, 2.0, 3.0], &[4.0, 5.0, 6.0]], &d);
+    let b = t2(&[&[1.0, 2.0, 3.0], &[4.0, 5.0, 6.5]], &d); // off at (1, 2)
+    let err = assert_logits_close(&a, &b, 1e-3).unwrap_err().to_string();
+    assert!(
+        err.contains("position 1") && err.contains("vocab_index 2"),
+        "error should name (position 1, vocab_index 2); got: {err}"
+    );
+}
+
+#[test]
+fn logits_close_reports_shape_mismatch() {
+    let d = Device::Cpu;
+    let a = t2(&[&[1.0, 2.0, 3.0], &[4.0, 5.0, 6.0]], &d);
+    let b = t2(&[&[1.0, 2.0, 3.0]], &d);
+    let err = assert_logits_close(&a, &b, 1e-3).unwrap_err().to_string();
+    assert!(err.contains("length mismatch"), "got: {err}");
+}
+
+#[test]
+fn distribution_close_accepts_equal_distributions() {
+    let d = Device::Cpu;
+    let p = t2(&[&[0.5, 0.5], &[0.25, 0.75]], &d);
+    assert_distribution_close(&p, &p, 1e-6).expect("identical distributions should pass");
+}
+
+#[test]
+fn distribution_close_reports_offending_position() {
+    let d = Device::Cpu;
+    let rust = t2(&[&[0.5, 0.5], &[0.9, 0.1]], &d);
+    let reference = t2(&[&[0.5, 0.5], &[0.1, 0.9]], &d); // diverges at row 1
+    let err = assert_distribution_close(&rust, &reference, 0.01)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("position 1"), "got: {err}");
+}
+
+#[test]
+fn embeddings_close_accepts_parallel_vectors() {
+    let d = Device::Cpu;
+    let rust = t2(&[&[1.0, 0.0], &[0.0, 2.0]], &d);
+    let reference = t2(&[&[2.0, 0.0], &[0.0, 5.0]], &d); // same directions
+    assert_embeddings_close(&rust, &reference, 0.999).expect("parallel rows should pass");
+}
+
+#[test]
+fn embeddings_close_reports_offending_position() {
+    let d = Device::Cpu;
+    let rust = t2(&[&[1.0, 0.0], &[1.0, 0.0]], &d);
+    let reference = t2(&[&[1.0, 0.0], &[0.0, 1.0]], &d); // orthogonal at row 1
+    let err = assert_embeddings_close(&rust, &reference, 0.9)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("position 1"), "got: {err}");
+}
+
+#[test]
+fn align_rows_strips_bos_eos() {
+    let d = Device::Cpu;
+    // (1, 4, 2): BOS + two residues + EOS
+    let batched = t2(&[&[9.0, 9.0], &[1.0, 1.0], &[2.0, 2.0], &[8.0, 8.0]], &d)
+        .unsqueeze(0)
+        .unwrap();
+    let aligned = align_rows(&batched, SpecialTokens::BOS_EOS).unwrap();
+    assert_eq!(aligned.dims(), &[2, 2], "should drop BOS and EOS rows");
+    let rows = aligned.to_vec2::<f32>().unwrap();
+    assert_eq!(rows[0], vec![1.0, 1.0]);
+    assert_eq!(rows[1], vec![2.0, 2.0]);
+}
+
+#[test]
+fn align_rows_none_is_identity() {
+    let d = Device::Cpu;
+    let m = t2(&[&[1.0, 1.0], &[2.0, 2.0]], &d);
+    let out = align_rows(&m, SpecialTokens::NONE).unwrap();
+    assert_eq!(out.dims(), &[2, 2]);
+}
+
+#[test]
+fn fixture_load_missing_names_generator_script() {
+    let d = Device::Cpu;
+    let err = support::parity::ParityFixture::load("nonexistent_parity", &d)
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("generate_nonexistent_fixtures.py"),
+        "missing-fixture error should point at the generator script; got: {err}"
+    );
+    // sanity: fixture_path resolves under the crate's tests/fixtures dir
+    assert!(
+        fixture_path("nonexistent_parity")
+            .to_string_lossy()
+            .ends_with("tests/fixtures/nonexistent_parity.safetensors")
+    );
+}

--- a/crates/ferritin-plms/tests/test_plm_amplify.rs
+++ b/crates/ferritin-plms/tests/test_plm_amplify.rs
@@ -5,10 +5,7 @@ mod support;
 use ferritin_plms::amplify::amplify_runner::{AmplifyModels, AmplifyRunner};
 use ferritin_plms::device;
 use support::model_harness::{TEST_SEQUENCE, run_remote_amplify_prediction_smoke};
-
-/// Fixture produced by `scripts/generate_amplify_fixtures.py` (gitignored, not committed).
-/// Generate with: `python scripts/generate_amplify_fixtures.py --output crates/ferritin-plms/tests/fixtures/`
-const AMPLIFY_PARITY_FIXTURE: &str = "tests/fixtures/amplify_parity.safetensors";
+use support::parity::{ParityFixture, SpecialTokens, align_rows, assert_logits_close};
 
 /// Max absolute logit difference threshold (matching ferritin-1ti issue spec of 1e-3).
 const AMPLIFY_LOGIT_TOLERANCE: f32 = 1e-3;
@@ -106,58 +103,28 @@ fn test_amplify_120m_contact_map() {
 #[test]
 #[ignore = "requires HF model download and fixture: run scripts/generate_amplify_fixtures.py"]
 fn test_amplify_parity_vs_python_reference() {
-    use candle_core::safetensors;
-    use std::collections::HashMap;
-
-    let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join(AMPLIFY_PARITY_FIXTURE);
-    assert!(
-        fixture_path.exists(),
-        "Fixture not found at {fixture_path:?}. Run scripts/generate_amplify_fixtures.py first."
-    );
-
     let amplify = load_amplify_120m();
-    let device = amplify.run_forward(PARITY_SEQUENCES[0].1)
+    let device = amplify
+        .run_forward(PARITY_SEQUENCES[0].1)
         .expect("forward pass failed")
         .logits
         .device()
         .clone();
 
-    let fixtures: HashMap<String, candle_core::Tensor> =
-        safetensors::load(&fixture_path, &device)
-            .expect("Failed to load AMPLIFY parity fixture");
+    // The AMPLIFY reference (generate_amplify_fixtures.py) strips BOS/EOS and
+    // stores only the L interior residue rows, so align the Rust output.
+    let fixture = ParityFixture::load("amplify_parity", &device)
+        .expect("failed to load AMPLIFY parity fixture");
 
     for (name, sequence) in PARITY_SEQUENCES {
-        let key = format!("{name}_logits");
-        let ref_logits = fixtures.get(&key)
-            .unwrap_or_else(|| panic!("fixture missing key '{key}'"));
+        let ref_logits = fixture
+            .tensor(&format!("{name}_logits"))
+            .expect("fixture missing logits key");
 
         let output = amplify.run_forward(sequence).expect("forward pass failed");
-        let seq_len = sequence.len();
-        // Strip BOS/EOS tokens from Rust output: indices [1..=seq_len]
-        let rust_logits = output.logits
-            .narrow(1, 1, seq_len)
-            .expect("narrow failed")
-            .squeeze(0)
-            .expect("squeeze failed");
-
-        let (rust_l, rust_v) = rust_logits.dims2().expect("dims2 failed");
-        let (ref_l, ref_v) = ref_logits.dims2().expect("ref dims2 failed");
-        assert_eq!(rust_l, ref_l, "{name}: sequence length mismatch");
-        assert_eq!(rust_v, ref_v, "{name}: vocab size mismatch");
-
-        let rust_flat: Vec<f32> = rust_logits.flatten_all().expect("flatten").to_vec1().expect("to_vec1");
-        let ref_flat: Vec<f32> = ref_logits.flatten_all().expect("flatten").to_vec1().expect("to_vec1");
-
-        let max_diff = rust_flat.iter()
-            .zip(ref_flat.iter())
-            .map(|(&r, &p)| (r - p).abs())
-            .fold(0.0_f32, f32::max);
-
-        assert!(
-            max_diff <= AMPLIFY_LOGIT_TOLERANCE,
-            "{name}: max absolute logit diff {max_diff:.6} exceeds tolerance {AMPLIFY_LOGIT_TOLERANCE}"
-        );
-        println!("{name}: max logit diff = {max_diff:.6e}");
+        let rust_logits = align_rows(&output.logits, SpecialTokens::BOS_EOS).expect("align failed");
+        assert_logits_close(&rust_logits, ref_logits, AMPLIFY_LOGIT_TOLERANCE)
+            .unwrap_or_else(|e| panic!("{name}: {e}"));
+        println!("{name}: logit parity OK (tol {AMPLIFY_LOGIT_TOLERANCE:.1e})");
     }
 }

--- a/crates/ferritin-plms/tests/test_plm_esm2.rs
+++ b/crates/ferritin-plms/tests/test_plm_esm2.rs
@@ -9,10 +9,6 @@ use anyhow::Result;
 use ferritin_plms::ESM2Models;
 use support::model_harness::run_remote_esm2_smoke;
 
-/// Fixture produced by `scripts/generate_esm2_fixtures.py` (gitignored, not committed).
-/// Generate with: `python scripts/generate_esm2_fixtures.py --output crates/ferritin-plms/tests/fixtures/`
-const ESM2_PARITY_FIXTURE: &str = "tests/fixtures/esm2_parity.safetensors";
-
 /// Max absolute logit difference threshold (ferritin-lgr issue spec: 1e-3).
 const ESM2_LOGIT_TOLERANCE: f32 = 1e-3;
 
@@ -49,54 +45,23 @@ fn test_esm2_150m_embedding() -> Result<()> {
 #[test]
 #[ignore = "requires HF model download and fixture: run scripts/generate_esm2_fixtures.py"]
 fn test_esm2_parity_vs_python_reference() -> Result<()> {
-    use candle_core::safetensors;
     use ferritin_plms::ESM2Runner;
     use ferritin_plms::device;
-    use std::collections::HashMap;
-
-    let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join(ESM2_PARITY_FIXTURE);
-    assert!(
-        fixture_path.exists(),
-        "Fixture not found at {fixture_path:?}. Run scripts/generate_esm2_fixtures.py first."
-    );
+    use support::parity::{ParityFixture, SpecialTokens, align_rows, assert_logits_close};
 
     let dev = device(false)?;
     let esm2 = ESM2Runner::load_model(ESM2Models::T6_8M, dev.clone())?;
 
-    let fixtures: HashMap<String, candle_core::Tensor> =
-        safetensors::load(&fixture_path, &dev)?;
+    // The ESM2 reference (generate_esm2_fixtures.py) strips BOS/EOS and stores
+    // only the L interior residue rows, so align the Rust output to match.
+    let fixture = ParityFixture::load("esm2_parity", &dev)?;
 
     for (name, sequence) in PARITY_SEQUENCES {
-        let key = format!("{name}_logits");
-        let ref_logits = fixtures.get(&key)
-            .unwrap_or_else(|| panic!("fixture missing key '{key}'"));
-
+        let ref_logits = fixture.tensor(&format!("{name}_logits"))?;
         let output = esm2.run_forward(sequence)?;
-        let seq_len = sequence.chars().filter(|c| *c != '<' && *c != '>').count();
-        // Strip BOS at index 0 and EOS at index -1; keep inner L positions
-        let rust_logits = output.logits
-            .narrow(1, 1, seq_len)?
-            .squeeze(0)?;
-
-        let (rust_l, rust_v) = rust_logits.dims2()?;
-        let (ref_l, ref_v) = ref_logits.dims2()?;
-        assert_eq!(rust_l, ref_l, "{name}: sequence length mismatch ({rust_l} vs {ref_l})");
-        assert_eq!(rust_v, ref_v, "{name}: vocab size mismatch");
-
-        let rust_flat: Vec<f32> = rust_logits.flatten_all()?.to_vec1()?;
-        let ref_flat: Vec<f32> = ref_logits.flatten_all()?.to_vec1()?;
-
-        let max_diff = rust_flat.iter()
-            .zip(ref_flat.iter())
-            .map(|(&r, &p)| (r - p).abs())
-            .fold(0.0_f32, f32::max);
-
-        assert!(
-            max_diff <= ESM2_LOGIT_TOLERANCE,
-            "{name}: max absolute logit diff {max_diff:.6} exceeds tolerance {ESM2_LOGIT_TOLERANCE}"
-        );
-        println!("{name}: max logit diff = {max_diff:.6e}");
+        let rust_logits = align_rows(&output.logits, SpecialTokens::BOS_EOS)?;
+        assert_logits_close(&rust_logits, ref_logits, ESM2_LOGIT_TOLERANCE)?;
+        println!("{name}: logit parity OK (tol {ESM2_LOGIT_TOLERANCE:.1e})");
     }
     Ok(())
 }

--- a/crates/ferritin-plms/tests/test_plm_esm3.rs
+++ b/crates/ferritin-plms/tests/test_plm_esm3.rs
@@ -7,6 +7,8 @@
 //! cargo test -p ferritin-plms test_esm3 -- --ignored --nocapture
 //! ```
 
+mod support;
+
 use anyhow::Result;
 use candle_core::{DType, Device, Tensor};
 use ferritin_plms::{
@@ -16,6 +18,11 @@ use ferritin_plms::{
         tokenization::sequence::{decode_sequence, tokenize_sequence},
     },
 };
+
+/// Cosine-similarity floor for ESM3 sm-open per-residue embedding parity.
+/// A 48-layer trunk accumulates more F32 rounding than the shallower ports, so
+/// this is looser than the 1e-3 logit tolerance used for ESM2/AMPLIFY.
+const ESM3_EMBED_COSINE_FLOOR: f32 = 0.99;
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -242,5 +249,36 @@ fn test_esm3_sm_open_gfp_logit_shape() -> Result<()> {
     let expected_len = GFP.len() + 2;
     let seq_logits = output.sequence_logits.expect("sequence logits");
     assert_eq!(seq_logits.dims(), &[1, expected_len, 64]);
+    Ok(())
+}
+
+/// Numerical parity: ESM3 sm-open Rust per-residue embeddings vs the Python
+/// reference. The reference `(L+2, 1536)` tensor keeps the BOS/EOS rows, so the
+/// Rust `(1, L+2, 1536)` output aligns 1:1 after squeezing the batch dim
+/// (`SpecialTokens::NONE`); a BOS/EOS placement mismatch surfaces as a failure
+/// at position 0 or L+1 rather than passing silently.
+///
+/// Requires gated access to `EvolutionaryScale/esm3-sm-open-v1` (accept the
+/// Cambrian Non-Commercial license and `huggingface-cli login`) plus the
+/// fixture `tests/fixtures/esm3_parity.safetensors` from
+/// `scripts/generate_esm3_fixtures.py`.
+///
+/// Run: `cargo test -p ferritin-plms test_esm3_parity -- --ignored --nocapture`
+#[test]
+#[ignore = "requires gated HF download and fixture: run scripts/generate_esm3_fixtures.py"]
+fn test_esm3_parity_vs_python_reference() -> Result<()> {
+    use ferritin_plms::{ESM3Models, ESM3Runner};
+    use support::parity::{ParityFixture, SpecialTokens, align_rows, assert_embeddings_close};
+
+    let device = Device::Cpu;
+    let fixture = ParityFixture::load("esm3_parity", &device)?;
+    let ref_embeddings = fixture.tensor("embeddings")?;
+
+    let runner = ESM3Runner::from_pretrained(ESM3Models::SmOpen, device)?;
+    let rust = runner.embed_sequence(SHORT_SEQ)?; // (1, L+2, 1536)
+    let rust_embeddings = align_rows(&rust, SpecialTokens::NONE)?;
+
+    assert_embeddings_close(&rust_embeddings, ref_embeddings, ESM3_EMBED_COSINE_FLOOR)?;
+    println!("ESM3 sm-open embedding parity OK (cosine floor {ESM3_EMBED_COSINE_FLOOR})");
     Ok(())
 }

--- a/crates/ferritin-plms/tests/test_plm_esmc.rs
+++ b/crates/ferritin-plms/tests/test_plm_esmc.rs
@@ -17,6 +17,15 @@ use ferritin_plms::{
     esmc::models::esmc::{ESMC, LogitsConfig},
 };
 
+/// Cosine-similarity floor for ESMC-300M per-residue embedding parity.
+/// A 30-layer transformer accumulates F32 rounding, so this is looser than the
+/// 1e-3 logit tolerance used for the shallower ESM2/AMPLIFY ports.
+const ESMC_EMBED_COSINE_FLOOR: f32 = 0.999;
+
+/// Reference sequence for the ESMC embedding parity fixture.
+const ESMC_PARITY_SEQ: &str =
+    "MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG";
+
 /// GFP — used as the primary smoke-test sequence (matches the biohub model card).
 const GFP: &str = concat!(
     "MSKGEELFTGVVPILVELDGDVNGHKFSVSGEGEGDATYGKLTLKFICTTGKLPVPWPTLVTTFSYGVQCF",
@@ -204,5 +213,36 @@ fn test_esmc_300m_logits_shape() -> Result<()> {
         &[1, expected_len, 64],
         "ESMC-300M logits shape wrong"
     );
+    Ok(())
+}
+
+/// Numerical parity: ESMC-300M Rust per-residue embeddings vs the Python
+/// reference. The reference `(L+2, 960)` tensor **keeps** the BOS/EOS rows, so
+/// the Rust `(1, L+2, 960)` output aligns 1:1 after squeezing the batch dim
+/// (`SpecialTokens::NONE`) — a mismatch in BOS/EOS placement therefore shows up
+/// as a failure at position 0 or L+1 rather than passing silently.
+///
+/// Requires:
+///   1. `biohub/ESMC-300M` weights (~1.3 GB, cached by hf_hub on first run)
+///   2. Fixture `tests/fixtures/esmc_parity.safetensors` from
+///      `scripts/generate_esmc_fixtures.py`
+///
+/// Run: `cargo test -p ferritin-plms test_esmc_parity -- --ignored --nocapture`
+#[test]
+#[ignore = "requires HF model download and fixture: run scripts/generate_esmc_fixtures.py"]
+fn test_esmc_parity_vs_python_reference() -> Result<()> {
+    use ferritin_plms::{ESMCModels, ESMCRunner};
+    use support::parity::{ParityFixture, SpecialTokens, align_rows, assert_embeddings_close};
+
+    let device = Device::Cpu;
+    let fixture = ParityFixture::load("esmc_parity", &device)?;
+    let ref_embeddings = fixture.tensor("embeddings")?;
+
+    let runner = ESMCRunner::from_pretrained(ESMCModels::ESMC300M, device)?;
+    let rust = runner.embed_sequence(ESMC_PARITY_SEQ)?; // (1, L+2, 960)
+    let rust_embeddings = align_rows(&rust, SpecialTokens::NONE)?;
+
+    assert_embeddings_close(&rust_embeddings, ref_embeddings, ESMC_EMBED_COSINE_FLOOR)?;
+    println!("ESMC-300M embedding parity OK (cosine floor {ESMC_EMBED_COSINE_FLOOR})");
     Ok(())
 }

--- a/crates/ferritin-plms/tests/test_plm_ligandmpnn.rs
+++ b/crates/ferritin-plms/tests/test_plm_ligandmpnn.rs
@@ -1,29 +1,17 @@
 //! Tests for ProteinMPNNRunner — model loading and inference via the public API.
 
+#[path = "support/mod.rs"]
+mod support;
+
 #[cfg(test)]
 mod tests {
+    use super::support::parity::{ParityFixture, assert_distribution_close};
     use candle_core::Device;
-    use ferritin_plms::ligandmpnn::configs::{MPNNExecConfig, ModelTypes, RunConfig};
     use ferritin_plms::ProteinMPNNRunner;
+    use ferritin_plms::ligandmpnn::configs::{MPNNExecConfig, ModelTypes, RunConfig};
     use ferritin_test_data::TestFile;
 
-    /// Fixture path produced by `scripts/generate_proteinmpnn_fixtures.py`.
-    /// Not committed; generate locally then run with `cargo test -- --include-ignored`.
-    const PMPNN_PARITY_FIXTURE: &str = "tests/fixtures/1BC8_log_probs.safetensors";
-
     const KL_THRESHOLD: f64 = 0.01;
-
-    /// KL(P ‖ Q) = Σ P_i · ln(P_i / Q_i).  Both slices must be probability vectors.
-    fn kl_divergence(p: &[f32], q: &[f32]) -> f64 {
-        p.iter()
-            .zip(q.iter())
-            .filter(|(pi, _)| **pi > 1e-9)
-            .map(|(pi, qi)| {
-                let qi = qi.max(1e-9_f32);
-                (*pi as f64) * ((*pi as f64).ln() - (qi as f64).ln())
-            })
-            .sum()
-    }
 
     fn run_config() -> RunConfig {
         RunConfig {
@@ -102,35 +90,16 @@ mod tests {
     #[test]
     #[ignore = "requires fixture: run scripts/generate_proteinmpnn_fixtures.py first"]
     fn test_pmpnn_parity_vs_python_reference() {
-        use candle_core::safetensors;
-        use std::collections::HashMap;
-
-        let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join(PMPNN_PARITY_FIXTURE);
-        assert!(
-            fixture_path.exists(),
-            "Fixture not found at {fixture_path:?}. Run scripts/generate_proteinmpnn_fixtures.py first."
-        );
-
         let device = Device::Cpu;
 
-        // Load Python-reference log-probs: shape (L, 21)
-        let tensors: HashMap<String, candle_core::Tensor> =
-            safetensors::load(&fixture_path, &device)
-                .expect("Failed to load parity fixture");
-        let ref_log_probs = tensors
-            .get("log_probs")
-            .expect("fixture must contain 'log_probs' tensor");
-        let (seq_len, vocab_size) = ref_log_probs.dims2().expect("expected 2D tensor");
+        // Python-reference log-probs, shape (L, 21). ProteinMPNN has no special
+        // tokens, so the reference rows align 1:1 with residues.
+        let fixture = ParityFixture::load_with_generator("1BC8_log_probs", "proteinmpnn", &device)
+            .expect("failed to load ProteinMPNN parity fixture");
+        let ref_log_probs = fixture.tensor("log_probs").expect("missing 'log_probs'");
+        let (_, vocab_size) = ref_log_probs.dims2().expect("expected 2D tensor");
         assert_eq!(vocab_size, 21, "ProteinMPNN vocab is 21 amino acids");
-
-        let ref_probs_flat: Vec<f32> = ref_log_probs
-            .exp()
-            .expect("exp failed")
-            .reshape((seq_len * vocab_size,))
-            .expect("reshape failed")
-            .to_vec1()
-            .expect("to_vec1 failed");
+        let ref_probs = ref_log_probs.exp().expect("exp failed");
 
         // Run Rust model on 1BC8.pdb (same structure used for fixture generation)
         let (weights_path, _weights_handle) = TestFile::ligmpnn_pmpnn_01()
@@ -160,30 +129,14 @@ mod tests {
             .expect("Failed to generate protein features");
 
         // get_log_probs returns (L, 21) log-probabilities
-        let rust_log_probs = runner
+        let rust_probs = runner
             .get_log_probs(&features)
-            .expect("get_log_probs failed");
-        let rust_probs_flat: Vec<f32> = rust_log_probs
+            .expect("get_log_probs failed")
             .exp()
-            .expect("exp failed")
-            .reshape((seq_len * vocab_size,))
-            .expect("reshape failed")
-            .to_vec1()
-            .expect("to_vec1 failed");
+            .expect("exp failed");
 
-        let mut max_kl: f64 = 0.0;
-        for pos in 0..seq_len {
-            let ref_slice = &ref_probs_flat[pos * 21..(pos + 1) * 21];
-            let rust_slice = &rust_probs_flat[pos * 21..(pos + 1) * 21];
-            let kl = kl_divergence(ref_slice, rust_slice);
-            if kl > max_kl {
-                max_kl = kl;
-            }
-            assert!(
-                kl < KL_THRESHOLD,
-                "KL divergence at position {pos} = {kl:.5} exceeds threshold {KL_THRESHOLD}"
-            );
-        }
-        println!("Max per-position KL divergence: {max_kl:.6}");
+        // ProteinMPNN has no special tokens; reference and Rust rows align 1:1.
+        assert_distribution_close(&rust_probs, &ref_probs, KL_THRESHOLD)
+            .expect("ProteinMPNN distribution parity");
     }
 }

--- a/scripts/generate_esm3_fixtures.py
+++ b/scripts/generate_esm3_fixtures.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Generate ESM3 sm-open parity fixtures for the Rust numerical comparison test.
+
+Runs the EvolutionaryScale reference ESM3 sm-open-v1 on a fixed sequence and
+saves the per-residue embeddings as safetensors. The Rust test
+`test_esm3_parity_vs_python_reference` (marked #[ignore]) loads this fixture and
+asserts per-residue cosine similarity above a floor.
+
+Gated access
+------------
+esm3-sm-open-v1 is gated: accept the Cambrian Non-Commercial license at
+<https://huggingface.co/EvolutionaryScale/esm3-sm-open-v1> and run
+``huggingface-cli login`` before running this script.
+
+Alignment contract (must match tests/support/parity.rs)
+-------------------------------------------------------
+The saved ``embeddings`` tensor has shape ``(L + 2, 1536)`` and **keeps** the
+BOS/EOS rows. The Rust side compares with ``SpecialTokens::NONE`` (batch dim
+squeezed, no rows stripped), so a BOS/EOS placement mismatch surfaces as a
+failure at position 0 or L+1 rather than passing silently.
+
+Usage
+-----
+    pip install esm safetensors torch
+
+    python scripts/generate_esm3_fixtures.py \
+        --output crates/ferritin-plms/tests/fixtures/
+
+The reference sequence must stay in sync with ``SHORT_SEQ`` in
+crates/ferritin-plms/tests/test_plm_esm3.rs.
+"""
+
+import argparse
+from pathlib import Path
+
+import torch
+
+# Must match SHORT_SEQ in tests/test_plm_esm3.rs
+SEQUENCE = "ACDEFGHIK"
+
+
+@torch.no_grad()
+def get_embeddings(sequence: str) -> torch.Tensor:
+    """Return per-residue embeddings, shape (L + 2, 1536), including BOS/EOS."""
+    from esm.models.esm3 import ESM3
+    from esm.sdk.api import ESMProtein, SamplingConfig
+
+    client = ESM3.from_pretrained("esm3_sm_open_v1")
+    client.eval()
+
+    protein = ESMProtein(sequence=sequence)
+    tensor = client.encode(protein)
+    output = client.forward_and_sample(
+        tensor,
+        SamplingConfig(return_per_residue_embeddings=True),
+    )
+    # per_residue_embedding: (L + 2, 1536)
+    return output.per_residue_embedding.float().cpu()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate ESM3 sm-open parity fixtures")
+    parser.add_argument("--output", required=True, help="Output directory for safetensors")
+    args = parser.parse_args()
+
+    try:
+        from safetensors.torch import save_file
+    except ImportError:
+        raise ImportError("pip install safetensors")
+
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Embedding reference sequence ({len(SEQUENCE)} residues) with ESM3 sm-open ...")
+    embeddings = get_embeddings(SEQUENCE)
+    print(f"  embeddings shape: {tuple(embeddings.shape)} (expected ({len(SEQUENCE) + 2}, 1536))")
+
+    out_path = output_dir / "esm3_parity.safetensors"
+    save_file({"embeddings": embeddings.contiguous()}, str(out_path))
+    print(f"Saved {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_esmc_fixtures.py
+++ b/scripts/generate_esmc_fixtures.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Generate ESMC-300M parity fixtures for the Rust numerical comparison test.
+
+Runs the EvolutionaryScale reference ESMC-300M on a fixed sequence and saves the
+per-residue embeddings as safetensors. The Rust test
+`test_esmc_parity_vs_python_reference` (marked #[ignore]) loads this fixture and
+asserts per-residue cosine similarity above a floor.
+
+Alignment contract (must match tests/support/parity.rs)
+-------------------------------------------------------
+The saved ``embeddings`` tensor has shape ``(L + 2, 960)`` and **keeps** the
+BOS/EOS rows the tokenizer prepends/appends. The Rust side compares with
+``SpecialTokens::NONE`` (batch dim squeezed, no rows stripped), so a mismatch in
+BOS/EOS placement surfaces as a failure at position 0 or L+1 rather than passing
+silently.
+
+Usage
+-----
+    pip install esm safetensors torch
+
+    python scripts/generate_esmc_fixtures.py \
+        --output crates/ferritin-plms/tests/fixtures/
+
+The reference sequence must stay in sync with ``ESMC_PARITY_SEQ`` in
+crates/ferritin-plms/tests/test_plm_esmc.rs.
+"""
+
+import argparse
+from pathlib import Path
+
+import torch
+
+# Must match ESMC_PARITY_SEQ in tests/test_plm_esmc.rs
+SEQUENCE = "MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG"
+
+
+@torch.no_grad()
+def get_embeddings(sequence: str) -> torch.Tensor:
+    """Return per-residue embeddings, shape (L + 2, 960), including BOS/EOS."""
+    from esm.models.esmc import ESMC
+    from esm.sdk.api import ESMProtein, LogitsConfig
+
+    client = ESMC.from_pretrained("esmc_300m")
+    client.eval()
+
+    protein = ESMProtein(sequence=sequence)
+    tensor = client.encode(protein)
+    output = client.logits(
+        tensor,
+        LogitsConfig(sequence=True, return_embeddings=True),
+    )
+    # output.embeddings: (1, L + 2, 960) -> drop the batch dim
+    return output.embeddings[0].float().cpu()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate ESMC-300M parity fixtures")
+    parser.add_argument("--output", required=True, help="Output directory for safetensors")
+    args = parser.parse_args()
+
+    try:
+        from safetensors.torch import save_file
+    except ImportError:
+        raise ImportError("pip install safetensors")
+
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Embedding reference sequence ({len(SEQUENCE)} residues) with ESMC-300M ...")
+    embeddings = get_embeddings(SEQUENCE)
+    print(f"  embeddings shape: {tuple(embeddings.shape)} (expected ({len(SEQUENCE) + 2}, 960))")
+
+    out_path = output_dir / "esmc_parity.safetensors"
+    save_file({"embeddings": embeddings.contiguous()}, str(out_path))
+    print(f"Saved {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes the P0a task **ferritin-100.1** in the ferritin-plms hardening epic (ferritin-100). Every parity test previously hand-rolled its own comparison logic — `test_plm_ligandmpnn.rs` had a private `kl_divergence`, `test_plm_amplify` / `test_plm_esm2` each repeated a load-safetensors-and-max-diff block, and ESMC/ESM3 had no parity test at all. This introduces one shared harness and rewires everything onto it.

## What's here

**New harness — `crates/ferritin-plms/tests/support/parity.rs`**
- `ParityFixture::load(name)` — resolves `tests/fixtures/<name>.safetensors`, returns a keyed tensor map, and emits a *"run scripts/generate_X_fixtures.py"* error (naming the present keys) when a fixture or key is absent. `load_with_generator` covers the ProteinMPNN case whose fixture stem (`1BC8_log_probs`) doesn't match its script name.
- `assert_logits_close` — max-absolute-difference; names the offending `(position, vocab_index)`.
- `assert_distribution_close` — per-position KL divergence (lifted out of `test_plm_ligandmpnn.rs`); names the max-KL position.
- `assert_embeddings_close` — per-residue cosine similarity; names the min-cosine position (for models whose output is an embedding, i.e. ESMC/ESM3).
- `SpecialTokens` + `align_rows` — centralize BOS/EOS alignment. The reference tokenizers disagree on BOS/EOS, so a silent off-by-one would make a broken port look correct; the layout for each family is documented in the module header and a mismatch now fails at position 0 / L+1 rather than passing.

**Rewired + new tests**
- `test_plm_amplify`, `test_plm_esm2`, `test_plm_ligandmpnn` now call the harness instead of local copies.
- New parity tests for **ESMC-300M** and **ESM3 sm-open** (embedding cosine parity), with matching `scripts/generate_esmc_fixtures.py` / `generate_esm3_fixtures.py` reference generators so the tests' error messages point at real scripts.
- `test_parity_harness.rs` — 10 self-tests covering every helper with hand-built tensors (no weights), including asserting each failure message names the offending position.

## Testing

`cargo test -p ferritin-plms` → **150 passed, 0 failed** across 12 binaries; 22 ignored are the weight/fixture-gated parity + smoke tests. `cargo fmt --check` clean on all changed files.

The parity tests stay `#[ignore]` until the fixtures land — that's the blocked follow-up **ferritin-100.2 (P0b)**.

## Out of scope

`cargo clippy` surfaces a pre-existing `eq_op` error at `src/esmc/models/esmc.rs:135` (`36f64 / 36.`) unrelated to this change — it belongs to the clippy-gate task **ferritin-100.5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)