### PR TITLE
Fix AMPLIFY Candle port rotary frequency base + special tokens (ferritin-edm)

### DIFF
--- a/crates/ferritin-plms/src/amplify/amplify.rs
+++ b/crates/ferritin-plms/src/amplify/amplify.rs
@@ -133,8 +133,12 @@ impl AMPLIFY {
 pub fn precompute_freqs_cis(head_dim: usize, seq_len: usize) -> Result<Tensor> {
     let half_dim = head_dim / 2;
     let theta = 10000.0_f32;
+    // AMPLIFY rotary.py: freqs = 1 / theta ** (arange(0, head_dim, 2) / head_dim),
+    // i.e. exponent 2*i / head_dim for i in 0..head_dim/2. The denominator is the
+    // full head_dim, NOT half_dim — dividing by half_dim makes the frequencies
+    // decay twice as fast and skews rotary phase with position.
     let freqs = Tensor::from_iter(
-        (0..half_dim).map(|i| 1.0 / theta.powf(2.0 * i as f32 / half_dim as f32)),
+        (0..half_dim).map(|i| 1.0 / theta.powf(2.0 * i as f32 / head_dim as f32)),
         &Device::Cpu,
     )?;
     let t = (0..seq_len).map(|x| x as f32);

--- a/crates/ferritin-plms/src/amplify/amplify_runner.rs
+++ b/crates/ferritin-plms/src/amplify/amplify_runner.rs
@@ -72,7 +72,7 @@ impl AmplifyRunner {
         let device = self.model.get_device();
         let tokens = self
             .tokenizer
-            .encode(prot_sequence.to_string(), false)
+            .encode(prot_sequence.to_string(), true)
             .map_err(E::msg)?
             .get_ids()
             .to_vec();
@@ -166,7 +166,7 @@ impl PlmRunner for AmplifyRunner {
         let device = self.model.get_device();
         let tokens = self
             .tokenizer
-            .encode(sequence.to_string(), false)
+            .encode(sequence.to_string(), true)
             .map_err(E::msg)?
             .get_ids()
             .to_vec();


### PR DESCRIPTION
Fixes **ferritin-edm** — the AMPLIFY 120M Candle port diverged from the HuggingFace reference by ~1.0 in logits (argmax still matched), with the error **growing with sequence position** — the classic signature of a rotary-embedding bug.

## Root cause

1. **Rotary frequency base (dominant).** `precompute_freqs_cis` computed `1 / theta^(2i / (head_dim/2))`, dividing the exponent by `half_dim` instead of `head_dim`. AMPLIFY's `rotary.py` uses `freqs = 1 / theta ** (arange(0, head_dim, 2) / head_dim)` → exponent `2i / head_dim`. The bug made rotary frequencies decay twice as fast, skewing phase with position (worst at position 7 in the 11-mer). Fixed the denominator to `head_dim`.
2. **Missing special tokens.** `AmplifyRunner` tokenized with `encode(.., false)`, dropping the `<bos>`/`<eos>` that the bundled tokenizer's `TemplateProcessing` post-processor adds (AMPLIFY has one, unlike ESM2, so `encode(.., true)` suffices — no manual helper). `embed` documents "L includes BOS and EOS", so this also fixes that path.

## Result

- With both fixed, the committed `amplify_parity` test passes at **tol 1e-3** on all three reference sequences (was diverging ~1.0).
- `cargo test -p ferritin-plms` → green, no regressions.

## How it was found

Ruled out an ESM2-style head-unmerge/gelu bug (AMPLIFY's attention uses proper `permute` and correct SwiGLU/silu), then compared the Rust RoPE against AMPLIFY's official `rotary.py` and found the frequency-base mismatch.

## Reference caveat

Verified against the `amplify_parity` fixture, whose Python reference uses a pure-torch xformers stand-in for `SwiGLU` (CPU AMPLIFY uses native SDPA for attention). The Rust port and that stand-in compute SwiGLU identically, so the now-passing attention/rotary/decoder path is trustworthy.

## Notes

- The cross-runner `PlmRunner` special-token contract remains **ferritin-100.7**; this fixes AMPLIFY specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
