### PR TITLE
Fix ESM2 Candle port numeric divergence (ferritin-n5g)

### DIFF
--- a/crates/ferritin-plms/src/esm2/esm2.rs
+++ b/crates/ferritin-plms/src/esm2/esm2.rs
@@ -514,8 +514,12 @@ impl ESM2Attention {
 
         // Apply attention weights to values
         let attn_output = attention_weights_flat.matmul(&v)?;
+        // Un-merge heads: (batch*heads, seq, head_dim) -> (seq, batch*heads,
+        // head_dim) -> (seq, batch, embed). This must mirror the forward split
+        // (transpose(0,1)); transpose(1,2) here would scramble seq with
+        // head_dim.
         let attn_output = attn_output
-            .transpose(1, 2)?
+            .transpose(0, 1)?
             .contiguous()?
             .reshape((seq_len, batch_size, embed_dim))?;
         let output = self.out_proj.forward(&attn_output)?;
@@ -562,9 +566,13 @@ impl ESM2Layer {
         let norm_x = xs.apply(&self.self_attn_layer_norm)?;
         let (attn_out, attn_weights) = self.self_attn.forward(&norm_x, &norm_x, &norm_x)?;
         let x = (attn_out + xs)?;
-        // Pre-LayerNorm → FFN → residual
+        // Pre-LayerNorm → FFN → residual.
+        // ESM-2's intermediate activation is exact (erf-based) gelu; candle's
+        // `gelu()` is the tanh approximation, which drifts per layer and
+        // compounds across the stack. Match the LM head (which already uses
+        // `gelu_erf`) and HF modeling_esm.py.
         let norm_x2 = x.apply(&self.final_layer_norm)?;
-        let ffn_out = norm_x2.apply(&self.fc1)?.gelu()?.apply(&self.fc2)?;
+        let ffn_out = norm_x2.apply(&self.fc1)?.gelu_erf()?.apply(&self.fc2)?;
         Ok(((ffn_out + x)?, attn_weights))
     }
 }

--- a/crates/ferritin-plms/src/esm2/esm2_runner.rs
+++ b/crates/ferritin-plms/src/esm2/esm2_runner.rs
@@ -87,14 +87,38 @@ impl ESM2Runner {
         let tokenizer = ESM2::load_tokenizer()?;
         Ok(ESM2Runner { model, tokenizer })
     }
+    /// Encode a sequence to token ids **with** ESM-2's BOS (`<cls>`) and EOS
+    /// (`<eos>`) special tokens.
+    ///
+    /// The bundled `tokenizer.json` has no post-processor, so `encode(.., true)`
+    /// would still NOT add them. ESM-2 is trained with BOS/EOS wrapping the
+    /// sequence, and every consumer here (`predict_contacts`,
+    /// `get_pseudo_probabilities`, `embed`, `decode_logits`) assumes an `L + 2`
+    /// row output and strips those two rows. Running the model without them
+    /// feeds a different context and its logits diverge from the HF reference,
+    /// so they must be added explicitly.
+    fn encode_with_special(&self, sequence: &str) -> Result<Vec<u32>> {
+        let bos = self
+            .tokenizer
+            .token_to_id("<cls>")
+            .ok_or_else(|| anyhow!("ESM2 tokenizer missing <cls> token"))?;
+        let eos = self
+            .tokenizer
+            .token_to_id("<eos>")
+            .ok_or_else(|| anyhow!("ESM2 tokenizer missing <eos> token"))?;
+        let inner = self
+            .tokenizer
+            .encode(sequence.to_string(), false)
+            .map_err(E::msg)?;
+        let mut ids = Vec::with_capacity(inner.get_ids().len() + 2);
+        ids.push(bos);
+        ids.extend_from_slice(inner.get_ids());
+        ids.push(eos);
+        Ok(ids)
+    }
     pub fn run_forward(&self, prot_sequence: &str) -> Result<ESM2Output> {
         let device = self.model.get_device();
-        let tokens = self
-            .tokenizer
-            .encode(prot_sequence.to_string(), false)
-            .map_err(E::msg)?
-            .get_ids()
-            .to_vec();
+        let tokens = self.encode_with_special(prot_sequence)?;
         let token_ids = Tensor::new(&tokens[..], device)?.unsqueeze(0)?;
         let encoded = self.model.forward(&token_ids, None)?;
         Ok(encoded)
@@ -105,12 +129,7 @@ impl ESM2Runner {
     /// so dimensions equal the number of amino acids in `prot_sequence`).
     pub fn predict_contacts(&self, prot_sequence: &str) -> Result<Tensor> {
         let device = self.model.get_device();
-        let tokens = self
-            .tokenizer
-            .encode(prot_sequence.to_string(), false)
-            .map_err(E::msg)?
-            .get_ids()
-            .to_vec();
+        let tokens = self.encode_with_special(prot_sequence)?;
         let token_ids = Tensor::new(&tokens[..], device)?.unsqueeze(0)?;
         // squeeze batch dim: (1, L, L) → (L, L)
         self.model
@@ -173,12 +192,7 @@ impl PlmRunner for ESM2Runner {
     /// Shape: `(1, L, hidden_size)` where `L` includes BOS and EOS tokens.
     fn embed(&self, sequence: &str) -> Result<Tensor> {
         let device = self.model.get_device();
-        let tokens = self
-            .tokenizer
-            .encode(sequence.to_string(), false)
-            .map_err(E::msg)?
-            .get_ids()
-            .to_vec();
+        let tokens = self.encode_with_special(sequence)?;
         let token_ids = Tensor::new(&tokens[..], device)?.unsqueeze(0)?;
         Ok(self.model.embed(&token_ids, None)?)
     }


### PR DESCRIPTION
Fixes **ferritin-n5g** — the ESM2 Candle port produced logits that diverged from the HuggingFace `esm2_t6_8M` reference by ~9-15 on identical input (surfaced by the parity fixture committed in #171 / ferritin-100.2).

## Root cause

Stage-by-stage comparison against HF intermediates (embeddings matched to 0.0; **layer 0 already diverged by 3.45**) localized two numeric bugs in the transformer layer, plus a tokenization bug:

1. **Attention head-unmerge (dominant).** After `weights @ v` the context is `(batch*heads, seq, head_dim)`; the code did `transpose(1, 2)` before reshaping back to `(seq, batch, embed)`, scrambling `seq` with `head_dim`. It must mirror the forward split's `transpose(0, 1)`.
2. **FFN activation.** The layer FFN used candle's `gelu()` (tanh approximation); ESM-2's `hidden_act="gelu"` is exact **erf** gelu. The LM head already used `gelu_erf()` with a comment noting plain gelu is "subtly wrong" — the encoder layers were inconsistent.
3. **Special tokens.** `ESM2Runner` tokenized with `encode(.., false)` — no BOS/EOS — while `predict_contacts`, `get_pseudo_probabilities`, `embed`, and `decode_logits` all document and strip an `L + 2` output. The bundled tokenizer has no post-processor, so a new `encode_with_special()` adds `<cls>`/`<eos>` explicitly.

## Result

- With bugs 1+2 fixed, Rust matches HF to **~1e-5** on identical token input (was ~9-15).
- With bug 3 fixed, the committed `esm2_parity` test passes at **tol 1e-3** on all four reference sequences.

## Test plan

- `FERRITIN_HF_TESTS=1 cargo test -p ferritin-plms test_esm2_parity` → all 4 sequences "logit parity OK (tol 1.0e-3)".
- `cargo test -p ferritin-plms` → green, no regressions (111 lib + integration).

## Notes

- The cross-runner `PlmRunner` special-token contract (and the same `encode(.., false)` pattern in the AMPLIFY runner / **ferritin-edm**) remains **ferritin-100.7**; this PR fixes ESM2 specifically so its parity test is verifiable now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
