### PR TITLE
Fix AmplifyRunner::get_contact_map residue labels (ferritin-100.3)

### DIFF
--- a/crates/ferritin-plms/src/amplify/amplify_runner.rs
+++ b/crates/ferritin-plms/src/amplify/amplify_runner.rs
@@ -99,10 +99,34 @@ impl AmplifyRunner {
     }
     pub fn get_contact_map(&self, prot_sequence: &str) -> Result<Vec<ContactMap>> {
         let model_output: AmplifyOutput = self.run_forward(prot_sequence)?;
-        let contact_map_tensor = model_output.get_contact_map()?;
-        let averaged = contact_map_tensor.clone().unwrap().max_keepdim(D::Minus1)?;
+        let contact_map_tensor = model_output.get_contact_map()?.ok_or_else(|| {
+            anyhow!("AMPLIFY forward() returned no attentions for the contact map")
+        })?;
+        let averaged = contact_map_tensor.max_keepdim(D::Minus1)?;
         let (position1, position2, val) = averaged.dims3()?;
         let data = averaged.to_vec3::<f32>()?;
+
+        // Per-position residue labels. The contact map is BOS/EOS-stripped, so
+        // position `p` is the p-th residue; decode the actual token ids the
+        // model saw (encode adds BOS/EOS, so the residues are ids[1..len-1])
+        // rather than decoding the position index as if it were a token id.
+        let encoded = self
+            .tokenizer
+            .encode(prot_sequence.to_string(), true)
+            .map_err(E::msg)?;
+        let ids = encoded.get_ids();
+        let residue_ids = if ids.len() >= 2 {
+            &ids[1..ids.len() - 1]
+        } else {
+            &ids[..]
+        };
+        let label_at = |p: usize| -> char {
+            residue_ids
+                .get(p)
+                .and_then(|&id| self.tokenizer.decode(&[id], true).ok())
+                .and_then(|s| s.chars().next())
+                .unwrap_or('?')
+        };
 
         let mut contacts = Vec::new();
         for i in 0..position1 {
@@ -110,19 +134,9 @@ impl AmplifyRunner {
                 for k in 0..val {
                     contacts.push(ContactMap {
                         position_1: i,
-                        amino_acid_1: self
-                            .tokenizer
-                            .decode(&[i as u32], true)
-                            .ok()
-                            .and_then(|s| s.chars().next())
-                            .unwrap_or('?'),
+                        amino_acid_1: label_at(i),
                         position_2: j,
-                        amino_acid_2: self
-                            .tokenizer
-                            .decode(&[j as u32], true)
-                            .ok()
-                            .and_then(|s| s.chars().next())
-                            .unwrap_or('?'),
+                        amino_acid_2: label_at(j),
                         contact_estimate: data[i][j][k],
                         layer: 1,
                     });

--- a/crates/ferritin-plms/tests/test_plm_amplify.rs
+++ b/crates/ferritin-plms/tests/test_plm_amplify.rs
@@ -90,6 +90,24 @@ fn test_amplify_120m_contact_map() {
             "Contact estimate should be a valid number"
         );
     }
+
+    // Regression for ferritin-100.3: labels must be the actual residues, not
+    // '?' (the old code decoded the position index as a token id, so every
+    // position >= vocab size, i.e. essentially all of this ~250-residue
+    // protein, came back '?').
+    let seq: Vec<char> = TEST_SEQUENCE.chars().collect();
+    for contact in &contacts {
+        assert_eq!(
+            contact.amino_acid_1, seq[contact.position_1],
+            "amino_acid_1 at position {} should be the input residue",
+            contact.position_1
+        );
+        assert_eq!(
+            contact.amino_acid_2, seq[contact.position_2],
+            "amino_acid_2 at position {} should be the input residue",
+            contact.position_2
+        );
+    }
 }
 
 /// Numerical parity: AMPLIFY Rust logits vs HuggingFace Python reference.


### PR DESCRIPTION
Fixes **ferritin-100.3** — `AmplifyRunner::get_contact_map` labeled every residue `'?'` on any real-length protein.

## Bug

The contact-map loop decoded the residue **position index** as if it were a token id:

```rust
amino_acid_1: self.tokenizer.decode(&[i as u32], true)...unwrap_or('?')
```

`i` is the position `0..seq_len`. The AMPLIFY vocab is ~27 tokens, so any position `>= 27` decodes to an empty string → `'?'` — essentially every residue of any protein longer than ~27. Below 27 the label was confidently wrong (naming whichever amino acid sits at that vocab index).

## Fix

Label each position from the **actual token ids the model saw**. `encode` adds BOS/EOS, so the residues are `ids[1..len-1]`, which line up 1:1 with the BOS/EOS-stripped contact map. Also replaced the `Option::clone().unwrap()` on the contact tensor with a real `ok_or_else` message.

## Test

Strengthened the (ignored) `test_amplify_120m_contact_map` to assert every `amino_acid_{1,2}` equals the corresponding input residue. Verified against the cached AMPLIFY 120M weights (`-- --ignored`): passes on the ~250-residue `TEST_SEQUENCE`. Full `cargo test -p ferritin-plms` green.

## Out of scope

The `seq_len^2` `ContactMap` allocation with an always-1 `k` dimension is an API change; left for its own issue per the bug notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
