### PR TITLE
Add clippy + rustfmt CI gates and clear all lint findings (ferritin-100.5, ferritin-100.15)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
 
       - name: Install ALSA development package
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev protobuf-compiler
@@ -33,6 +35,12 @@ jobs:
 
       - name: Check all targets (examples, tests, benches)
         run: cargo check --workspace --all-targets
+
+      - name: Format
+        run: cargo fmt --all --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: Check rerun-gated code
         run: cargo check -p ferritin-bevy --features rerun

--- a/crates/ferritin-bevy/src/colors.rs
+++ b/crates/ferritin-bevy/src/colors.rs
@@ -5,7 +5,9 @@ use bevy::color::Srgba;
 use bevy::math::Vec4;
 use bevy::prelude::{Color, Mesh};
 use ferritin_core::AtomCollection;
-use ferritin_molviewspec::molviewspec::nodes::{ColorNamesT, ColorT, ColorThemeT, ComponentSelector};
+use ferritin_molviewspec::molviewspec::nodes::{
+    ColorNamesT, ColorT, ColorThemeT, ComponentSelector,
+};
 
 /// Represents different color schemes for rendering atoms.
 #[derive(Clone)]
@@ -65,16 +67,14 @@ pub fn initial_colors_from_theme(
     match theme {
         ColorThemeT::Uniform => vec![white; n_verts],
 
-        ColorThemeT::ElementSymbol => {
-            vertex_map
-                .iter()
-                .map(|&atom_idx| {
-                    let elem = model.get_element(atom_idx);
-                    let c = element_color(elem);
-                    Vec4::new(c.red, c.green, c.blue, c.alpha)
-                })
-                .collect()
-        }
+        ColorThemeT::ElementSymbol => vertex_map
+            .iter()
+            .map(|&atom_idx| {
+                let elem = model.get_element(atom_idx);
+                let c = element_color(elem);
+                Vec4::new(c.red, c.green, c.blue, c.alpha)
+            })
+            .collect(),
 
         ColorThemeT::ChainId => {
             // Assign each unique chain an index in encounter order; wrap palette.
@@ -114,10 +114,9 @@ pub fn initial_colors_from_theme(
                     let res_idx = match map_kind {
                         VertexMapKind::AtomMap => {
                             // Find which residue owns this atom.
-                            model.get_residue_start_indices()
-                                .and_then(|rs| {
-                                    rs.partition_point(|&s| s <= idx).checked_sub(1)
-                                })
+                            model
+                                .get_residue_start_indices()
+                                .and_then(|rs| rs.partition_point(|&s| s <= idx).checked_sub(1))
                                 .unwrap_or(0)
                         }
                         VertexMapKind::ResidueMap => idx,
@@ -135,7 +134,11 @@ pub fn initial_colors_from_theme(
                     .map(|&idx| {
                         let atom_idx = resolve_atom_index(model, idx, map_kind);
                         let v = values[atom_idx];
-                        let t = if max > min { (v - min) / (max - min) } else { 0.5 };
+                        let t = if max > min {
+                            (v - min) / (max - min)
+                        } else {
+                            0.5
+                        };
                         uncertainty_gradient(t)
                     })
                     .collect()
@@ -243,27 +246,23 @@ fn occupancy_color(v: f32) -> Vec4 {
 /// Returns one `Vec4` color per amino-acid residue in iteration order.
 fn detect_secondary_structure_colors(model: &AtomCollection) -> Vec<Vec4> {
     // Canonical SS colors matching the cartoon renderer.
-    let helix_color = Vec4::new(1.0, 0.6, 0.6, 1.0);   // salmon
-    let sheet_color = Vec4::new(0.6, 0.6, 1.0, 1.0);   // periwinkle
-    let loop_color  = Vec4::new(0.6, 0.9, 0.6, 1.0);   // light-green
+    let helix_color = Vec4::new(1.0, 0.6, 0.6, 1.0); // salmon
+    let sheet_color = Vec4::new(0.6, 0.6, 1.0, 1.0); // periwinkle
+    let loop_color = Vec4::new(0.6, 0.9, 0.6, 1.0); // light-green
 
     // Collect CA positions for each amino-acid residue.
     let ca_positions: Vec<Option<[f32; 3]>> = model
         .iter_residues_aminoacid()
-        .map(|res| {
-            res.find_atom_by_name("CA").map(|a| *a.coords())
-        })
+        .map(|res| res.find_atom_by_name("CA").map(|a| *a.coords()))
         .collect();
 
     let n = ca_positions.len();
     let mut ss_colors = vec![loop_color; n];
 
     for i in 1..n.saturating_sub(1) {
-        let (Some(prev), Some(curr), Some(next)) = (
-            ca_positions[i - 1],
-            ca_positions[i],
-            ca_positions[i + 1],
-        ) else {
+        let (Some(prev), Some(curr), Some(next)) =
+            (ca_positions[i - 1], ca_positions[i], ca_positions[i + 1])
+        else {
             continue;
         };
         let d1 = dist(prev, curr);
@@ -337,13 +336,19 @@ pub fn apply_mvs_colors_with_theme(
         return;
     }
     let mut vertex_colors = initial_colors_from_theme(theme, model, vertex_map, &map_kind);
-    apply_color_overrides(&mut vertex_colors, color_nodes, model, vertex_map, &map_kind);
+    apply_color_overrides(
+        &mut vertex_colors,
+        color_nodes,
+        model,
+        vertex_map,
+        &map_kind,
+    );
     mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, vertex_colors);
 }
 
 /// Overlay `color_nodes` on top of an existing `vertex_colors` array in-place.
 fn apply_color_overrides(
-    vertex_colors: &mut Vec<Vec4>,
+    vertex_colors: &mut [Vec4],
     color_nodes: &[(ComponentSelector, ColorT)],
     model: &AtomCollection,
     vertex_map: &[usize],
@@ -405,14 +410,14 @@ pub fn color_t_to_bevy(color: &ColorT) -> Color {
 /// Returns `Color::WHITE` with a `warn!` on any parse error.
 pub fn parse_hex_color(s: &str) -> Color {
     let s = s.trim_start_matches('#');
-    if s.len() == 6 {
-        if let (Ok(r), Ok(g), Ok(b)) = (
+    if s.len() == 6
+        && let (Ok(r), Ok(g), Ok(b)) = (
             u8::from_str_radix(&s[0..2], 16),
             u8::from_str_radix(&s[2..4], 16),
             u8::from_str_radix(&s[4..6], 16),
-        ) {
-            return Color::srgb(r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0);
-        }
+        )
+    {
+        return Color::srgb(r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0);
     }
     bevy::log::warn!("Invalid hex color '{}'; falling back to white", s);
     Color::WHITE
@@ -921,7 +926,10 @@ mod tests {
         let has_non_white = colors.iter().any(|c| {
             (c[0] - 1.0).abs() > 0.05 || (c[1] - 1.0).abs() > 0.05 || (c[2] - 1.0).abs() > 0.05
         });
-        assert!(has_non_white, "ElementSymbol theme should produce non-white colors");
+        assert!(
+            has_non_white,
+            "ElementSymbol theme should produce non-white colors"
+        );
     }
 
     // T2-51: ChainId theme gives distinct colors per chain
@@ -1003,9 +1011,21 @@ mod tests {
                 initial_colors_from_theme(&theme, &ac, &vertex_map, &VertexMapKind::AtomMap);
             assert_eq!(colors.len(), 9);
             for c in colors {
-                assert!((c[0] - 1.0).abs() < 1e-6, "{:?} should fall back to white", theme);
-                assert!((c[1] - 1.0).abs() < 1e-6, "{:?} should fall back to white", theme);
-                assert!((c[2] - 1.0).abs() < 1e-6, "{:?} should fall back to white", theme);
+                assert!(
+                    (c[0] - 1.0).abs() < 1e-6,
+                    "{:?} should fall back to white",
+                    theme
+                );
+                assert!(
+                    (c[1] - 1.0).abs() < 1e-6,
+                    "{:?} should fall back to white",
+                    theme
+                );
+                assert!(
+                    (c[2] - 1.0).abs() < 1e-6,
+                    "{:?} should fall back to white",
+                    theme
+                );
             }
         }
     }
@@ -1014,9 +1034,8 @@ mod tests {
     // range to a blue-white-red gradient instead of falling back to white.
     #[test]
     fn test_uncertainty_theme_uses_real_gradient() {
-        let ac = make_test_collection().with_b_factor(vec![
-            0.0, 12.5, 25.0, 37.5, 50.0, 62.5, 75.0, 87.5, 100.0,
-        ]);
+        let ac = make_test_collection()
+            .with_b_factor(vec![0.0, 12.5, 25.0, 37.5, 50.0, 62.5, 75.0, 87.5, 100.0]);
         let vertex_map: Vec<usize> = (0..9).collect();
         let colors = initial_colors_from_theme(
             &ColorThemeT::Uncertainty,
@@ -1027,17 +1046,24 @@ mod tests {
         // Lowest value -> blue-heavy, highest value -> red-heavy, not uniform white.
         let low = colors[0];
         let high = colors[8];
-        assert!(low[2] > low[0], "lowest b_factor should read blue-leaning: {:?}", low);
-        assert!(high[0] > high[2], "highest b_factor should read red-leaning: {:?}", high);
+        assert!(
+            low[2] > low[0],
+            "lowest b_factor should read blue-leaning: {:?}",
+            low
+        );
+        assert!(
+            high[0] > high[2],
+            "highest b_factor should read red-leaning: {:?}",
+            high
+        );
         assert_ne!(low, high);
     }
 
     // ferritin-clv: PlddtConfidence buckets values into AlphaFold-style bands.
     #[test]
     fn test_plddt_confidence_theme_bands_values() {
-        let ac = make_test_collection().with_b_factor(vec![
-            95.0, 95.0, 95.0, 80.0, 80.0, 60.0, 60.0, 30.0, 30.0,
-        ]);
+        let ac = make_test_collection()
+            .with_b_factor(vec![95.0, 95.0, 95.0, 80.0, 80.0, 60.0, 60.0, 30.0, 30.0]);
         let vertex_map: Vec<usize> = (0..9).collect();
         let colors = initial_colors_from_theme(
             &ColorThemeT::PlddtConfidence,
@@ -1055,9 +1081,8 @@ mod tests {
     // ferritin-clv: Occupancy maps partial occupancy toward red, full occupancy toward white.
     #[test]
     fn test_occupancy_theme_uses_real_gradient() {
-        let ac = make_test_collection().with_occupancy(vec![
-            1.0, 1.0, 1.0, 1.0, 1.0, 0.5, 0.5, 0.2, 0.2,
-        ]);
+        let ac = make_test_collection()
+            .with_occupancy(vec![1.0, 1.0, 1.0, 1.0, 1.0, 0.5, 0.5, 0.2, 0.2]);
         let vertex_map: Vec<usize> = (0..9).collect();
         let colors = initial_colors_from_theme(
             &ColorThemeT::Occupancy,
@@ -1065,7 +1090,14 @@ mod tests {
             &vertex_map,
             &VertexMapKind::AtomMap,
         );
-        assert_eq!(colors[0], Vec4::new(1.0, 1.0, 1.0, 1.0), "full occupancy is white");
-        assert!(colors[7][1] < colors[0][1], "partial occupancy should read less white/more red");
+        assert_eq!(
+            colors[0],
+            Vec4::new(1.0, 1.0, 1.0, 1.0),
+            "full occupancy is white"
+        );
+        assert!(
+            colors[7][1] < colors[0][1],
+            "partial occupancy should read less white/more red"
+        );
     }
 }

--- a/crates/ferritin-bevy/src/mvs_executor.rs
+++ b/crates/ferritin-bevy/src/mvs_executor.rs
@@ -27,7 +27,7 @@ use bevy::core_pipeline::tonemapping::Tonemapping;
 use bevy::pbr::{ScreenSpaceAmbientOcclusion, ScreenSpaceAmbientOcclusionQualityLevel};
 use bevy::prelude::*;
 use bevy::ui::Node as UiNode;
-use ferritin_core::{load_model, AtomCollection, Model};
+use ferritin_core::{AtomCollection, Model, load_model};
 use ferritin_molviewspec::molviewspec::nodes::{
     CameraParams, CanvasParams, ColorT, ColorThemeT, ComponentInlineParams, ComponentSelector,
     FocusInlineParams, KindT, LabelInlineParams, LineParams, Node, NodeParams, ParseFormatT,
@@ -35,8 +35,8 @@ use ferritin_molviewspec::molviewspec::nodes::{
     StructureTypeT, TransformParams,
 };
 
-use crate::colors::{apply_mvs_colors_with_theme, color_t_to_bevy, VertexMapKind};
-use crate::selection::{evaluate_selector, AtomMask};
+use crate::colors::{VertexMapKind, apply_mvs_colors_with_theme, color_t_to_bevy};
+use crate::selection::{AtomMask, evaluate_selector};
 use crate::structure::{RenderOptions, Structure};
 
 // ---------------------------------------------------------------------------
@@ -388,17 +388,17 @@ fn execute_root(root: &Node, ctx: &mut Ctx) {
     // Canvas and camera are applied first so that any `focus` node encountered later
     // (deep inside a structure) overrides the camera — focus always wins.
     for child in children(root) {
-        if child.kind == KindT::Canvas {
-            if let Some(NodeParams::CanvasParams(p)) = &child.params {
-                apply_canvas(p, ctx);
-            }
+        if child.kind == KindT::Canvas
+            && let Some(NodeParams::CanvasParams(p)) = &child.params
+        {
+            apply_canvas(p, ctx);
         }
     }
     for child in children(root) {
-        if child.kind == KindT::Camera {
-            if let Some(NodeParams::CameraParams(p)) = &child.params {
-                apply_camera(p, ctx);
-            }
+        if child.kind == KindT::Camera
+            && let Some(NodeParams::CameraParams(p)) = &child.params
+        {
+            apply_camera(p, ctx);
         }
     }
 
@@ -441,13 +441,13 @@ fn execute_download(node: &Node, ctx: &mut Ctx) {
             continue;
         }
         // `format` is informational here; load_model auto-detects from the file.
-        if let Some(NodeParams::ParseParams(pp)) = &parse.params {
-            if matches!(pp.format, ParseFormatT::Bcif) {
-                ctx.errors.push(MvsError::UnsupportedNode {
-                    kind: KindT::Parse,
-                    reason: "bcif parsing is not supported".to_string(),
-                });
-            }
+        if let Some(NodeParams::ParseParams(pp)) = &parse.params
+            && matches!(pp.format, ParseFormatT::Bcif)
+        {
+            ctx.errors.push(MvsError::UnsupportedNode {
+                kind: KindT::Parse,
+                reason: "bcif parsing is not supported".to_string(),
+            });
         }
         for structure in children(parse) {
             if structure.kind == KindT::Structure {
@@ -467,12 +467,12 @@ fn execute_structure(node: &Node, model: &Model, ac: &AtomCollection, ctx: &mut 
     // structure. Collect it first so it can be handed to every component.
     let mut pending_transform = Transform::IDENTITY;
     for child in children(node) {
-        if child.kind == KindT::Transform {
-            if let Some(NodeParams::TransformParams(tp)) = &child.params {
-                match parse_transform(tp) {
-                    Ok(t) => pending_transform = t,
-                    Err(()) => ctx.errors.push(MvsError::InvalidTransform),
-                }
+        if child.kind == KindT::Transform
+            && let Some(NodeParams::TransformParams(tp)) = &child.params
+        {
+            match parse_transform(tp) {
+                Ok(t) => pending_transform = t,
+                Err(()) => ctx.errors.push(MvsError::InvalidTransform),
             }
         }
     }

--- a/crates/ferritin-bevy/src/plugin.rs
+++ b/crates/ferritin-bevy/src/plugin.rs
@@ -29,6 +29,12 @@ pub struct StructurePlugin {
     initial_files: Vec<(PathBuf, StructureSettings)>,
 }
 
+impl Default for StructurePlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl StructurePlugin {
     pub fn new() -> Self {
         Self {

--- a/crates/ferritin-bevy/src/selection.rs
+++ b/crates/ferritin-bevy/src/selection.rs
@@ -110,58 +110,58 @@ fn evaluate_expression(expr: &ComponentExpression, model: &AtomCollection) -> At
 
     for (res_iter_idx, residue) in model.iter_residues().enumerate() {
         // Chain filter (label_asym_id matched against auth_asym_id in MVP)
-        if let Some(ref chain) = expr.label_asym_id {
-            if residue.chain_id() != chain {
-                continue;
-            }
+        if let Some(ref chain) = expr.label_asym_id
+            && residue.chain_id() != chain
+        {
+            continue;
         }
-        if let Some(ref chain) = expr.auth_asym_id {
-            if residue.chain_id() != chain {
-                continue;
-            }
+        if let Some(ref chain) = expr.auth_asym_id
+            && residue.chain_id() != chain
+        {
+            continue;
         }
 
         // residue_index: 0-based residue iteration index
-        if let Some(ri) = expr.residue_index {
-            if res_iter_idx as i32 != ri {
-                continue;
-            }
+        if let Some(ri) = expr.residue_index
+            && res_iter_idx as i32 != ri
+        {
+            continue;
         }
 
         let res_id = residue.residue_id();
 
         // Exact residue seq id (label_seq_id matched against auth_seq_id in MVP)
-        if let Some(seq) = expr.label_seq_id {
-            if res_id != seq {
-                continue;
-            }
+        if let Some(seq) = expr.label_seq_id
+            && res_id != seq
+        {
+            continue;
         }
-        if let Some(seq) = expr.auth_seq_id {
-            if res_id != seq {
-                continue;
-            }
+        if let Some(seq) = expr.auth_seq_id
+            && res_id != seq
+        {
+            continue;
         }
 
         // Range filters (beg inclusive, end inclusive)
-        if let Some(beg) = expr.beg_label_seq_id {
-            if res_id < beg {
-                continue;
-            }
+        if let Some(beg) = expr.beg_label_seq_id
+            && res_id < beg
+        {
+            continue;
         }
-        if let Some(end) = expr.end_label_seq_id {
-            if res_id > end {
-                continue;
-            }
+        if let Some(end) = expr.end_label_seq_id
+            && res_id > end
+        {
+            continue;
         }
-        if let Some(beg) = expr.beg_auth_seq_id {
-            if res_id < beg {
-                continue;
-            }
+        if let Some(beg) = expr.beg_auth_seq_id
+            && res_id < beg
+        {
+            continue;
         }
-        if let Some(end) = expr.end_auth_seq_id {
-            if res_id > end {
-                continue;
-            }
+        if let Some(end) = expr.end_auth_seq_id
+            && res_id > end
+        {
+            continue;
         }
 
         // residue_index: 0-based index of this residue in iteration order
@@ -170,30 +170,30 @@ fn evaluate_expression(expr: &ComponentExpression, model: &AtomCollection) -> At
         // Residue passed — now check per-atom fields
         for idx in residue.atom_range() {
             // atom_index: 0-based global atom index
-            if let Some(ai) = expr.atom_index {
-                if idx as i32 != ai {
-                    continue;
-                }
+            if let Some(ai) = expr.atom_index
+                && idx as i32 != ai
+            {
+                continue;
             }
 
             // label_atom_id / auth_atom_id
             let atom_name = model.get_atom_name(idx);
-            if let Some(ref la) = expr.label_atom_id {
-                if atom_name != la {
-                    continue;
-                }
+            if let Some(ref la) = expr.label_atom_id
+                && atom_name != la
+            {
+                continue;
             }
-            if let Some(ref aa) = expr.auth_atom_id {
-                if atom_name != aa {
-                    continue;
-                }
+            if let Some(ref aa) = expr.auth_atom_id
+                && atom_name != aa
+            {
+                continue;
             }
 
             // type_symbol (element symbol, uppercase)
-            if let Some(ref sym) = expr.type_symbol {
-                if model.get_element(idx).symbol() != sym.as_str() {
-                    continue;
-                }
+            if let Some(ref sym) = expr.type_symbol
+                && model.get_element(idx).symbol() != sym.as_str()
+            {
+                continue;
             }
 
             mask[idx] = true;
@@ -511,8 +511,15 @@ mod tests {
         };
         let sel = ComponentSelector::Expression(expr);
         let mask = evaluate_selector(&sel, &ac);
-        assert_eq!(mask.count_true(), 3, "residue_index 0 must select ALA (3 atoms)");
-        assert!(mask.0[0] && mask.0[1] && mask.0[2], "atoms 0-2 should be selected");
+        assert_eq!(
+            mask.count_true(),
+            3,
+            "residue_index 0 must select ALA (3 atoms)"
+        );
+        assert!(
+            mask.0[0] && mask.0[1] && mask.0[2],
+            "atoms 0-2 should be selected"
+        );
 
         // residue_index=1 → GLY (2 atoms)
         let expr2 = ComponentExpression {
@@ -520,7 +527,11 @@ mod tests {
             ..Default::default()
         };
         let mask2 = evaluate_selector(&ComponentSelector::Expression(expr2), &ac);
-        assert_eq!(mask2.count_true(), 2, "residue_index 1 must select GLY (2 atoms)");
+        assert_eq!(
+            mask2.count_true(),
+            2,
+            "residue_index 1 must select GLY (2 atoms)"
+        );
 
         // residue_index=3 → ZN (1 atom); residues: 0=ALA, 1=GLY, 2=HOH, 3=ZN, 4=LIG
         let expr3 = ComponentExpression {
@@ -528,7 +539,11 @@ mod tests {
             ..Default::default()
         };
         let mask3 = evaluate_selector(&ComponentSelector::Expression(expr3), &ac);
-        assert_eq!(mask3.count_true(), 1, "residue_index 3 must select ZN (1 atom)");
+        assert_eq!(
+            mask3.count_true(),
+            1,
+            "residue_index 3 must select ZN (1 atom)"
+        );
     }
 
     // T2-26: residue_index combined with atom_name → single atom
@@ -542,7 +557,11 @@ mod tests {
             ..Default::default()
         };
         let mask = evaluate_selector(&ComponentSelector::Expression(expr), &ac);
-        assert_eq!(mask.count_true(), 1, "residue 1 CA should be exactly 1 atom");
+        assert_eq!(
+            mask.count_true(),
+            1,
+            "residue 1 CA should be exactly 1 atom"
+        );
         assert!(mask.0[4], "atom index 4 is GLY CA");
     }
 }

--- a/crates/ferritin-bevy/src/structure.rs
+++ b/crates/ferritin-bevy/src/structure.rs
@@ -170,14 +170,17 @@ impl Structure {
         let rotation = Quat::from_rotation_arc(Vec3::Y, direction.normalize());
         let half_height = height / 4.0;
         let make_half = |center: Vec3| -> Mesh {
-            Cylinder { radius, half_height }
-                .mesh()
-                .build()
-                .transformed_by(Transform {
-                    translation: center,
-                    rotation,
-                    ..default()
-                })
+            Cylinder {
+                radius,
+                half_height,
+            }
+            .mesh()
+            .build()
+            .transformed_by(Transform {
+                translation: center,
+                rotation,
+                ..default()
+            })
         };
         let first = make_half((pos1 + mid) * 0.5);
         let second = make_half((mid + pos2) * 0.5);
@@ -360,7 +363,11 @@ impl Structure {
                 curve[i] - curve[i - 1]
             };
             let t = raw.normalize_or_zero();
-            if t.length_squared() > 1e-8 { t } else { Vec3::Z }
+            if t.length_squared() > 1e-8 {
+                t
+            } else {
+                Vec3::Z
+            }
         };
 
         let mut prev_up: Option<Vec3> = None;
@@ -383,10 +390,10 @@ impl Structure {
                     }
                 };
             }
-            if let Some(p) = prev_up {
-                if up.dot(p) < 0.0 {
-                    up = -up;
-                }
+            if let Some(p) = prev_up
+                && up.dot(p) < 0.0
+            {
+                up = -up;
             }
             let right = up.cross(t_cur).normalize_or_zero();
             // Re-derive up from (tangent, right) so the pair is exactly
@@ -634,22 +641,22 @@ impl Structure {
         for window in ca_by_chain.windows(2) {
             let (chain_a, pos_a) = &window[0];
             let (chain_b, pos_b) = &window[1];
-            if chain_a == chain_b {
-                if let Some((mut first, second)) =
+            if chain_a == chain_b
+                && let Some((mut first, second)) =
                     Structure::half_bond_cylinders(*pos_a, *pos_b, Structure::LINE_RADIUS)
-                {
-                    let _ = first.merge(&second);
-                    match &mut combined {
-                        None => combined = Some(first),
-                        Some(acc) => {
-                            let _ = acc.merge(&first);
-                        }
+            {
+                let _ = first.merge(&second);
+                match &mut combined {
+                    None => combined = Some(first),
+                    Some(acc) => {
+                        let _ = acc.merge(&first);
                     }
                 }
             }
         }
 
-        combined.unwrap_or_else(|| Mesh::new(PrimitiveTopology::TriangleList, RenderAssetUsages::all()))
+        combined
+            .unwrap_or_else(|| Mesh::new(PrimitiveTopology::TriangleList, RenderAssetUsages::all()))
     }
 
     fn render_cartoon(&self) -> Mesh {
@@ -708,14 +715,20 @@ impl Structure {
                     let vc1 = first.count_vertices();
                     first.insert_attribute(
                         Mesh::ATTRIBUTE_COLOR,
-                        vec![Vec4::new(color_a.red, color_a.green, color_a.blue, color_a.alpha); vc1],
+                        vec![
+                            Vec4::new(color_a.red, color_a.green, color_a.blue, color_a.alpha);
+                            vc1
+                        ],
                     );
 
                     let color_b = self.color_scheme.get_color(&elements[idx_b]).to_srgba();
                     let vc2 = second.count_vertices();
                     second.insert_attribute(
                         Mesh::ATTRIBUTE_COLOR,
-                        vec![Vec4::new(color_b.red, color_b.green, color_b.blue, color_b.alpha); vc2],
+                        vec![
+                            Vec4::new(color_b.red, color_b.green, color_b.blue, color_b.alpha);
+                            vc2
+                        ],
                     );
 
                     let _ = first.merge(&second);
@@ -794,10 +807,10 @@ impl Structure {
 
         for atom in self.pdb.atoms() {
             let idx = atom.index();
-            if let Some(m) = mask {
-                if !m.0[idx] {
-                    continue;
-                }
+            if let Some(m) = mask
+                && !m.0[idx]
+            {
+                continue;
             }
 
             let coord = atom.coords();
@@ -816,7 +829,7 @@ impl Structure {
             );
             sphere_mesh = sphere_mesh.translated_by(center);
             sphere_mesh.compute_smooth_normals();
-            atom_map.extend(std::iter::repeat(idx).take(vc));
+            atom_map.extend(std::iter::repeat_n(idx, vc));
             match &mut combined {
                 None => combined = Some(sphere_mesh),
                 Some(acc) => {
@@ -858,21 +871,22 @@ impl Structure {
         for window in ca_data.windows(2) {
             let (chain_a, idx_a, pos_a) = &window[0];
             let (chain_b, idx_b, pos_b) = &window[1];
-            let a_ok = mask.map_or(true, |m| m.0[*idx_a]);
-            let b_ok = mask.map_or(true, |m| m.0[*idx_b]);
-            if chain_a == chain_b && a_ok && b_ok {
-                if let Some((first, second)) =
+            let a_ok = mask.is_none_or(|m| m.0[*idx_a]);
+            let b_ok = mask.is_none_or(|m| m.0[*idx_b]);
+            if chain_a == chain_b
+                && a_ok
+                && b_ok
+                && let Some((first, second)) =
                     Structure::half_bond_cylinders(*pos_a, *pos_b, Structure::LINE_RADIUS)
-                {
-                    atom_map.extend(std::iter::repeat(*idx_a).take(first.count_vertices()));
-                    atom_map.extend(std::iter::repeat(*idx_b).take(second.count_vertices()));
-                    let mut seg = first;
-                    let _ = seg.merge(&second);
-                    match &mut combined {
-                        None => combined = Some(seg),
-                        Some(acc) => {
-                            let _ = acc.merge(&seg);
-                        }
+            {
+                atom_map.extend(std::iter::repeat_n(*idx_a, first.count_vertices()));
+                atom_map.extend(std::iter::repeat_n(*idx_b, second.count_vertices()));
+                let mut seg = first;
+                let _ = seg.merge(&second);
+                match &mut combined {
+                    None => combined = Some(seg),
+                    Some(acc) => {
+                        let _ = acc.merge(&seg);
                     }
                 }
             }
@@ -891,10 +905,10 @@ impl Structure {
         // Atom spheres (filtered by mask).
         for atom in self.pdb.atoms() {
             let idx = atom.index();
-            if let Some(m) = mask {
-                if !m.0[idx] {
-                    continue;
-                }
+            if let Some(m) = mask
+                && !m.0[idx]
+            {
+                continue;
             }
 
             let coord = atom.coords();
@@ -914,7 +928,7 @@ impl Structure {
             );
             sphere_mesh = sphere_mesh.translated_by(center);
             sphere_mesh.compute_smooth_normals();
-            atom_map.extend(std::iter::repeat(idx).take(vc));
+            atom_map.extend(std::iter::repeat_n(idx, vc));
             match &mut combined {
                 None => combined = Some(sphere_mesh),
                 Some(acc) => {
@@ -933,10 +947,10 @@ impl Structure {
             for i in 0..bonds.atom_a.len() {
                 let idx_a = bonds.atom_a[i] as usize;
                 let idx_b = bonds.atom_b[i] as usize;
-                if let Some(m) = mask {
-                    if !m.0[idx_a] || !m.0[idx_b] {
-                        continue;
-                    }
+                if let Some(m) = mask
+                    && (!m.0[idx_a] || !m.0[idx_b])
+                {
+                    continue;
                 }
                 let pos1 = Vec3::from_array(self.pdb.coord(idx_a));
                 let pos2 = Vec3::from_array(self.pdb.coord(idx_b));
@@ -951,14 +965,14 @@ impl Structure {
                     Mesh::ATTRIBUTE_COLOR,
                     vec![Vec4::new(0.5, 0.5, 0.5, 0.5); vc1],
                 );
-                atom_map.extend(std::iter::repeat(idx_a).take(vc1));
+                atom_map.extend(std::iter::repeat_n(idx_a, vc1));
 
                 let vc2 = second.count_vertices();
                 second.insert_attribute(
                     Mesh::ATTRIBUTE_COLOR,
                     vec![Vec4::new(0.5, 0.5, 0.5, 0.5); vc2],
                 );
-                atom_map.extend(std::iter::repeat(idx_b).take(vc2));
+                atom_map.extend(std::iter::repeat_n(idx_b, vc2));
 
                 let _ = first.merge(&second);
                 match &mut combined {
@@ -987,10 +1001,10 @@ impl Structure {
             .enumerate()
             .filter_map(|(res_iter_idx, residue)| {
                 let ca = residue.find_atom_by_name("CA")?;
-                if let Some(m) = mask {
-                    if !m.0[ca.index()] {
-                        return None;
-                    }
+                if let Some(m) = mask
+                    && !m.0[ca.index()]
+                {
+                    return None;
                 }
                 let n = residue.find_atom_by_name("N")?;
                 let c = residue.find_atom_by_name("C")?;
@@ -1025,10 +1039,10 @@ impl Structure {
         let mut current: Vec<(usize, BackboneAtoms)> = Vec::new();
         let mut last_chain: Option<String> = None;
         for (idx, chain, bb) in indexed_backbone {
-            if let (Some(last), Some(prev_chain)) = (current.last(), last_chain.as_deref()) {
-                if Structure::is_backbone_break(last.0, prev_chain, last.1.ca, idx, &chain, bb.ca) {
-                    segments.push(std::mem::take(&mut current));
-                }
+            if let (Some(last), Some(prev_chain)) = (current.last(), last_chain.as_deref())
+                && Structure::is_backbone_break(last.0, prev_chain, last.1.ca, idx, &chain, bb.ca)
+            {
+                segments.push(std::mem::take(&mut current));
             }
             last_chain = Some(chain);
             current.push((idx, bb));
@@ -1103,10 +1117,10 @@ impl Structure {
             .enumerate()
             .filter_map(|(res_iter_idx, residue)| {
                 let ca = residue.find_atom_by_name("CA")?;
-                if let Some(m) = mask {
-                    if !m.0[ca.index()] {
-                        return None;
-                    }
+                if let Some(m) = mask
+                    && !m.0[ca.index()]
+                {
+                    return None;
                 }
                 Some((
                     res_iter_idx,
@@ -1129,10 +1143,10 @@ impl Structure {
         let mut current: Vec<(usize, Vec3)> = Vec::new();
         let mut last_chain: Option<String> = None;
         for (idx, chain, ca) in ca_data {
-            if let (Some(last), Some(prev_chain)) = (current.last(), last_chain.as_deref()) {
-                if Structure::is_backbone_break(last.0, prev_chain, last.1, idx, &chain, ca) {
-                    segments.push(std::mem::take(&mut current));
-                }
+            if let (Some(last), Some(prev_chain)) = (current.last(), last_chain.as_deref())
+                && Structure::is_backbone_break(last.0, prev_chain, last.1, idx, &chain, ca)
+            {
+                segments.push(std::mem::take(&mut current));
             }
             last_chain = Some(chain);
             current.push((idx, ca));
@@ -1184,6 +1198,7 @@ mod tests {
     // ferritin-c1k.1: BallAndStick balls must read as thicker than the sticks
     // joining them, not as one uniform-radius licorice tube.
     #[test]
+    #[allow(clippy::assertions_on_constants)] // guards an invariant between two consts
     fn test_ballandstick_stick_thinner_than_ball() {
         assert!(
             Structure::STICK_RADIUS < Structure::BALL_RADIUS,
@@ -1206,6 +1221,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::assertions_on_constants)] // guards an invariant on a const
     fn test_water_radius_scale_shrinks_but_does_not_vanish() {
         assert!(
             Structure::WATER_RADIUS_SCALE > 0.0 && Structure::WATER_RADIUS_SCALE < 1.0,
@@ -1376,7 +1392,10 @@ mod tests {
         let (mesh, atom_map) = structure.to_mesh_with_atom_map(None);
         assert_eq!(mesh.count_vertices(), atom_map.len());
 
-        let sphere_vc = Sphere::new(Structure::BALL_RADIUS).mesh().build().count_vertices();
+        let sphere_vc = Sphere::new(Structure::BALL_RADIUS)
+            .mesh()
+            .build()
+            .count_vertices();
         let count_in_map = atom_map.iter().filter(|&&i| i == target_idx).count();
         assert!(
             count_in_map > sphere_vc,

--- a/crates/ferritin-cellscape/examples/simple.rs
+++ b/crates/ferritin-cellscape/examples/simple.rs
@@ -1,12 +1,12 @@
 use geo::{BooleanOps, Coord, LineString, MultiPolygon, Point, Polygon};
 use std::error::Error;
 use std::f64::consts::PI;
-use svg::node::element::{Circle, Path};
 use svg::Document;
+use svg::node::element::{Circle, Path};
 
 fn main() -> Result<(), Box<dyn Error>> {
     // 1. Generate some test points (x, y, radius)
-    let points = vec![
+    let points = [
         (100.0, 100.0, 30.0),
         (150.0, 120.0, 25.0),
         (120.0, 150.0, 20.0),
@@ -101,6 +101,7 @@ fn create_svg_path(polygon: &Polygon<f64>, fill: &str, stroke: &str, stroke_widt
 }
 
 /// Creates SVG circles for the original points
+#[allow(dead_code)] // kept as a reference helper for the example
 fn create_point_circles(points: &[(f64, f64, f64)]) -> svg::node::element::Group {
     let mut group = svg::node::element::Group::new().set("class", "points");
 

--- a/crates/ferritin-cellscape/src/cellscape.rs
+++ b/crates/ferritin-cellscape/src/cellscape.rs
@@ -96,7 +96,11 @@ impl StructureFlatten for Model {
                             .atomic_radius()
                             .van_der_waals
                             .unwrap_or(DEFAULT_VDW_RADIUS);
-                        ProjectedAtom { chain_id: chain_id.clone(), center, radius }
+                        ProjectedAtom {
+                            chain_id: chain_id.clone(),
+                            center,
+                            radius,
+                        }
                     })
                     .collect()
             })
@@ -106,7 +110,10 @@ impl StructureFlatten for Model {
         let base = Document::new()
             .set("width", options.canvas_size)
             .set("height", options.canvas_size)
-            .set("viewBox", (0.0, 0.0, options.canvas_size, options.canvas_size));
+            .set(
+                "viewBox",
+                (0.0, 0.0, options.canvas_size, options.canvas_size),
+            );
 
         let Some((min_x, min_y, max_x, max_y)) = bounding_box(residues.iter().flatten()) else {
             return base;
@@ -132,17 +139,22 @@ impl StructureFlatten for Model {
                 })
                 .collect();
 
-            let merged = circles.iter().skip(1).fold(
-                MultiPolygon(vec![circles[0].clone()]),
-                |acc, circle| acc.union(circle),
-            );
+            let merged = circles
+                .iter()
+                .skip(1)
+                .fold(MultiPolygon(vec![circles[0].clone()]), |acc, circle| {
+                    acc.union(circle)
+                });
 
             let fill = if options.color_by_chain {
                 let chain = &atoms[0].chain_id;
-                let idx = chain_order.iter().position(|c| c == chain).unwrap_or_else(|| {
-                    chain_order.push(chain.clone());
-                    chain_order.len() - 1
-                });
+                let idx = chain_order
+                    .iter()
+                    .position(|c| c == chain)
+                    .unwrap_or_else(|| {
+                        chain_order.push(chain.clone());
+                        chain_order.len() - 1
+                    });
                 CHAIN_PALETTE[idx % CHAIN_PALETTE.len()]
             } else {
                 "blue"
@@ -157,7 +169,9 @@ impl StructureFlatten for Model {
 
 /// Axis-aligned bounding box `(min_x, min_y, max_x, max_y)` over atom circles
 /// (center ± radius), or `None` if there are no atoms.
-fn bounding_box<'a>(atoms: impl Iterator<Item = &'a ProjectedAtom>) -> Option<(f64, f64, f64, f64)> {
+fn bounding_box<'a>(
+    atoms: impl Iterator<Item = &'a ProjectedAtom>,
+) -> Option<(f64, f64, f64, f64)> {
     atoms.fold(None, |acc, atom| {
         let (cx, cy) = atom.center;
         let r = atom.radius;
@@ -250,7 +264,10 @@ mod tests {
     #[test]
     fn test_flatten_structure_respects_canvas_size() {
         let model = load_test_model();
-        let options = FlattenOptions { canvas_size: 500.0, ..Default::default() };
+        let options = FlattenOptions {
+            canvas_size: 500.0,
+            ..Default::default()
+        };
         let doc = model.flatten_structure_with(&options);
         let svg = doc.to_string();
         assert!(svg.contains(r#"width="500""#));
@@ -259,9 +276,17 @@ mod tests {
 
     #[test]
     fn test_bounding_box_matches_atom_extent() {
-        let atoms = vec![
-            ProjectedAtom { chain_id: "A".into(), center: (0.0, 0.0), radius: 1.0 },
-            ProjectedAtom { chain_id: "A".into(), center: (10.0, 5.0), radius: 2.0 },
+        let atoms = [
+            ProjectedAtom {
+                chain_id: "A".into(),
+                center: (0.0, 0.0),
+                radius: 1.0,
+            },
+            ProjectedAtom {
+                chain_id: "A".into(),
+                center: (10.0, 5.0),
+                radius: 2.0,
+            },
         ];
         let (min_x, min_y, max_x, max_y) = bounding_box(atoms.iter()).unwrap();
         assert_eq!((min_x, min_y), (-1.0, -1.0));
@@ -286,18 +311,30 @@ mod tests {
     fn test_flatten_structure_with_different_projections_differs() {
         let model = load_test_model();
         let xy = model
-            .flatten_structure_with(&FlattenOptions { projection: ProjectionAxis::Xy, ..Default::default() })
+            .flatten_structure_with(&FlattenOptions {
+                projection: ProjectionAxis::Xy,
+                ..Default::default()
+            })
             .to_string();
         let xz = model
-            .flatten_structure_with(&FlattenOptions { projection: ProjectionAxis::Xz, ..Default::default() })
+            .flatten_structure_with(&FlattenOptions {
+                projection: ProjectionAxis::Xz,
+                ..Default::default()
+            })
             .to_string();
-        assert_ne!(xy, xz, "different projection axes should generally produce different outlines");
+        assert_ne!(
+            xy, xz,
+            "different projection axes should generally produce different outlines"
+        );
     }
 
     #[test]
     fn test_flatten_structure_uniform_fill_when_not_colored_by_chain() {
         let model = load_test_model();
-        let options = FlattenOptions { color_by_chain: false, ..Default::default() };
+        let options = FlattenOptions {
+            color_by_chain: false,
+            ..Default::default()
+        };
         let doc = model.flatten_structure_with(&options);
         let svg = doc.to_string();
         assert!(svg.contains(r#"fill="blue""#));

--- a/crates/ferritin-core/src/atomcollection.rs
+++ b/crates/ferritin-core/src/atomcollection.rs
@@ -4,17 +4,17 @@
 //! and residue information. Additional data like bonds can be added post-instantiation.
 //! The data for residues within this collection can be iterated through. Other useful queries like inter-atomic
 //! distances are supported.
-use std::sync::Arc;
 use super::bonds::{Bond, BondOrder};
 use super::info::constants::get_bonds_canonical20;
 use super::views::chain::ChainView;
 use super::views::residue::ResidueView;
 use crate::data::Segmentation;
 use crate::info::elements::Element;
-use crate::model::{AtomicConformation, AtomicHierarchy, Bonds, Model};
 use crate::model::tables::{AtomsTable, ChainsTable, ResidueGroup, ResiduesTable};
+use crate::model::{AtomicConformation, AtomicHierarchy, Bonds, Model};
 use compact_str::CompactString;
 use itertools::{Itertools, izip};
+use std::sync::Arc;
 
 /// Atom Collection
 ///
@@ -45,6 +45,7 @@ pub struct AtomCollection {
 }
 
 impl AtomCollection {
+    #[allow(clippy::too_many_arguments)] // parallel per-atom columns; grouping them is ferritin-100.8's job
     pub fn new(
         size: usize,
         coords: Vec<[f32; 3]>,
@@ -72,6 +73,7 @@ impl AtomCollection {
     ///
     /// Used by paths that already hold `CompactString` names (e.g. `filter`)
     /// to avoid a needless round-trip through `String`.
+    #[allow(clippy::too_many_arguments)] // mirrors `new`; parallel per-atom columns
     fn from_compact(
         size: usize,
         coords: Vec<[f32; 3]>,
@@ -109,7 +111,11 @@ impl AtomCollection {
     /// # Panics
     /// Panics if `values.len() != self.get_size()`.
     pub fn with_b_factor(mut self, values: Vec<f32>) -> Self {
-        assert_eq!(values.len(), self.size, "b_factor length must equal atom count");
+        assert_eq!(
+            values.len(),
+            self.size,
+            "b_factor length must equal atom count"
+        );
         self.b_factor = Some(values);
         self
     }
@@ -119,7 +125,11 @@ impl AtomCollection {
     /// # Panics
     /// Panics if `values.len() != self.get_size()`.
     pub fn with_occupancy(mut self, values: Vec<f32>) -> Self {
-        assert_eq!(values.len(), self.size, "occupancy length must equal atom count");
+        assert_eq!(
+            values.len(),
+            self.size,
+            "occupancy length must equal atom count"
+        );
         self.occupancy = Some(values);
         self
     }
@@ -154,14 +164,13 @@ impl AtomCollection {
                 .iter()
                 .map(|&atom_idx| {
                     // Find the residue index that contains this atom
-                    let residue_idx = residue_starts
+
+                    residue_starts
                         .iter()
                         .enumerate()
-                        .filter(|&(_, &res_start)| res_start <= atom_idx)
-                        .last()
+                        .rfind(|&(_, &res_start)| res_start <= atom_idx)
                         .map(|(i, _)| i)
-                        .unwrap_or(0);
-                    residue_idx
+                        .unwrap_or(0)
                 })
                 .collect();
 
@@ -210,10 +219,7 @@ impl AtomCollection {
             if self.is_hetero[curr_start_i] || self.is_hetero[next_start_i] {
                 continue;
             }
-            let next_end_i = residue_starts
-                .get(res_i + 2)
-                .copied()
-                .unwrap_or(n_atoms);
+            let next_end_i = residue_starts.get(res_i + 2).copied().unwrap_or(n_atoms);
             let c_idx = (curr_start_i..next_start_i).find(|&i| self.atom_names[i] == "C");
             let n_idx = (next_start_i..next_end_i).find(|&i| self.atom_names[i] == "N");
             if let (Some(c), Some(n)) = (c_idx, n_idx) {
@@ -327,15 +333,28 @@ impl AtomCollection {
             })
             .collect();
 
-        let selected: Vec<usize> = remap.iter().enumerate().filter_map(|(i, r)| r.map(|_| i)).collect();
+        let selected: Vec<usize> = remap
+            .iter()
+            .enumerate()
+            .filter_map(|(i, r)| r.map(|_| i))
+            .collect();
 
         let coords: Vec<[f32; 3]> = selected.iter().map(|&i| self.coords[i]).collect();
         let res_ids: Vec<i32> = selected.iter().map(|&i| self.res_ids[i]).collect();
-        let res_names: Vec<CompactString> = selected.iter().map(|&i| self.res_names[i].clone()).collect();
+        let res_names: Vec<CompactString> = selected
+            .iter()
+            .map(|&i| self.res_names[i].clone())
+            .collect();
         let is_hetero: Vec<bool> = selected.iter().map(|&i| self.is_hetero[i]).collect();
-        let elements: Vec<Element> = selected.iter().map(|&i| self.elements[i].clone()).collect();
-        let atom_names: Vec<CompactString> = selected.iter().map(|&i| self.atom_names[i].clone()).collect();
-        let chain_ids: Vec<CompactString> = selected.iter().map(|&i| self.chain_ids[i].clone()).collect();
+        let elements: Vec<Element> = selected.iter().map(|&i| self.elements[i]).collect();
+        let atom_names: Vec<CompactString> = selected
+            .iter()
+            .map(|&i| self.atom_names[i].clone())
+            .collect();
+        let chain_ids: Vec<CompactString> = selected
+            .iter()
+            .map(|&i| self.chain_ids[i].clone())
+            .collect();
 
         let bonds: Option<Vec<Bond>> = self.bonds.as_ref().map(|bonds| {
             bonds
@@ -352,7 +371,9 @@ impl AtomCollection {
                 .collect()
         });
 
-        let mut filtered = AtomCollection::from_compact(next, coords, res_ids, res_names, is_hetero, elements, atom_names, chain_ids, bonds);
+        let mut filtered = AtomCollection::from_compact(
+            next, coords, res_ids, res_names, is_hetero, elements, atom_names, chain_ids, bonds,
+        );
         if let Some(values) = &self.b_factor {
             filtered.b_factor = Some(selected.iter().map(|&i| values[i]).collect());
         }
@@ -375,7 +396,10 @@ impl AtomCollection {
     /// Build a boolean mask selecting solvent atoms (HOH, WAT, H2O).
     pub fn select_water(&self) -> Vec<bool> {
         const WATER: [&str; 3] = ["HOH", "WAT", "H2O"];
-        self.res_names.iter().map(|n| WATER.contains(&n.as_str())).collect()
+        self.res_names
+            .iter()
+            .map(|n| WATER.contains(&n.as_str()))
+            .collect()
     }
 
     /// Build a boolean mask selecting single-atom hetero residues that are not water (ions).
@@ -383,6 +407,7 @@ impl AtomCollection {
         let mut mask = vec![false; self.size];
         for residue in self.iter_residues() {
             if residue.is_ion() {
+                #[allow(clippy::needless_range_loop)] // index range spans one residue's atoms
                 for idx in residue.start_atom_idx..residue.end_atom_idx {
                     mask[idx] = true;
                 }
@@ -394,7 +419,10 @@ impl AtomCollection {
     /// Build a boolean mask selecting backbone atoms (N, CA, C, O).
     pub fn select_backbone(&self) -> Vec<bool> {
         const BACKBONE: [&str; 4] = ["N", "CA", "C", "O"];
-        self.atom_names.iter().map(|n| BACKBONE.contains(&n.as_str())).collect()
+        self.atom_names
+            .iter()
+            .map(|n| BACKBONE.contains(&n.as_str()))
+            .collect()
     }
 
     /// Build a boolean mask selecting atoms with `atom_name`.
@@ -445,11 +473,7 @@ impl AtomCollection {
         let last_atom_idx = residue_starts.last().copied();
         (0..residue_starts.len().saturating_sub(1))
             .map(move |i| ResidueView::new(self, residue_starts[i], residue_starts[i + 1]))
-            .chain(
-                last_atom_idx
-                    .map(|idx| ResidueView::new(self, idx, atom_size))
-                    .into_iter(),
-            )
+            .chain(last_atom_idx.map(|idx| ResidueView::new(self, idx, atom_size)))
     }
     /// Iterates over amino acid residues in the collection
     ///
@@ -604,21 +628,17 @@ impl From<&Model> for AtomCollection {
         let atom_names = hierarchy.atoms.atom_name.clone();
 
         let mut ac = AtomCollection::new(
-            n_atoms,
-            coords,
-            res_ids,
-            res_names,
-            is_hetero,
-            elements,
-            atom_names,
-            chain_ids,
-            None,
+            n_atoms, coords, res_ids, res_names, is_hetero, elements, atom_names, chain_ids, None,
         );
 
         // Predicted structures (AlphaFold/ESM3) carry per-atom confidence rather than a
         // crystallographic B-factor; viz themes read both from the same slot, so prefer
         // confidence when both are present.
-        if let Some(values) = conformation.confidence.clone().or_else(|| conformation.b_iso.clone()) {
+        if let Some(values) = conformation
+            .confidence
+            .clone()
+            .or_else(|| conformation.b_iso.clone())
+        {
             ac = ac.with_b_factor(values);
         }
         if let Some(values) = conformation.occupancy.clone() {
@@ -643,30 +663,19 @@ mod tests {
         ];
         let res_ids = vec![1, 1, 1, 2, 2];
         let res_names = vec![
-            "ALA".into(), "ALA".into(), "ALA".into(),
-            "GLY".into(), "GLY".into(),
+            "ALA".into(),
+            "ALA".into(),
+            "ALA".into(),
+            "GLY".into(),
+            "GLY".into(),
         ];
         let is_hetero = vec![false, false, false, false, false];
         let elements = vec![Element::N, Element::C, Element::C, Element::N, Element::C];
-        let atom_names = vec![
-            "N".into(), "CA".into(), "C".into(),
-            "N".into(), "CA".into(),
-        ];
-        let chain_ids = vec![
-            "A".into(), "A".into(), "A".into(),
-            "A".into(), "A".into(),
-        ];
+        let atom_names = vec!["N".into(), "CA".into(), "C".into(), "N".into(), "CA".into()];
+        let chain_ids = vec!["A".into(), "A".into(), "A".into(), "A".into(), "A".into()];
 
         AtomCollection::new(
-            5,
-            coords,
-            res_ids,
-            res_names,
-            is_hetero,
-            elements,
-            atom_names,
-            chain_ids,
-            None,
+            5, coords, res_ids, res_names, is_hetero, elements, atom_names, chain_ids, None,
         )
     }
 
@@ -677,12 +686,24 @@ mod tests {
             .with_occupancy(vec![1.0, 1.0, 0.5, 1.0, 0.3]);
 
         let model = original.to_model();
-        assert_eq!(model.conformation.b_iso.as_deref(), Some(&[10.0, 20.0, 30.0, 40.0, 50.0][..]));
-        assert_eq!(model.conformation.occupancy.as_deref(), Some(&[1.0, 1.0, 0.5, 1.0, 0.3][..]));
+        assert_eq!(
+            model.conformation.b_iso.as_deref(),
+            Some(&[10.0, 20.0, 30.0, 40.0, 50.0][..])
+        );
+        assert_eq!(
+            model.conformation.occupancy.as_deref(),
+            Some(&[1.0, 1.0, 0.5, 1.0, 0.3][..])
+        );
 
         let restored = AtomCollection::from(&model);
-        assert_eq!(restored.get_b_factors(), Some(&[10.0, 20.0, 30.0, 40.0, 50.0][..]));
-        assert_eq!(restored.get_occupancies(), Some(&[1.0, 1.0, 0.5, 1.0, 0.3][..]));
+        assert_eq!(
+            restored.get_b_factors(),
+            Some(&[10.0, 20.0, 30.0, 40.0, 50.0][..])
+        );
+        assert_eq!(
+            restored.get_occupancies(),
+            Some(&[1.0, 1.0, 0.5, 1.0, 0.3][..])
+        );
     }
 
     #[test]
@@ -692,7 +713,10 @@ mod tests {
         model.conformation.confidence = Some(vec![90.0, 91.0, 92.0, 93.0, 94.0]);
 
         let ac = AtomCollection::from(&model);
-        assert_eq!(ac.get_b_factors(), Some(&[90.0, 91.0, 92.0, 93.0, 94.0][..]));
+        assert_eq!(
+            ac.get_b_factors(),
+            Some(&[90.0, 91.0, 92.0, 93.0, 94.0][..])
+        );
     }
 
     #[test]
@@ -716,12 +740,42 @@ mod tests {
         assert_eq!(original.get_size(), restored.get_size());
 
         for i in 0..original.get_size() {
-            assert_eq!(original.get_coord(i), restored.get_coord(i), "coord mismatch at {}", i);
-            assert_eq!(original.get_res_id(i), restored.get_res_id(i), "res_id mismatch at {}", i);
-            assert_eq!(original.get_res_name(i), restored.get_res_name(i), "res_name mismatch at {}", i);
-            assert_eq!(original.get_atom_name(i), restored.get_atom_name(i), "atom_name mismatch at {}", i);
-            assert_eq!(original.get_chain_id(i), restored.get_chain_id(i), "chain_id mismatch at {}", i);
-            assert_eq!(original.get_is_hetero(i), restored.get_is_hetero(i), "is_hetero mismatch at {}", i);
+            assert_eq!(
+                original.get_coord(i),
+                restored.get_coord(i),
+                "coord mismatch at {}",
+                i
+            );
+            assert_eq!(
+                original.get_res_id(i),
+                restored.get_res_id(i),
+                "res_id mismatch at {}",
+                i
+            );
+            assert_eq!(
+                original.get_res_name(i),
+                restored.get_res_name(i),
+                "res_name mismatch at {}",
+                i
+            );
+            assert_eq!(
+                original.get_atom_name(i),
+                restored.get_atom_name(i),
+                "atom_name mismatch at {}",
+                i
+            );
+            assert_eq!(
+                original.get_chain_id(i),
+                restored.get_chain_id(i),
+                "chain_id mismatch at {}",
+                i
+            );
+            assert_eq!(
+                original.get_is_hetero(i),
+                restored.get_is_hetero(i),
+                "is_hetero mismatch at {}",
+                i
+            );
         }
     }
 
@@ -732,6 +786,7 @@ mod tests {
 
         let model_coords = model.coords_as_slice();
         assert_eq!(model_coords.len(), ac.get_size());
+        #[allow(clippy::needless_range_loop)] // paired with get_coord(i), a method not an index
         for i in 0..ac.get_size() {
             assert_eq!(model_coords[i], *ac.get_coord(i), "coord mismatch at {}", i);
         }
@@ -758,11 +813,7 @@ mod tests {
 
     #[test]
     fn test_multi_chain_roundtrip() {
-        let coords = vec![
-            [1.0, 1.0, 1.0],
-            [2.0, 2.0, 2.0],
-            [3.0, 3.0, 3.0],
-        ];
+        let coords = vec![[1.0, 1.0, 1.0], [2.0, 2.0, 2.0], [3.0, 3.0, 3.0]];
         let res_ids = vec![1, 1, 10];
         let res_names = vec!["ALA".into(), "ALA".into(), "GLY".into()];
         let is_hetero = vec![false, false, true];
@@ -789,19 +840,44 @@ mod tests {
         // Chain A: 3 atoms (N, CA, C), res 1 ALA
         // Chain B: 2 atoms (N, CA), res 2 GLY
         // Atom order: 0=A/N, 1=A/CA, 2=A/C, 3=B/N, 4=B/CA
-        let coords = vec![[1.,0.,0.],[2.,0.,0.],[3.,0.,0.],[4.,0.,0.],[5.,0.,0.]];
+        let coords = vec![
+            [1., 0., 0.],
+            [2., 0., 0.],
+            [3., 0., 0.],
+            [4., 0., 0.],
+            [5., 0., 0.],
+        ];
         let res_ids = vec![1, 1, 1, 2, 2];
-        let res_names: Vec<String> = ["ALA","ALA","ALA","GLY","GLY"].iter().map(|s| s.to_string()).collect();
+        let res_names: Vec<String> = ["ALA", "ALA", "ALA", "GLY", "GLY"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
         let is_hetero = vec![false, false, false, false, false];
         let elements = vec![Element::N, Element::C, Element::C, Element::N, Element::C];
-        let atom_names: Vec<String> = ["N","CA","C","N","CA"].iter().map(|s| s.to_string()).collect();
-        let chain_ids: Vec<String> = ["A","A","A","B","B"].iter().map(|s| s.to_string()).collect();
+        let atom_names: Vec<String> = ["N", "CA", "C", "N", "CA"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let chain_ids: Vec<String> = ["A", "A", "A", "B", "B"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
         let bonds = vec![
             Bond::new(0, 1, BondOrder::Single),
             Bond::new(1, 2, BondOrder::Single),
             Bond::new(3, 4, BondOrder::Single),
         ];
-        AtomCollection::new(5, coords, res_ids, res_names, is_hetero, elements, atom_names, chain_ids, Some(bonds))
+        AtomCollection::new(
+            5,
+            coords,
+            res_ids,
+            res_names,
+            is_hetero,
+            elements,
+            atom_names,
+            chain_ids,
+            Some(bonds),
+        )
     }
 
     #[test]
@@ -888,13 +964,19 @@ mod tests {
         ];
         let res_ids = vec![1, 1, 2, 3, 4];
         let res_names: Vec<String> = vec!["ALA", "ALA", "HOH", "ZN", "WAT"]
-            .into_iter().map(|s| s.to_string()).collect();
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
         let is_hetero = vec![false, false, true, true, true];
         let elements = vec![Element::N, Element::C, Element::O, Element::Zn, Element::O];
         let atom_names: Vec<String> = vec!["N", "CA", "O", "ZN", "O"]
-            .into_iter().map(|s| s.to_string()).collect();
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
         let chain_ids: Vec<String> = vec!["A"; 5].into_iter().map(|s| s.to_string()).collect();
-        AtomCollection::new(5, coords, res_ids, res_names, is_hetero, elements, atom_names, chain_ids, None)
+        AtomCollection::new(
+            5, coords, res_ids, res_names, is_hetero, elements, atom_names, chain_ids, None,
+        )
     }
 
     #[test]
@@ -955,14 +1037,25 @@ mod tests {
         // ALA is multi-atom hetero (2 atoms) — not an ion even if flagged hetero
         let coords = vec![[0.0; 3], [1.0; 3]];
         let res_ids = vec![1, 1];
-        let res_names: Vec<String> = vec!["LIG", "LIG"].into_iter().map(|s| s.to_string()).collect();
+        let res_names: Vec<String> = vec!["LIG", "LIG"]
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
         let is_hetero = vec![true, true];
         let elements = vec![Element::C, Element::O];
-        let atom_names: Vec<String> = vec!["C1", "O1"].into_iter().map(|s| s.to_string()).collect();
+        let atom_names: Vec<String> = vec!["C1", "O1"]
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
         let chain_ids: Vec<String> = vec!["A", "A"].into_iter().map(|s| s.to_string()).collect();
-        let ac = AtomCollection::new(2, coords, res_ids, res_names, is_hetero, elements, atom_names, chain_ids, None);
+        let ac = AtomCollection::new(
+            2, coords, res_ids, res_names, is_hetero, elements, atom_names, chain_ids, None,
+        );
         let lig = ac.iter_residues().next().unwrap();
-        assert!(!lig.is_ion(), "multi-atom hetero residue should not be an ion");
+        assert!(
+            !lig.is_ion(),
+            "multi-atom hetero residue should not be an ion"
+        );
     }
 
     #[test]
@@ -988,12 +1081,17 @@ mod tests {
         // in full (a fixed [u8; 4] representation would have truncated them).
         let coords = vec![[0.0; 3], [1.0; 3]];
         let res_ids = vec![1, 1];
-        let res_names: Vec<String> = vec!["AABCD", "AABCD"].into_iter().map(String::from).collect();
+        let res_names: Vec<String> = vec!["AABCD", "AABCD"]
+            .into_iter()
+            .map(String::from)
+            .collect();
         let is_hetero = vec![false, false];
         let elements = vec![Element::C, Element::O];
         let atom_names: Vec<String> = vec!["C1", "OXT"].into_iter().map(String::from).collect();
         let chain_ids: Vec<String> = vec!["AA", "AA"].into_iter().map(String::from).collect();
-        let ac = AtomCollection::new(2, coords, res_ids, res_names, is_hetero, elements, atom_names, chain_ids, None);
+        let ac = AtomCollection::new(
+            2, coords, res_ids, res_names, is_hetero, elements, atom_names, chain_ids, None,
+        );
 
         assert_eq!(ac.get_res_name(0), "AABCD");
         assert_eq!(ac.get_chain_id(0), "AA");

--- a/crates/ferritin-core/src/info/amino_acids.rs
+++ b/crates/ferritin-core/src/info/amino_acids.rs
@@ -7,8 +7,8 @@ use strum::EnumIter;
 
 /// One-letter code alphabet for the 20 standard amino acids plus UNK.
 pub const ALPHABET: [char; 21] = [
-    'A', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'K', 'L',
-    'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'V', 'W', 'Y', 'X',
+    'A', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'V', 'W',
+    'Y', 'X',
 ];
 
 /// The 20 standard amino acids plus Unknown, with integer discriminants
@@ -16,10 +16,26 @@ pub const ALPHABET: [char; 21] = [
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter)]
 pub enum AminoAcid {
-    Ala = 0,  Cys = 1,  Asp = 2,  Glu = 3,  Phe = 4,
-    Gly = 5,  His = 6,  Ile = 7,  Lys = 8,  Leu = 9,
-    Met = 10, Asn = 11, Pro = 12, Gln = 13, Arg = 14,
-    Ser = 15, Thr = 16, Val = 17, Trp = 18, Tyr = 19,
+    Ala = 0,
+    Cys = 1,
+    Asp = 2,
+    Glu = 3,
+    Phe = 4,
+    Gly = 5,
+    His = 6,
+    Ile = 7,
+    Lys = 8,
+    Leu = 9,
+    Met = 10,
+    Asn = 11,
+    Pro = 12,
+    Gln = 13,
+    Arg = 14,
+    Ser = 15,
+    Thr = 16,
+    Val = 17,
+    Trp = 18,
+    Tyr = 19,
     Unknown = 20,
 }
 
@@ -55,13 +71,27 @@ impl AminoAcid {
     /// Parse from integer index (0–20). Out-of-range → `Unknown`.
     pub fn from_index(idx: u32) -> Self {
         match idx {
-            0  => Self::Ala, 1  => Self::Cys, 2  => Self::Asp,
-            3  => Self::Glu, 4  => Self::Phe, 5  => Self::Gly,
-            6  => Self::His, 7  => Self::Ile, 8  => Self::Lys,
-            9  => Self::Leu, 10 => Self::Met, 11 => Self::Asn,
-            12 => Self::Pro, 13 => Self::Gln, 14 => Self::Arg,
-            15 => Self::Ser, 16 => Self::Thr, 17 => Self::Val,
-            18 => Self::Trp, 19 => Self::Tyr, _  => Self::Unknown,
+            0 => Self::Ala,
+            1 => Self::Cys,
+            2 => Self::Asp,
+            3 => Self::Glu,
+            4 => Self::Phe,
+            5 => Self::Gly,
+            6 => Self::His,
+            7 => Self::Ile,
+            8 => Self::Lys,
+            9 => Self::Leu,
+            10 => Self::Met,
+            11 => Self::Asn,
+            12 => Self::Pro,
+            13 => Self::Gln,
+            14 => Self::Arg,
+            15 => Self::Ser,
+            16 => Self::Thr,
+            17 => Self::Val,
+            18 => Self::Trp,
+            19 => Self::Tyr,
+            _ => Self::Unknown,
         }
     }
 

--- a/crates/ferritin-core/src/info/atom37.rs
+++ b/crates/ferritin-core/src/info/atom37.rs
@@ -42,7 +42,11 @@ static ATOM_ORDER: OnceLock<HashMap<&'static str, usize>> = OnceLock::new();
 /// Map from atom name (e.g. `"CA"`) to its atom37 slot index.
 pub fn atom_order() -> &'static HashMap<&'static str, usize> {
     ATOM_ORDER.get_or_init(|| {
-        ATOM37_NAMES.iter().enumerate().map(|(i, &n)| (n, i)).collect()
+        ATOM37_NAMES
+            .iter()
+            .enumerate()
+            .map(|(i, &n)| (n, i))
+            .collect()
     })
 }
 
@@ -110,5 +114,4 @@ mod tests {
         assert_eq!(AAAtom::OXT as i32, 36);
         assert_eq!(AAAtom::Unknown as i32, -1);
     }
-
 }

--- a/crates/ferritin-core/src/info/constants.rs
+++ b/crates/ferritin-core/src/info/constants.rs
@@ -73,6 +73,7 @@ pub(crate) fn default_distance_range(a: &str, b: &str) -> Option<(f32, f32)> {
     }
 }
 
+#[allow(clippy::type_complexity)] // (atom, atom, bond-order) bond table keyed by residue
 static AA_BONDS: OnceLock<HashMap<&'static str, Vec<(&'static str, &'static str, i32)>>> =
     OnceLock::new();
 

--- a/crates/ferritin-core/src/io/cif.rs
+++ b/crates/ferritin-core/src/io/cif.rs
@@ -158,7 +158,7 @@ impl CIFFile {
                 }
                 // Create new data block
                 current_data_block = Some(CIFDataBlock {
-                    _name: line[5..].to_string(),
+                    _name: line.strip_prefix("data_").unwrap_or(line).to_string(),
                     categories: HashMap::new(),
                 });
                 in_loop = false;
@@ -232,10 +232,10 @@ impl CIFFile {
                     if current_category.is_none()
                         || current_category.as_ref().unwrap().name != category_name
                     {
-                        if let Some(category) = current_category.take() {
-                            if let Some(block) = &mut current_data_block {
-                                block.categories.insert(category.name.clone(), category);
-                            }
+                        if let Some(category) = current_category.take()
+                            && let Some(block) = &mut current_data_block
+                        {
+                            block.categories.insert(category.name.clone(), category);
                         }
                         current_category = Some(CIFCategory::new(category_name));
                     }
@@ -428,10 +428,10 @@ impl CIFFile {
             let element = Element::from_symbol(element_str).unwrap_or_else(|| {
                 // Try to infer element from atom name if element is missing or invalid
                 let atom_name = &row[atom_name_col];
-                if atom_name.len() >= 1 {
+                if !atom_name.is_empty() {
                     let first_char = atom_name.chars().next().unwrap();
                     if first_char.is_alphabetic() && !first_char.is_numeric() {
-                        Element::from_symbol(&first_char.to_string()).unwrap_or(Element::H)
+                        Element::from_symbol(first_char.to_string()).unwrap_or(Element::H)
                     } else {
                         Element::H
                     }
@@ -628,7 +628,7 @@ impl CIFFile {
             let element_str = &row[element_col];
             let element = Element::from_symbol(element_str).unwrap_or_else(|| {
                 let first_char = element_str.chars().next().unwrap_or('C');
-                Element::from_symbol(&first_char.to_string()).unwrap_or(Element::H)
+                Element::from_symbol(first_char.to_string()).unwrap_or(Element::H)
             });
             elements_vec.push(element);
 
@@ -1016,7 +1016,7 @@ impl CIFFile {
             let element_str = &row[element_col];
             let element = Element::from_symbol(element_str).unwrap_or_else(|| {
                 let first_char = element_str.chars().next().unwrap_or('C');
-                Element::from_symbol(&first_char.to_string()).unwrap_or(Element::H)
+                Element::from_symbol(first_char.to_string()).unwrap_or(Element::H)
             });
             elements_vec.push(element);
 
@@ -1386,6 +1386,7 @@ fn optional_scalar(block: &CIFDataBlock, category_name: &str, column: &str) -> O
 
 fn parse_operator_matrix(category: &CIFCategory, row: usize) -> Result<Mat4, CIFError> {
     let mut matrix = IDENTITY_MAT4;
+    #[allow(clippy::needless_range_loop)] // indices name the matrix[i][j] CIF columns
     for row_index in 0..3 {
         for column_index in 0..3 {
             let name = format!("matrix[{}][{}]", row_index + 1, column_index + 1);
@@ -1661,7 +1662,7 @@ fn parse_symmetry_data(block: &CIFDataBlock) -> Result<SymmetryData, CIFError> {
     let details_by_id: HashMap<String, String> = block
         .categories
         .get("pdbx_struct_assembly")
-        .map(|category| {
+        .and_then(|category| {
             let id = category.get_column_index("id")?;
             let details = category.get_column_index("details")?;
             Some(
@@ -1675,7 +1676,6 @@ fn parse_symmetry_data(block: &CIFDataBlock) -> Result<SymmetryData, CIFError> {
                     .collect(),
             )
         })
-        .flatten()
         .unwrap_or_default();
 
     let mut assemblies_by_id: HashMap<String, Vec<AssemblyUnit>> = HashMap::new();
@@ -1824,7 +1824,7 @@ mod tests {
     fn test_cif_file_read() {
         let (cif_file, _temp) = TestFile::protein_01().create_temp().unwrap();
         let cif = CIFFile::read(&cif_file).unwrap();
-        assert!(cif.data_blocks.len() > 0);
+        assert!(!cif.data_blocks.is_empty());
 
         // check conversion
         let ac: AtomCollection = cif.parse_to_atom_collection().unwrap();
@@ -1892,9 +1892,11 @@ mod tests {
             .clone();
         let assembly_units = model.assembly_units(&assembly_id).unwrap();
         assert!(!assembly_units.is_empty());
-        assert!(assembly_units
-            .iter()
-            .all(|unit| std::ptr::eq(unit.model(), &model)));
+        assert!(
+            assembly_units
+                .iter()
+                .all(|unit| std::ptr::eq(unit.model(), &model))
+        );
 
         let distinct_chain_ids: std::collections::HashSet<&str> =
             (0..ac.get_size()).map(|i| ac.get_chain_id(i)).collect();

--- a/crates/ferritin-core/src/io/io.rs
+++ b/crates/ferritin-core/src/io/io.rs
@@ -1,8 +1,8 @@
-use crate::model::Model;
-use crate::trajectory::ArrayTrajectory;
 use crate::AtomCollection;
 use crate::io::cif;
 use crate::io::pdb;
+use crate::model::Model;
+use crate::trajectory::ArrayTrajectory;
 use anyhow::{Context, Result};
 use std::path::Path;
 
@@ -44,7 +44,9 @@ pub fn load_trajectory<P: AsRef<Path>>(file_path: P) -> Result<ArrayTrajectory> 
         "cif" => cif::CIFFile::read(path)?
             .parse_to_trajectory()
             .context("Failed to parse CIF file to trajectory"),
-        "pdb" => Err(anyhow::anyhow!("PDB multi-model trajectory not yet implemented")),
+        "pdb" => Err(anyhow::anyhow!(
+            "PDB multi-model trajectory not yet implemented"
+        )),
         _ => Err(anyhow::anyhow!("Unsupported file extension: {}", extension)),
     }
 }
@@ -67,7 +69,9 @@ pub fn load_model<P: AsRef<Path>>(file_path: P) -> Result<Model> {
         "cif" => cif::CIFFile::read(path)?
             .parse_to_model()
             .context("Failed to parse CIF file to model"),
-        "pdb" => Err(anyhow::anyhow!("load_model for PDB not yet implemented; use load_trajectory for CIF files")),
+        "pdb" => Err(anyhow::anyhow!(
+            "load_model for PDB not yet implemented; use load_trajectory for CIF files"
+        )),
         _ => Err(anyhow::anyhow!("Unsupported file extension: {}", extension)),
     }
 }

--- a/crates/ferritin-core/src/io/pdb.rs
+++ b/crates/ferritin-core/src/io/pdb.rs
@@ -112,7 +112,7 @@ impl PDBFile {
     pub fn parse_remark(&self, number: i64) -> Result<Option<Vec<String>>, PDBError> {
         const CONTENT_START_COLUMN: usize = 11;
 
-        if number < 0 || number > 999 {
+        if !(0..=999).contains(&number) {
             return Err(PDBError::ValueError(
                 "The number must be in range 0-999".to_string(),
             ));
@@ -137,6 +137,7 @@ impl PDBFile {
     /// Parse the `CRYST1` record of the PDB file to obtain the unit cell lengths
     /// and angles (in degrees).
     #[allow(dead_code)]
+    #[allow(clippy::type_complexity)] // (a, b, c, alpha, beta, gamma) unit-cell tuple
     pub fn parse_box(&self) -> Result<Option<(f32, f32, f32, f32, f32, f32)>, PDBError> {
         for line in self.lines.iter() {
             if line.starts_with("CRYST1") {
@@ -203,10 +204,10 @@ impl PDBFile {
             let element_str = line[76..78].trim();
             let element = if element_str.is_empty() {
                 let atom_name = line[12..16].trim();
-                if atom_name.len() >= 1 {
+                if !atom_name.is_empty() {
                     let first_char = atom_name.chars().next().unwrap();
                     if first_char.is_alphabetic() && !first_char.is_numeric() {
-                        Element::from_symbol(&first_char.to_string()).unwrap()
+                        Element::from_symbol(first_char.to_string()).unwrap()
                     } else {
                         Element::H // todo: fix
                     }
@@ -249,25 +250,25 @@ impl PDBFile {
         for line in self.lines.iter() {
             if line.starts_with("CONECT") && line.len() >= 16 {
                 // Extract ID of center atom
-                if let Ok(center_id) = parse_number::<i32>(&line[6..11]) {
-                    if let Some(&center_index) = atom_id_to_index.get(&center_id) {
-                        // Iterate over atom IDs bonded to center atom
-                        for i in (11..31).step_by(5) {
-                            if i + 5 > line.len() {
-                                break;
+                if let Ok(center_id) = parse_number::<i32>(&line[6..11])
+                    && let Some(&center_index) = atom_id_to_index.get(&center_id)
+                {
+                    // Iterate over atom IDs bonded to center atom
+                    for i in (11..31).step_by(5) {
+                        if i + 5 > line.len() {
+                            break;
+                        }
+                        if let Ok(bonded_id) = parse_number::<i32>(&line[i..i + 5]) {
+                            if let Some(&bonded_index) = atom_id_to_index.get(&bonded_id) {
+                                bonds.push(Bond::new(
+                                    center_index,
+                                    bonded_index,
+                                    BondOrder::Single,
+                                ));
                             }
-                            if let Ok(bonded_id) = parse_number::<i32>(&line[i..i + 5]) {
-                                if let Some(&bonded_index) = atom_id_to_index.get(&bonded_id) {
-                                    bonds.push(Bond::new(
-                                        center_index,
-                                        bonded_index,
-                                        BondOrder::Single,
-                                    ));
-                                }
-                            } else {
-                                // No more bonded atoms
-                                break;
-                            }
+                        } else {
+                            // No more bonded atoms
+                            break;
                         }
                     }
                 }
@@ -305,6 +306,7 @@ impl PDBFile {
 
         // For single model mode, just write all atoms
         if !as_multiple_models {
+            #[allow(clippy::needless_range_loop)] // i indexes several parallel per-atom columns
             for i in 0..size {
                 let atom_line = format!(
                     "{:6}{:>5} {:4} {:>3} {:1}{:>4}{:1}   {:>8.3}{:>8.3}{:>8.3}{:>6.2}{:>6.2}          {:>2}  ",
@@ -336,6 +338,7 @@ impl PDBFile {
             // Note: This is a simplification that assumes a single model in the AtomCollection
             // In a real implementation, you'd need to handle multiple models in the collection
             self.lines.push(format!("MODEL {:>8}", 1));
+            #[allow(clippy::needless_range_loop)] // i indexes several parallel per-atom columns
             for i in 0..size {
                 let atom_line = format!(
                     "{:6}{:>5} {:4} {:>3} {:1}{:>4}{:1}   {:>8.3}{:>8.3}{:>8.3}{:>6.2}{:>6.2}          {:>2}  ",
@@ -430,7 +433,6 @@ impl PDBFile {
             self.model_start_i = vec![0]
         }
     }
-
 }
 
 /// Center atom name for proper PDB formatting
@@ -469,7 +471,6 @@ fn parse_float_from_string(line: &str, start: usize, stop: usize) -> Result<f32,
         ))
     })
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/crates/ferritin-core/src/lib.rs
+++ b/crates/ferritin-core/src/lib.rs
@@ -11,6 +11,10 @@
 //! The main entry point is the [`AtomCollection`] struct which represents a biomolecular structure
 //! and provides methods for manipulating and analyzing it.
 //!
+
+// Deliberate `foo/mod.rs` + inner `mod foo` layout (io, model, unit).
+#![allow(clippy::module_inception)]
+
 mod atomcollection;
 mod bonds;
 pub mod data;

--- a/crates/ferritin-core/src/model/bonds.rs
+++ b/crates/ferritin-core/src/model/bonds.rs
@@ -3,9 +3,9 @@
 //! After construction via [`Bonds::from_unsorted`], bonds are sorted by `atom_a`
 //! and `atom_bond_starts` provides O(1) access to all bonds for a given atom.
 
+use super::tables::{AtomsTable, ResidueGroup, ResiduesTable};
 use crate::data::Segmentation;
 use crate::info::constants::get_bonds_canonical20;
-use super::tables::{AtomsTable, ResiduesTable, ResidueGroup};
 
 /// Bond connectivity stored as SoA (struct-of-arrays).
 ///
@@ -42,8 +42,16 @@ impl Bonds {
         order: Vec<u8>,
         n_atoms: usize,
     ) -> Self {
-        assert_eq!(atom_a.len(), atom_b.len(), "atom_a and atom_b must have the same length");
-        assert_eq!(atom_a.len(), order.len(), "atom_a and order must have the same length");
+        assert_eq!(
+            atom_a.len(),
+            atom_b.len(),
+            "atom_a and atom_b must have the same length"
+        );
+        assert_eq!(
+            atom_a.len(),
+            order.len(),
+            "atom_a and order must have the same length"
+        );
 
         let n_bonds = atom_a.len();
 
@@ -59,7 +67,12 @@ impl Bonds {
         let mut atom_bond_starts = vec![0u32; n_atoms + 1];
         for &a in &sorted_a {
             let a = a as usize;
-            assert!(a < n_atoms, "atom index {} out of range (n_atoms={})", a, n_atoms);
+            assert!(
+                a < n_atoms,
+                "atom index {} out of range (n_atoms={})",
+                a,
+                n_atoms
+            );
             atom_bond_starts[a + 1] += 1;
         }
         // prefix-sum
@@ -125,10 +138,14 @@ pub(crate) fn infer_bonds_from_residue_templates(
         let range = atom_to_residue.segment(res_idx);
         if let Some(bond_dict_for_res) = aa_bond_info.get(residues.comp_id[res_idx].as_str()) {
             for &(name1, name2, bond_order) in bond_dict_for_res {
-                let indices1: Vec<usize> =
-                    range.clone().filter(|&i| atoms.atom_name[i] == name1).collect();
-                let indices2: Vec<usize> =
-                    range.clone().filter(|&i| atoms.atom_name[i] == name2).collect();
+                let indices1: Vec<usize> = range
+                    .clone()
+                    .filter(|&i| atoms.atom_name[i] == name1)
+                    .collect();
+                let indices2: Vec<usize> = range
+                    .clone()
+                    .filter(|&i| atoms.atom_name[i] == name2)
+                    .collect();
                 for &i in &indices1 {
                     for &j in &indices2 {
                         atom_a.push(i as u32);

--- a/crates/ferritin-core/src/trajectory/mod.rs
+++ b/crates/ferritin-core/src/trajectory/mod.rs
@@ -8,8 +8,8 @@
 //!
 //! All implementations are object-safe (`dyn Trajectory` works).
 
-use std::borrow::Cow;
 use crate::model::Model;
+use std::borrow::Cow;
 
 pub mod array_trajectory;
 pub mod coordinates;

--- a/crates/ferritin-core/src/unit/unit.rs
+++ b/crates/ferritin-core/src/unit/unit.rs
@@ -420,7 +420,7 @@ mod tests {
         let model = make_test_model(10);
 
         let mask_a: Vec<bool> = (0..10).map(|i| i < 5).collect();
-        let mask_b: Vec<bool> = (0..10).map(|i| i >= 3 && i < 8).collect();
+        let mask_b: Vec<bool> = (0..10).map(|i| (3..8).contains(&i)).collect();
 
         let unit_a = Unit::from_mask(&model, &mask_a);
         let unit_b = Unit::from_mask(&model, &mask_b);

--- a/crates/ferritin-core/src/views/chain.rs
+++ b/crates/ferritin-core/src/views/chain.rs
@@ -52,10 +52,10 @@ impl<'a> ChainView<'a> {
         }
 
         // Add the last residue if it exists and matches the chain ID
-        if let Some(&last_idx) = atom_indices.last() {
-            if self.data.get_chain_id(last_idx) == chain_id {
-                residues.push(ResidueView::new(self.data, last_idx, last_residue_end_idx));
-            }
+        if let Some(&last_idx) = atom_indices.last()
+            && self.data.get_chain_id(last_idx) == chain_id
+        {
+            residues.push(ResidueView::new(self.data, last_idx, last_residue_end_idx));
         }
 
         residues.into_iter()

--- a/crates/ferritin-core/src/views/model_residue.rs
+++ b/crates/ferritin-core/src/views/model_residue.rs
@@ -63,7 +63,8 @@ impl<'a> ModelResidueView<'a> {
     pub fn find_atom_by_name(&self, name: &str) -> Option<ModelAtomView<'a>> {
         let mut range = self.model.hierarchy.atoms_in_residue(self.res_idx);
         let model = self.model;
-        range.find(|&i| model.hierarchy.atoms.atom_name[i] == name)
+        range
+            .find(|&i| model.hierarchy.atoms.atom_name[i] == name)
             .map(|idx| ModelAtomView::new(model, idx))
     }
 }

--- a/crates/ferritin-core/tests/test_atom_collection.rs
+++ b/crates/ferritin-core/tests/test_atom_collection.rs
@@ -9,7 +9,7 @@ fn test_chain_view() {
     ac.calculate_chain_indices();
 
     let chains: Vec<_> = ac.iter_chains().collect();
-    assert!(chains.len() > 0);
+    assert!(!chains.is_empty());
 
     // Test first chain
     let first_chain = &chains[0];

--- a/crates/ferritin-core/tests/test_io.rs
+++ b/crates/ferritin-core/tests/test_io.rs
@@ -1,7 +1,7 @@
-use ferritin_core::{load_structure, load_trajectory};
 use ferritin_core::trajectory::Trajectory;
-use std::sync::Arc;
+use ferritin_core::{load_structure, load_trajectory};
 use ferritin_test_data::TestFile;
+use std::sync::Arc;
 
 #[test]
 fn test_load_structure_cif() {
@@ -25,19 +25,28 @@ fn test_load_trajectory_cif_multimodel() {
     let traj = load_trajectory(&file_path).unwrap();
 
     // 1D3Z: all frames share one Arc<AtomicHierarchy> (topology constant across NMR models)
-    assert!(traj.frame_count() > 1, "NMR trajectory must have multiple frames");
+    assert!(
+        traj.frame_count() > 1,
+        "NMR trajectory must have multiple frames"
+    );
     let n_atoms = traj.representative().n_atoms();
     assert!(n_atoms > 0, "Each frame must have atoms");
 
     // Verify all frames share the same topology
     let h0 = Arc::clone(&traj.frame(0).hierarchy);
     let hlast = Arc::clone(&traj.frame(traj.frame_count() - 1).hierarchy);
-    assert!(Arc::ptr_eq(&h0, &hlast), "All frames must share Arc<AtomicHierarchy>");
+    assert!(
+        Arc::ptr_eq(&h0, &hlast),
+        "All frames must share Arc<AtomicHierarchy>"
+    );
 
     // Verify coords differ between frames (NMR models have different coordinates)
     let coord_f0 = traj.frame(0).coord(0);
     let coord_flast = traj.frame(traj.frame_count() - 1).coord(0);
-    assert_ne!(coord_f0, coord_flast, "NMR frames must have differing coordinates");
+    assert_ne!(
+        coord_f0, coord_flast,
+        "NMR frames must have differing coordinates"
+    );
 }
 
 #[test]

--- a/crates/ferritin-examples/examples/bevy/capture_representations.rs
+++ b/crates/ferritin-examples/examples/bevy/capture_representations.rs
@@ -13,12 +13,12 @@
 use anyhow::Result;
 use bevy::app::AppExit;
 use bevy::prelude::*;
-use bevy::render::view::screenshot::{save_to_disk, Screenshot};
+use bevy::render::view::screenshot::{Screenshot, save_to_disk};
 use ferritin_bevy::{LoadMvsEvent, MvsPlugin, OrbitCamera};
 use ferritin_molviewspec::molviewspec::nodes::{
-    ColorNamesT, ColorT, ColorThemeT, ComponentExpression, ComponentSelector,
-    ComponentSelectorT, ParseFormatT, ParseParams, RepresentationTypeT, State, StructureParams,
-    StructureTypeT, TransformParams,
+    ColorNamesT, ColorT, ColorThemeT, ComponentExpression, ComponentSelector, ComponentSelectorT,
+    ParseFormatT, ParseParams, RepresentationTypeT, State, StructureParams, StructureTypeT,
+    TransformParams,
 };
 use ferritin_test_data::TestFile;
 use tempfile::NamedTempFile;
@@ -68,8 +68,7 @@ fn main() -> Result<()> {
     ];
     for rep in &reps {
         for theme in &themes {
-            let name: &'static str =
-                Box::leak(format!("rep_{rep:?}_{theme:?}").into_boxed_str());
+            let name: &'static str = Box::leak(format!("rep_{rep:?}_{theme:?}").into_boxed_str());
             shots.push(Shot {
                 name,
                 json: single_rep_state(&p_4hhb, rep.clone(), theme.clone()),
@@ -168,15 +167,14 @@ fn take_pending_screenshot(
     queue: Res<ShotQueue>,
 ) {
     // Fire the screenshot on the last settle frame only.
-    if let QueueState::Settling(n) = queue.state {
-        if n == SETTLE_FRAMES - 1 {
-            if let Some(pending) = pending {
-                let path = format!("{OUT_DIR}/{}.png", pending.0);
-                commands
-                    .spawn(Screenshot::primary_window())
-                    .observe(save_to_disk(path));
-            }
-        }
+    if let QueueState::Settling(n) = queue.state
+        && n == SETTLE_FRAMES - 1
+        && let Some(pending) = pending
+    {
+        let path = format!("{OUT_DIR}/{}.png", pending.0);
+        commands
+            .spawn(Screenshot::primary_window())
+            .observe(save_to_disk(path));
     }
 }
 
@@ -231,7 +229,10 @@ fn preset_basic(path: &str) -> String {
         let comp = structure.component(sel(ComponentSelectorT::All)).unwrap();
         comp.representation(RepresentationTypeT::Cartoon)
             .unwrap()
-            .color(ColorT::Named(ColorNamesT::Blue), sel(ComponentSelectorT::All));
+            .color(
+                ColorT::Named(ColorNamesT::Blue),
+                sel(ComponentSelectorT::All),
+            );
         comp.focus(None, None);
     }
     to_json(&state)
@@ -308,11 +309,17 @@ fn preset_label(path: &str) -> String {
             .unwrap()
             .representation(RepresentationTypeT::Cartoon)
             .unwrap()
-            .color(ColorT::Named(ColorNamesT::Lightgray), sel(ComponentSelectorT::All));
+            .color(
+                ColorT::Named(ColorNamesT::Lightgray),
+                sel(ComponentSelectorT::All),
+            );
         let c = structure.component(sel(ComponentSelectorT::Ion)).unwrap();
         c.representation(RepresentationTypeT::BallAndStick)
             .unwrap()
-            .color(ColorT::Named(ColorNamesT::Magenta), sel(ComponentSelectorT::All));
+            .color(
+                ColorT::Named(ColorNamesT::Magenta),
+                sel(ComponentSelectorT::All),
+            );
         c.label("Catalytic metal site".to_string());
         c.focus(None, None);
     }
@@ -332,7 +339,10 @@ fn preset_superposition(path_a: &str, path_b: &str) -> String {
         let c = structure.component(sel(ComponentSelectorT::All)).unwrap();
         c.representation(RepresentationTypeT::Cartoon)
             .unwrap()
-            .color(ColorT::Named(ColorNamesT::Steelblue), sel(ComponentSelectorT::All));
+            .color(
+                ColorT::Named(ColorNamesT::Steelblue),
+                sel(ComponentSelectorT::All),
+            );
         c.focus(None, None);
     }
     {
@@ -350,7 +360,10 @@ fn preset_superposition(path_a: &str, path_b: &str) -> String {
         let c = structure.component(sel(ComponentSelectorT::All)).unwrap();
         c.representation(RepresentationTypeT::Cartoon)
             .unwrap()
-            .color(ColorT::Named(ColorNamesT::Orange), sel(ComponentSelectorT::All));
+            .color(
+                ColorT::Named(ColorNamesT::Orange),
+                sel(ComponentSelectorT::All),
+            );
         // Focus the translated copy too, so the executor's focus union frames both
         // structures instead of leaving this one clipped off-frame (ferritin-t0h.6).
         c.focus(None, None);
@@ -382,7 +395,10 @@ fn preset_symmetry(path: &str) -> String {
         let c = structure.component(sel(ComponentSelectorT::All)).unwrap();
         c.representation(RepresentationTypeT::Cartoon)
             .unwrap()
-            .color(ColorT::Named(ColorNamesT::Seagreen), sel(ComponentSelectorT::All));
+            .color(
+                ColorT::Named(ColorNamesT::Seagreen),
+                sel(ComponentSelectorT::All),
+            );
         c.focus(None, None);
     }
     to_json(&state)
@@ -427,7 +443,12 @@ fn setup_scene(mut commands: Commands, orbit: Res<OrbitCamera>) {
             illuminance: 3_000.0,
             ..default()
         },
-        Transform::from_rotation(Quat::from_euler(EulerRot::XYZ, 0.0, std::f32::consts::PI, 0.0)),
+        Transform::from_rotation(Quat::from_euler(
+            EulerRot::XYZ,
+            0.0,
+            std::f32::consts::PI,
+            0.0,
+        )),
     ));
 }
 
@@ -449,4 +470,3 @@ fn sync_camera(orbit: Res<OrbitCamera>, mut camera: Query<&mut Transform, With<C
         transform.look_at(orbit.focus, up);
     }
 }
-

--- a/crates/ferritin-examples/examples/bevy/interactive_viewer.rs
+++ b/crates/ferritin-examples/examples/bevy/interactive_viewer.rs
@@ -16,12 +16,13 @@ use bevy::ecs::hierarchy::ChildSpawnerCommands;
 use bevy::input::mouse::{AccumulatedMouseMotion, AccumulatedMouseScroll, MouseScrollUnit};
 use bevy::prelude::*;
 use bevy_feathers::{
+    FeathersPlugins,
     dark_theme::create_dark_theme,
     theme::{ThemeBackgroundColor, UiTheme},
-    tokens, FeathersPlugins,
+    tokens,
 };
 use ferritin_bevy::{ColorScheme, RenderOptions, Structure};
-use ferritin_core::{load_model, Model};
+use ferritin_core::{Model, load_model};
 use ferritin_test_data::TestFile;
 
 // ---- Resources -----------------------------------------------------------------
@@ -144,7 +145,12 @@ fn setup_scene(mut commands: Commands) {
             illuminance: 3_000.0,
             ..default()
         },
-        Transform::from_rotation(Quat::from_euler(EulerRot::XYZ, 0.0, std::f32::consts::PI, 0.0)),
+        Transform::from_rotation(Quat::from_euler(
+            EulerRot::XYZ,
+            0.0,
+            std::f32::consts::PI,
+            0.0,
+        )),
     ));
 }
 
@@ -180,6 +186,7 @@ fn rebuild_protein(
 }
 
 /// Update ViewerState when a control button is pressed; update hover colours too.
+#[allow(clippy::type_complexity)] // idiomatic Bevy query type
 fn handle_button_interactions(
     mut query: Query<
         (&Interaction, &ButtonAction, &mut BackgroundColor),
@@ -279,7 +286,10 @@ fn setup_ui(mut commands: Commands) {
                     panel,
                     "Representation",
                     &[
-                        ("Wireframe", ButtonAction::SetRender(RenderOptions::Wireframe)),
+                        (
+                            "Wireframe",
+                            ButtonAction::SetRender(RenderOptions::Wireframe),
+                        ),
                         ("Cartoon", ButtonAction::SetRender(RenderOptions::Cartoon)),
                         (
                             "Ball+Stick",
@@ -300,15 +310,11 @@ fn setup_ui(mut commands: Commands) {
                         ),
                         (
                             "Teal",
-                            ButtonAction::SetColor(ColorScheme::Solid(Color::srgb(
-                                0.0, 0.8, 0.8,
-                            ))),
+                            ButtonAction::SetColor(ColorScheme::Solid(Color::srgb(0.0, 0.8, 0.8))),
                         ),
                         (
                             "Gold",
-                            ButtonAction::SetColor(ColorScheme::Solid(Color::srgb(
-                                1.0, 0.8, 0.2,
-                            ))),
+                            ButtonAction::SetColor(ColorScheme::Solid(Color::srgb(1.0, 0.8, 0.2))),
                         ),
                     ],
                 );

--- a/crates/ferritin-examples/examples/bevy/molviewspec_viewer.rs
+++ b/crates/ferritin-examples/examples/bevy/molviewspec_viewer.rs
@@ -22,14 +22,15 @@
 
 use anyhow::Result;
 use bevy::ecs::hierarchy::ChildSpawnerCommands;
+use bevy::input::ButtonState;
 use bevy::input::keyboard::{Key, KeyboardInput};
 use bevy::input::mouse::{AccumulatedMouseMotion, AccumulatedMouseScroll, MouseScrollUnit};
-use bevy::input::ButtonState;
 use bevy::prelude::*;
 use bevy_feathers::{
+    FeathersPlugins,
     dark_theme::create_dark_theme,
     theme::{ThemeBackgroundColor, UiTheme},
-    tokens, FeathersPlugins,
+    tokens,
 };
 use ferritin_bevy::{LoadMvsEvent, MvsError, MvsPlugin, MvsStateResource, OrbitCamera};
 use ferritin_molviewspec::molviewspec::nodes::{
@@ -280,19 +281,25 @@ fn preset_components(path: &str) -> String {
             .unwrap();
 
         {
-            let c = structure.component(sel(ComponentSelectorT::Protein)).unwrap();
+            let c = structure
+                .component(sel(ComponentSelectorT::Protein))
+                .unwrap();
             c.representation(RepresentationTypeT::Cartoon)
                 .unwrap()
                 .color(orange, sel(ComponentSelectorT::All));
         }
         {
-            let c = structure.component(sel(ComponentSelectorT::Nucleic)).unwrap();
+            let c = structure
+                .component(sel(ComponentSelectorT::Nucleic))
+                .unwrap();
             c.representation(RepresentationTypeT::Cartoon)
                 .unwrap()
                 .color(blue, sel(ComponentSelectorT::All));
         }
         {
-            let c = structure.component(sel(ComponentSelectorT::Ligand)).unwrap();
+            let c = structure
+                .component(sel(ComponentSelectorT::Ligand))
+                .unwrap();
             c.representation(RepresentationTypeT::BallAndStick)
                 .unwrap()
                 .color(green, sel(ComponentSelectorT::All));
@@ -331,11 +338,15 @@ fn preset_label(path: &str) -> String {
             .model_structure(model_params())
             .unwrap();
         {
-            let c = structure.component(sel(ComponentSelectorT::Protein)).unwrap();
-            c.representation(RepresentationTypeT::Cartoon).unwrap().color(
-                ColorT::Named(ColorNamesT::Lightgray),
-                sel(ComponentSelectorT::All),
-            );
+            let c = structure
+                .component(sel(ComponentSelectorT::Protein))
+                .unwrap();
+            c.representation(RepresentationTypeT::Cartoon)
+                .unwrap()
+                .color(
+                    ColorT::Named(ColorNamesT::Lightgray),
+                    sel(ComponentSelectorT::All),
+                );
         }
         {
             let c = structure.component(sel(ComponentSelectorT::Ion)).unwrap();
@@ -365,10 +376,12 @@ fn preset_superposition(path_a: &str, path_b: &str) -> String {
             .model_structure(model_params())
             .unwrap();
         let c = structure.component(sel(ComponentSelectorT::All)).unwrap();
-        c.representation(RepresentationTypeT::Cartoon).unwrap().color(
-            ColorT::Named(ColorNamesT::Steelblue),
-            sel(ComponentSelectorT::All),
-        );
+        c.representation(RepresentationTypeT::Cartoon)
+            .unwrap()
+            .color(
+                ColorT::Named(ColorNamesT::Steelblue),
+                sel(ComponentSelectorT::All),
+            );
         c.focus(None, None);
     }
     {
@@ -385,10 +398,12 @@ fn preset_superposition(path_a: &str, path_b: &str) -> String {
             translation: Some((80.0, 0.0, 0.0)),
         });
         let c = structure.component(sel(ComponentSelectorT::All)).unwrap();
-        c.representation(RepresentationTypeT::Cartoon).unwrap().color(
-            ColorT::Named(ColorNamesT::Orange),
-            sel(ComponentSelectorT::All),
-        );
+        c.representation(RepresentationTypeT::Cartoon)
+            .unwrap()
+            .color(
+                ColorT::Named(ColorNamesT::Orange),
+                sel(ComponentSelectorT::All),
+            );
         // Focus the translated copy too, so the executor's focus union frames both
         // structures instead of leaving this one clipped off-frame (ferritin-t0h.6).
         c.focus(None, None);
@@ -414,10 +429,12 @@ fn preset_symmetry(path: &str) -> String {
             .symmetry_structure(params)
             .unwrap();
         let c = structure.component(sel(ComponentSelectorT::All)).unwrap();
-        c.representation(RepresentationTypeT::Cartoon).unwrap().color(
-            ColorT::Named(ColorNamesT::Seagreen),
-            sel(ComponentSelectorT::All),
-        );
+        c.representation(RepresentationTypeT::Cartoon)
+            .unwrap()
+            .color(
+                ColorT::Named(ColorNamesT::Seagreen),
+                sel(ComponentSelectorT::All),
+            );
         c.focus(None, None);
     }
     to_json(&state)
@@ -465,7 +482,12 @@ fn setup_scene(mut commands: Commands, orbit: Res<OrbitCamera>) {
             illuminance: 3_000.0,
             ..default()
         },
-        Transform::from_rotation(Quat::from_euler(EulerRot::XYZ, 0.0, std::f32::consts::PI, 0.0)),
+        Transform::from_rotation(Quat::from_euler(
+            EulerRot::XYZ,
+            0.0,
+            std::f32::consts::PI,
+            0.0,
+        )),
     ));
 }
 
@@ -500,13 +522,14 @@ fn orbit_input(
         orbit.pitch = (orbit.pitch - delta.y * 0.005).clamp(-1.5, 1.5);
     }
 
-    if mouse.pressed(MouseButton::Right) && delta != Vec2::ZERO {
-        if let Ok(transform) = camera.single() {
-            let right = transform.right();
-            let up = transform.up();
-            let pan_scale = orbit.radius * 0.001;
-            orbit.focus += (right * -delta.x + up * delta.y) * pan_scale;
-        }
+    if mouse.pressed(MouseButton::Right)
+        && delta != Vec2::ZERO
+        && let Ok(transform) = camera.single()
+    {
+        let right = transform.right();
+        let up = transform.up();
+        let pan_scale = orbit.radius * 0.001;
+        orbit.focus += (right * -delta.x + up * delta.y) * pan_scale;
     }
 
     if scroll_delta != 0.0 {
@@ -567,12 +590,12 @@ fn handle_preset_buttons(
     mut status: ResMut<StatusBar>,
 ) {
     for (interaction, button) in &query {
-        if *interaction == Interaction::Pressed {
-            if let Some(preset) = presets.0.get(button.0) {
-                loader.write(LoadMvsEvent::FromString(preset.json.clone()));
-                status.text = format!("Loaded preset: {}", preset.name);
-                status.error = false;
-            }
+        if *interaction == Interaction::Pressed
+            && let Some(preset) = presets.0.get(button.0)
+        {
+            loader.write(LoadMvsEvent::FromString(preset.json.clone()));
+            status.text = format!("Loaded preset: {}", preset.name);
+            status.error = false;
         }
     }
 }
@@ -785,11 +808,7 @@ fn collect_tree_lines(
     let is_collapsed = collapsed.contains(path);
 
     let chevron = if has_children {
-        if is_collapsed {
-            "▶"
-        } else {
-            "▼"
-        }
+        if is_collapsed { "▶" } else { "▼" }
     } else {
         "·"
     };
@@ -862,10 +881,7 @@ fn spawn_tree_row(
         row.insert(Button);
     }
     row.with_children(|r| {
-        r.spawn((
-            Text::new(label),
-            TextColor(TEXT_BRIGHT),
-        ));
+        r.spawn((Text::new(label), TextColor(TEXT_BRIGHT)));
     });
 }
 
@@ -900,10 +916,7 @@ fn spawn_top_bar(root: &mut ChildSpawnerCommands) {
         ThemeBackgroundColor(tokens::PANE_HEADER_BG),
     ))
     .with_children(|bar| {
-        bar.spawn((
-            Text::new("MolViewSpec Viewer"),
-            TextColor(TEXT_BRIGHT),
-        ));
+        bar.spawn((Text::new("MolViewSpec Viewer"), TextColor(TEXT_BRIGHT)));
 
         // Editable file-path field (click to focus, then type).
         bar.spawn((
@@ -1047,6 +1060,7 @@ fn spawn_text_button<C: Component>(parent: &mut ChildSpawnerCommands, caption: &
 }
 
 /// Hover/press feedback for the action buttons (not the tree rows or path field).
+#[allow(clippy::type_complexity)] // idiomatic Bevy query type
 fn button_hover_colors(
     mut query: Query<
         (&Interaction, &mut BackgroundColor),

--- a/crates/ferritin-molviewspec/src/molviewspec/nodes.rs
+++ b/crates/ferritin-molviewspec/src/molviewspec/nodes.rs
@@ -298,7 +298,10 @@ impl Node {
             None
         }
     }
-    pub fn component_from_source(&mut self, params: ComponentFromSourceParams) -> Option<&mut Node> {
+    pub fn component_from_source(
+        &mut self,
+        params: ComponentFromSourceParams,
+    ) -> Option<&mut Node> {
         if self.kind == KindT::Structure {
             let node = Node::new(
                 KindT::ComponentFromSource,
@@ -342,7 +345,6 @@ impl Node {
     /// Add a representation for this component.
     /// :param type: the type of representation, defaults to 'cartoon'
     /// :return: a builder that handles operations at representation level
-
     pub fn representation(
         &mut self,
         representation_type: RepresentationTypeT,
@@ -390,7 +392,9 @@ impl Node {
         if self.kind == KindT::Component {
             let node = Node::new(
                 KindT::Tooltip,
-                Some(NodeParams::TooltipInlineParams(TooltipInlineParams { text })),
+                Some(NodeParams::TooltipInlineParams(TooltipInlineParams {
+                    text,
+                })),
             );
             self.children.get_or_insert_with(Vec::new).push(node);
             self.children.as_mut().unwrap().last_mut()
@@ -406,7 +410,10 @@ impl Node {
         if self.kind == KindT::Component {
             let node = Node::new(
                 KindT::Focus,
-                Some(NodeParams::FocusInlineParams(FocusInlineParams { direction, up })),
+                Some(NodeParams::FocusInlineParams(FocusInlineParams {
+                    direction,
+                    up,
+                })),
             );
             self.children.get_or_insert_with(Vec::new).push(node);
             self.children.as_mut().unwrap().last_mut()
@@ -498,10 +505,12 @@ impl<'de> Deserialize<'de> for Node {
             None | Some(serde_json::Value::Null) => None,
             Some(v) => {
                 let p: NodeParams = match &helper.kind {
-                    KindT::Download => serde_json::from_value::<DownloadParams>(v)
-                        .map(NodeParams::DownloadParams),
-                    KindT::Parse => serde_json::from_value::<ParseParams>(v)
-                        .map(NodeParams::ParseParams),
+                    KindT::Download => {
+                        serde_json::from_value::<DownloadParams>(v).map(NodeParams::DownloadParams)
+                    }
+                    KindT::Parse => {
+                        serde_json::from_value::<ParseParams>(v).map(NodeParams::ParseParams)
+                    }
                     KindT::Structure => serde_json::from_value::<StructureParams>(v)
                         .map(NodeParams::StructureParams),
                     KindT::Representation => serde_json::from_value::<RepresentationParams>(v)
@@ -538,33 +547,44 @@ impl<'de> Deserialize<'de> for Node {
                         .map(NodeParams::FocusInlineParams),
                     KindT::Transform => serde_json::from_value::<TransformParams>(v)
                         .map(NodeParams::TransformParams),
-                    KindT::Camera => serde_json::from_value::<CameraParams>(v)
-                        .map(NodeParams::CameraParams),
-                    KindT::Canvas => serde_json::from_value::<CanvasParams>(v)
-                        .map(NodeParams::CanvasParams),
-                    KindT::Sphere => serde_json::from_value::<SphereParams>(v)
-                        .map(NodeParams::SphereParams),
-                    KindT::Line => serde_json::from_value::<LineParams>(v)
-                        .map(NodeParams::LineParams),
-                    KindT::Volume => serde_json::from_value::<VolumeParams>(v)
-                        .map(NodeParams::VolumeParams),
+                    KindT::Camera => {
+                        serde_json::from_value::<CameraParams>(v).map(NodeParams::CameraParams)
+                    }
+                    KindT::Canvas => {
+                        serde_json::from_value::<CanvasParams>(v).map(NodeParams::CanvasParams)
+                    }
+                    KindT::Sphere => {
+                        serde_json::from_value::<SphereParams>(v).map(NodeParams::SphereParams)
+                    }
+                    KindT::Line => {
+                        serde_json::from_value::<LineParams>(v).map(NodeParams::LineParams)
+                    }
+                    KindT::Volume => {
+                        serde_json::from_value::<VolumeParams>(v).map(NodeParams::VolumeParams)
+                    }
                     KindT::VolumeRepresentation => {
                         serde_json::from_value::<VolumeRepresentationParams>(v)
                             .map(NodeParams::VolumeRepresentationParams)
                     }
                     // Root and GenericVisuals carry no params; ignore any value present.
-                    KindT::Root | KindT::GenericVisuals => return Ok(Node {
-                        kind: helper.kind,
-                        params: None,
-                        children: helper.children,
-                    }),
+                    KindT::Root | KindT::GenericVisuals => {
+                        return Ok(Node {
+                            kind: helper.kind,
+                            params: None,
+                            children: helper.children,
+                        });
+                    }
                 }
                 .map_err(|e| serde::de::Error::custom(e.to_string()))?;
                 Some(p)
             }
         };
 
-        Ok(Node { kind: helper.kind, params, children: helper.children })
+        Ok(Node {
+            kind: helper.kind,
+            params,
+            children: helper.children,
+        })
     }
 }
 
@@ -602,6 +622,12 @@ pub struct State {
     pub root: Node,
     pub metadata: Metadata,
 }
+impl Default for State {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl State {
     pub fn new() -> Self {
         State {
@@ -615,6 +641,7 @@ impl State {
     }
 
     /// Parse a MVSJ string into a State.
+    #[allow(clippy::should_implement_trait)] // fallible JSON parse, not std FromStr
     pub fn from_str(s: &str) -> serde_json::Result<State> {
         serde_json::from_str(s)
     }
@@ -723,6 +750,7 @@ pub struct MvsjFile {
 }
 impl MvsjFile {
     /// Parse a multi-snapshot MVSJ string into an `MvsjFile`.
+    #[allow(clippy::should_implement_trait)] // fallible JSON parse, not std FromStr
     pub fn from_str(s: &str) -> serde_json::Result<MvsjFile> {
         serde_json::from_str(s)
     }
@@ -751,16 +779,13 @@ pub struct ParseParams {
 /// StructureType. Useful for specifying more complicated sets of structures
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum StructureTypeT {
     Model,
+    #[default]
     Assembly,
     Symmetry,
     SymmetryMates,
-}
-impl Default for StructureTypeT {
-    fn default() -> Self {
-        StructureTypeT::Assembly
-    }
 }
 
 /// Structure Params
@@ -1153,6 +1178,7 @@ pub struct ComponentInlineParams {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
+#[allow(clippy::large_enum_variant)] // untagged serde enum; boxing would change the wire shape
 pub enum ComponentSelector {
     Selector(ComponentSelectorT),
     Expression(ComponentExpression),

--- a/crates/ferritin-molviewspec/tests/test_molview_spec.rs
+++ b/crates/ferritin-molviewspec/tests/test_molview_spec.rs
@@ -23,12 +23,15 @@ fn test_molspecview_json_1cbs() {
     ];
 
     for json_file in json_files_component_list {
-        let file = File::open(json_file).expect(&format!("Failed to open file: {}", json_file));
+        let file =
+            File::open(json_file).unwrap_or_else(|_| panic!("Failed to open file: {}", json_file));
         let reader = BufReader::new(file);
-        let _: Vec<ComponentExpression> = from_reader(reader).expect(&format!(
-            "Failed to parse JSON as a Vector of ComponentExpressions: {}",
-            json_file
-        ));
+        let _: Vec<ComponentExpression> = from_reader(reader).unwrap_or_else(|_| {
+            panic!(
+                "Failed to parse JSON as a Vector of ComponentExpressions: {}",
+                json_file
+            )
+        });
     }
 
     // // Todo: Fix the Resideu_range_component/////
@@ -466,14 +469,20 @@ fn test_builder_parse_rejects_non_download_parent() {
     let result = node.parse(ParseParams {
         format: ParseFormatT::Mmcif,
     });
-    assert!(result.is_none(), "parse() must return None for non-Download parent");
+    assert!(
+        result.is_none(),
+        "parse() must return None for non-Download parent"
+    );
 }
 
 #[test]
 fn test_builder_assembly_structure_rejects_non_parse_parent() {
     let mut node = Node::new(KindT::Download, None);
     let result = node.assembly_structure(StructureParams::default());
-    assert!(result.is_none(), "assembly_structure() must return None for non-Parse parent");
+    assert!(
+        result.is_none(),
+        "assembly_structure() must return None for non-Parse parent"
+    );
 }
 
 #[test]
@@ -483,42 +492,63 @@ fn test_builder_model_structure_rejects_non_parse_parent() {
     // For now, assert component() rejects a non-Structure parent (covers same guard pattern).
     let mut node = Node::new(KindT::Parse, None);
     let result = node.component(ComponentSelector::default());
-    assert!(result.is_none(), "component() must return None for non-Structure parent");
+    assert!(
+        result.is_none(),
+        "component() must return None for non-Structure parent"
+    );
 }
 
 #[test]
 fn test_builder_component_rejects_non_structure_parent() {
     let mut node = Node::new(KindT::Parse, None);
     let result = node.component(ComponentSelector::default());
-    assert!(result.is_none(), "component() must return None for non-Structure parent");
+    assert!(
+        result.is_none(),
+        "component() must return None for non-Structure parent"
+    );
 }
 
 #[test]
 fn test_builder_representation_rejects_non_component_parent() {
     let mut node = Node::new(KindT::Structure, None);
     let result = node.representation(RepresentationTypeT::Cartoon);
-    assert!(result.is_none(), "representation() must return None for non-Component parent");
+    assert!(
+        result.is_none(),
+        "representation() must return None for non-Component parent"
+    );
 }
 
 #[test]
 fn test_builder_color_rejects_non_representation_parent() {
     let mut node = Node::new(KindT::Component, None);
-    let result = node.color(ColorT::Hex("#ff0000".to_string()), ComponentSelector::default());
-    assert!(result.is_none(), "color() must return None for non-Representation parent");
+    let result = node.color(
+        ColorT::Hex("#ff0000".to_string()),
+        ComponentSelector::default(),
+    );
+    assert!(
+        result.is_none(),
+        "color() must return None for non-Representation parent"
+    );
 }
 
 #[test]
 fn test_builder_label_rejects_non_component_parent() {
     let mut node = Node::new(KindT::Representation, None);
     let result = node.label("text".to_string());
-    assert!(result.is_none(), "label() must return None for non-Component parent");
+    assert!(
+        result.is_none(),
+        "label() must return None for non-Component parent"
+    );
 }
 
 #[test]
 fn test_builder_transform_rejects_non_structure_parent() {
     let mut node = Node::new(KindT::Parse, None);
     let result = node.transform(TransformParams::default());
-    assert!(result.is_none(), "transform() must return None for non-Structure parent");
+    assert!(
+        result.is_none(),
+        "transform() must return None for non-Structure parent"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -536,7 +566,10 @@ fn test_deser_focus_empty_params_is_focus_inline() {
     let json = r#"{"kind":"focus","params":{}}"#;
     let node: Node = serde_json::from_str(json).expect("valid focus node");
     match node.params {
-        Some(NodeParams::FocusInlineParams(FocusInlineParams { direction: None, up: None })) => {}
+        Some(NodeParams::FocusInlineParams(FocusInlineParams {
+            direction: None,
+            up: None,
+        })) => {}
         other => panic!("expected FocusInlineParams{{None,None}}, got {:?}", other),
     }
 }
@@ -559,9 +592,15 @@ fn test_deser_focus_with_direction() {
 #[test]
 fn test_deser_transform_with_rotation() {
     let rotation = vec![
-        -0.7202161f64, -0.33009904, -0.61018308,
-        0.36257631, 0.57075962, -0.73673053,
-        0.59146191, -0.75184312, -0.29138417,
+        -0.7202161f64,
+        -0.33009904,
+        -0.61018308,
+        0.36257631,
+        0.57075962,
+        -0.73673053,
+        0.59146191,
+        -0.75184312,
+        -0.29138417,
     ];
     let json = serde_json::json!({
         "kind": "transform",
@@ -588,7 +627,10 @@ fn test_deser_transform_empty_params() {
     let json = r#"{"kind":"transform","params":{}}"#;
     let node: Node = serde_json::from_str(json).expect("valid transform empty params");
     match node.params {
-        Some(NodeParams::TransformParams(TransformParams { rotation: None, translation: None })) => {}
+        Some(NodeParams::TransformParams(TransformParams {
+            rotation: None,
+            translation: None,
+        })) => {}
         other => panic!("expected empty TransformParams, got {:?}", other),
     }
 }
@@ -600,7 +642,10 @@ fn test_deser_component_string_selector() {
     let node: Node = serde_json::from_str(json).expect("valid component node");
     match node.params {
         Some(NodeParams::ComponentInlineParams(p)) => {
-            assert!(matches!(p.selector, ComponentSelector::Selector(ComponentSelectorT::All)));
+            assert!(matches!(
+                p.selector,
+                ComponentSelector::Selector(ComponentSelectorT::All)
+            ));
         }
         other => panic!("expected ComponentInlineParams, got {:?}", other),
     }
@@ -609,7 +654,8 @@ fn test_deser_component_string_selector() {
 // T1-06: component node with expression selector
 #[test]
 fn test_deser_component_expression_selector() {
-    let json = r#"{"kind":"component","params":{"selector":{"label_asym_id":"A","label_seq_id":42}}}"#;
+    let json =
+        r#"{"kind":"component","params":{"selector":{"label_asym_id":"A","label_seq_id":42}}}"#;
     let node: Node = serde_json::from_str(json).expect("valid component expression node");
     match node.params {
         Some(NodeParams::ComponentInlineParams(p)) => match p.selector {
@@ -630,7 +676,10 @@ fn test_deser_representation_cartoon() {
     let node: Node = serde_json::from_str(json).expect("valid representation node");
     match node.params {
         Some(NodeParams::RepresentationParams(p)) => {
-            assert!(matches!(p.representation_type, RepresentationTypeT::Cartoon));
+            assert!(matches!(
+                p.representation_type,
+                RepresentationTypeT::Cartoon
+            ));
         }
         other => panic!("expected RepresentationParams, got {:?}", other),
     }
@@ -664,7 +713,8 @@ fn test_deser_label_text() {
 // T1-10: download node round-trip
 #[test]
 fn test_deser_download_url() {
-    let json = r#"{"kind":"download","params":{"url":"https://files.wwpdb.org/download/1cbs.cif"}}"#;
+    let json =
+        r#"{"kind":"download","params":{"url":"https://files.wwpdb.org/download/1cbs.cif"}}"#;
     let node: Node = serde_json::from_str(json).expect("valid download node");
     match node.params {
         Some(NodeParams::DownloadParams(p)) => {
@@ -705,7 +755,10 @@ fn test_deser_structure_model() {
 fn test_deser_root_no_params() {
     let json = r#"{"kind":"root"}"#;
     let node: Node = serde_json::from_str(json).expect("valid root node");
-    assert!(node.params.is_none(), "root without params should have params=None");
+    assert!(
+        node.params.is_none(),
+        "root without params should have params=None"
+    );
 }
 
 // T1-26: root node with explicit null params
@@ -713,15 +766,17 @@ fn test_deser_root_no_params() {
 fn test_deser_root_null_params() {
     let json = r#"{"kind":"root","params":null}"#;
     let node: Node = serde_json::from_str(json).expect("valid root null-params node");
-    assert!(node.params.is_none(), "root with params:null should have params=None");
+    assert!(
+        node.params.is_none(),
+        "root with params:null should have params=None"
+    );
 }
 
 // T1-27: full components/state.mvsj round-trip (focus + transform)
 #[test]
 fn test_deser_components_example_roundtrip() {
     let path = "tests/mol-spec-examples/components/state.mvsj";
-    let content = std::fs::read_to_string(path)
-        .unwrap_or_else(|_| panic!("cannot read {}", path));
+    let content = std::fs::read_to_string(path).unwrap_or_else(|_| panic!("cannot read {}", path));
     let state: State = serde_json::from_str(&content)
         .unwrap_or_else(|e| panic!("failed to parse {}: {}", path, e));
     // The components example has a focus node with params:{}
@@ -732,15 +787,17 @@ fn test_deser_components_example_roundtrip() {
         }
         node.children.iter().flatten().any(find_focus)
     }
-    assert!(find_focus(&state.root), "components example must contain a FocusInlineParams node");
+    assert!(
+        find_focus(&state.root),
+        "components example must contain a FocusInlineParams node"
+    );
 }
 
 // T1-28: superposition/state.mvsj round-trip (transform with rotation)
 #[test]
 fn test_deser_superposition_example_roundtrip() {
     let path = "tests/mol-spec-examples/superposition/state.mvsj";
-    let content = std::fs::read_to_string(path)
-        .unwrap_or_else(|_| panic!("cannot read {}", path));
+    let content = std::fs::read_to_string(path).unwrap_or_else(|_| panic!("cannot read {}", path));
     let state: State = serde_json::from_str(&content)
         .unwrap_or_else(|e| panic!("failed to parse {}: {}", path, e));
     fn find_transform(node: &Node) -> bool {
@@ -749,15 +806,17 @@ fn test_deser_superposition_example_roundtrip() {
         }
         node.children.iter().flatten().any(find_transform)
     }
-    assert!(find_transform(&state.root), "superposition example must contain a TransformParams with rotation");
+    assert!(
+        find_transform(&state.root),
+        "superposition example must contain a TransformParams with rotation"
+    );
 }
 
 // T1-29: basic/state.mvsj round-trip
 #[test]
 fn test_deser_basic_example_roundtrip() {
     let path = "tests/mol-spec-examples/basic/state.mvsj";
-    let content = std::fs::read_to_string(path)
-        .unwrap_or_else(|_| panic!("cannot read {}", path));
+    let content = std::fs::read_to_string(path).unwrap_or_else(|_| panic!("cannot read {}", path));
     let _state: State = serde_json::from_str(&content)
         .unwrap_or_else(|e| panic!("failed to parse {}: {}", path, e));
 }
@@ -769,9 +828,14 @@ fn test_builder_serialize_deserialize_roundtrip() {
     state
         .download("https://files.wwpdb.org/download/1cbs.cif")
         .expect("download node")
-        .parse(ParseParams { format: ParseFormatT::Mmcif })
+        .parse(ParseParams {
+            format: ParseFormatT::Mmcif,
+        })
         .expect("parse node")
-        .assembly_structure(StructureParams { structure_type: StructureTypeT::Assembly, ..Default::default() })
+        .assembly_structure(StructureParams {
+            structure_type: StructureTypeT::Assembly,
+            ..Default::default()
+        })
         .expect("structure node")
         .component(ComponentSelector::Selector(ComponentSelectorT::All))
         .expect("component node")
@@ -797,10 +861,18 @@ fn test_builder_model_structure_ok() {
     let result = state
         .download("https://example.com/1abc.cif")
         .expect("download")
-        .parse(ParseParams { format: ParseFormatT::Mmcif })
+        .parse(ParseParams {
+            format: ParseFormatT::Mmcif,
+        })
         .expect("parse")
-        .model_structure(StructureParams { structure_type: StructureTypeT::Model, ..Default::default() });
-    assert!(result.is_some(), "model_structure() must return Some on Parse parent");
+        .model_structure(StructureParams {
+            structure_type: StructureTypeT::Model,
+            ..Default::default()
+        });
+    assert!(
+        result.is_some(),
+        "model_structure() must return Some on Parse parent"
+    );
 }
 
 // T1-32: State version must be "1.0"
@@ -817,14 +889,19 @@ fn test_builder_focus_on_component() {
     let result = state
         .download("https://example.com/1abc.cif")
         .expect("download")
-        .parse(ParseParams { format: ParseFormatT::Mmcif })
+        .parse(ParseParams {
+            format: ParseFormatT::Mmcif,
+        })
         .expect("parse")
         .assembly_structure(StructureParams::default())
         .expect("structure")
         .component(ComponentSelector::default())
         .expect("component")
         .focus(Some((0.0, 0.0, 1.0)), None);
-    assert!(result.is_some(), "focus() must return Some on Component parent");
+    assert!(
+        result.is_some(),
+        "focus() must return Some on Component parent"
+    );
 }
 
 // T1-34: focus() rejects non-Component parent
@@ -853,7 +930,9 @@ fn test_builder_tooltip_on_component() {
 #[test]
 fn test_builder_canvas_on_state() {
     let mut state = State::new();
-    let params = CanvasParams { background_color: ColorT::Hex("#ffffff".to_string()) };
+    let params = CanvasParams {
+        background_color: ColorT::Hex("#ffffff".to_string()),
+    };
     let result = state.canvas(params);
     assert!(result.is_some(), "canvas() must return Some");
 }
@@ -864,7 +943,10 @@ fn test_builder_generic_visuals_on_state() {
     let mut state = State::new();
     let result = state.generic_visuals();
     assert!(result.is_some(), "generic_visuals() must return Some");
-    assert_eq!(state.root.children.as_ref().unwrap()[0].kind, KindT::GenericVisuals);
+    assert_eq!(
+        state.root.children.as_ref().unwrap()[0].kind,
+        KindT::GenericVisuals
+    );
 }
 
 // T1-38: sphere() on GenericVisuals parent
@@ -905,7 +987,9 @@ fn test_state_from_str_roundtrip() {
     state
         .download("https://files.wwpdb.org/download/1cbs.cif")
         .expect("download")
-        .parse(ParseParams { format: ParseFormatT::Mmcif })
+        .parse(ParseParams {
+            format: ParseFormatT::Mmcif,
+        })
         .expect("parse")
         .assembly_structure(StructureParams::default())
         .expect("structure")
@@ -923,8 +1007,8 @@ fn test_state_from_str_roundtrip() {
 fn test_state_from_reader_basic_example() {
     let file = std::fs::File::open("tests/mol-spec-examples/basic/state.mvsj")
         .expect("open basic state.mvsj");
-    let state = State::from_reader(std::io::BufReader::new(file))
-        .expect("from_reader must succeed");
+    let state =
+        State::from_reader(std::io::BufReader::new(file)).expect("from_reader must succeed");
     assert_eq!(state.root.kind, KindT::Root);
 }
 
@@ -934,8 +1018,7 @@ fn test_state_from_reader_basic_example() {
 
 fn load_example(name: &str) -> State {
     let path = format!("tests/mol-spec-examples/{}/state.mvsj", name);
-    let content = std::fs::read_to_string(&path)
-        .unwrap_or_else(|_| panic!("cannot read {}", path));
+    let content = std::fs::read_to_string(&path).unwrap_or_else(|_| panic!("cannot read {}", path));
     State::from_str(&content).unwrap_or_else(|e| panic!("parse error in {}: {}", path, e))
 }
 
@@ -943,20 +1026,22 @@ fn find_node<'a, F: Fn(&Node) -> bool>(node: &'a Node, pred: &F) -> Option<&'a N
     if pred(node) {
         return Some(node);
     }
-    node.children.iter().flatten().find_map(|c| find_node(c, pred))
+    node.children
+        .iter()
+        .flatten()
+        .find_map(|c| find_node(c, pred))
 }
 
 // T1-42: basic — structure type Model, component All, cartoon, color named blue
 #[test]
 fn test_roundtrip_basic() {
     let state = load_example("basic");
-    let structure = find_node(&state.root, &|n| {
-        matches!(n.params, Some(NodeParams::StructureParams(ref p)) if matches!(p.structure_type, StructureTypeT::Model))
-    });
+    let structure = find_node(
+        &state.root,
+        &|n| matches!(n.params, Some(NodeParams::StructureParams(ref p)) if matches!(p.structure_type, StructureTypeT::Model)),
+    );
     assert!(structure.is_some(), "basic: must have a model structure");
-    let color = find_node(&state.root, &|n| {
-        matches!(n.kind, KindT::Color)
-    });
+    let color = find_node(&state.root, &|n| matches!(n.kind, KindT::Color));
     assert!(color.is_some(), "basic: must have a color node");
 }
 
@@ -967,13 +1052,26 @@ fn test_roundtrip_components() {
     let mut component_count = 0;
     let mut focus_count = 0;
     fn count(node: &Node, cc: &mut usize, fc: &mut usize) {
-        if node.kind == KindT::Component { *cc += 1; }
-        if matches!(node.params, Some(NodeParams::FocusInlineParams(_))) { *fc += 1; }
-        for child in node.children.iter().flatten() { count(child, cc, fc); }
+        if node.kind == KindT::Component {
+            *cc += 1;
+        }
+        if matches!(node.params, Some(NodeParams::FocusInlineParams(_))) {
+            *fc += 1;
+        }
+        for child in node.children.iter().flatten() {
+            count(child, cc, fc);
+        }
     }
     count(&state.root, &mut component_count, &mut focus_count);
-    assert!(component_count >= 5, "components: expected >=5 component nodes, got {}", component_count);
-    assert_eq!(focus_count, 1, "components: expected exactly 1 FocusInlineParams");
+    assert!(
+        component_count >= 5,
+        "components: expected >=5 component nodes, got {}",
+        component_count
+    );
+    assert_eq!(
+        focus_count, 1,
+        "components: expected exactly 1 FocusInlineParams"
+    );
 }
 
 // T1-44: label — has a label node and a focus node under the same component
@@ -993,15 +1091,20 @@ fn test_roundtrip_label() {
 #[test]
 fn test_roundtrip_superposition() {
     let state = load_example("superposition");
-    let transform = find_node(&state.root, &|n| {
-        matches!(n.params, Some(NodeParams::TransformParams(ref p)) if p.rotation.is_some())
-    });
+    let transform = find_node(
+        &state.root,
+        &|n| matches!(n.params, Some(NodeParams::TransformParams(ref p)) if p.rotation.is_some()),
+    );
     let transform = transform.expect("superposition: must have a TransformParams with rotation");
     if let Some(NodeParams::TransformParams(ref p)) = transform.params {
         let rot = p.rotation.as_ref().unwrap();
         assert_eq!(rot.len(), 9, "rotation must have 9 elements");
         let diff = (rot[0] - (-0.7202161_f64)).abs();
-        assert!(diff < 1e-5, "rotation[0] expected ~-0.720216, got {}", rot[0]);
+        assert!(
+            diff < 1e-5,
+            "rotation[0] expected ~-0.720216, got {}",
+            rot[0]
+        );
     }
 }
 
@@ -1009,9 +1112,10 @@ fn test_roundtrip_superposition() {
 #[test]
 fn test_roundtrip_symmetry() {
     let state = load_example("symmetry");
-    let structure = find_node(&state.root, &|n| {
-        matches!(n.params, Some(NodeParams::StructureParams(ref p)) if matches!(p.structure_type, StructureTypeT::Symmetry))
-    });
+    let structure = find_node(
+        &state.root,
+        &|n| matches!(n.params, Some(NodeParams::StructureParams(ref p)) if matches!(p.structure_type, StructureTypeT::Symmetry)),
+    );
     let structure = structure.expect("symmetry: must have a Symmetry structure");
     if let Some(NodeParams::StructureParams(ref p)) = structure.params {
         assert_eq!(p.ijk_min, Some((-1, -1, -1)));
@@ -1102,8 +1206,8 @@ fn test_volume_isosurface_roundtrip() {
     let json = serde_json::to_string(&root).expect("serialize volume state");
     let parsed: Node = serde_json::from_str(&json).expect("deserialize volume state");
 
-    let volume_node = find_node(&parsed, &|n| n.kind == KindT::Volume)
-        .expect("Volume node must round-trip");
+    let volume_node =
+        find_node(&parsed, &|n| n.kind == KindT::Volume).expect("Volume node must round-trip");
     if let Some(NodeParams::VolumeParams(ref p)) = volume_node.params {
         assert_eq!(p.channel_id.as_deref(), Some("2fo-fc"));
     } else {
@@ -1154,11 +1258,7 @@ fn test_mvsj_file_two_snapshot_sequence() {
     assert_eq!(story.snapshots[0].root.kind, KindT::Root);
     assert_eq!(story.snapshots[1].title.as_deref(), Some("Overview"));
     assert_eq!(
-        story.snapshots[1]
-            .root
-            .children
-            .as_ref()
-            .map(|c| c.len()),
+        story.snapshots[1].root.children.as_ref().map(|c| c.len()),
         Some(1)
     );
     assert_eq!(story.snapshots[0].linger_duration_ms, Some(3000));

--- a/crates/ferritin-plms/src/amplify/amplify.rs
+++ b/crates/ferritin-plms/src/amplify/amplify.rs
@@ -67,10 +67,8 @@ impl AMPLIFY {
             if output_hidden_states {
                 hidden_states.push(x.clone());
             }
-            if output_attentions {
-                if let Some(attn) = attn {
-                    attentions.push(attn);
-                }
+            if output_attentions && let Some(attn) = attn {
+                attentions.push(attn);
             }
         }
         // Final layer norm and decoder
@@ -249,9 +247,11 @@ impl EncoderBlock {
         let scores = (query.matmul(&key.transpose(D::Minus2, D::Minus1)?)? * scale)?;
         let masked_scores = attn_mask.map_or(Ok(scores.clone()), |mask| scores.add(mask))?;
         let attn_weights = softmax_last_dim(&masked_scores)?;
-        let attn_probs = (dropout_p > 0.0)
-            .then(|| candle_nn::ops::dropout(&attn_weights, dropout_p as f32))
-            .unwrap_or_else(|| Ok(attn_weights))?;
+        let attn_probs = if dropout_p > 0.0 {
+            candle_nn::ops::dropout(&attn_weights, dropout_p as f32)
+        } else {
+            Ok(attn_weights)
+        }?;
         attn_probs.matmul(value)
     }
     fn attention_block(
@@ -306,7 +306,7 @@ impl EncoderBlock {
         // avoid RuntimeError due to misaligned operand
         let multiple_of = 8;
         let intermediate_size = (config.intermediate_size * 2) / 3;
-        let intermediate_size = multiple_of * ((intermediate_size + multiple_of - 1) / multiple_of);
+        let intermediate_size = multiple_of * intermediate_size.div_ceil(multiple_of);
         let vb = vb.pp(layer);
         let attn_linear = |d_in, d_out, vb| {
             if config.att_bias {

--- a/crates/ferritin-plms/src/amplify/amplify_runner.rs
+++ b/crates/ferritin-plms/src/amplify/amplify_runner.rs
@@ -118,7 +118,7 @@ impl AmplifyRunner {
         let residue_ids = if ids.len() >= 2 {
             &ids[1..ids.len() - 1]
         } else {
-            &ids[..]
+            ids
         };
         let label_at = |p: usize| -> char {
             residue_ids
@@ -129,6 +129,7 @@ impl AmplifyRunner {
         };
 
         let mut contacts = Vec::new();
+        #[allow(clippy::needless_range_loop)] // i/j/k index a 3-D contact tensor
         for i in 0..position1 {
             for j in 0..position2 {
                 for k in 0..val {
@@ -151,6 +152,7 @@ impl AmplifyRunner {
         let data = tensor.to_vec3::<f32>()?;
         let (_, seq_len, vocab_size) = tensor.dims3()?;
         let mut logit_positions = Vec::with_capacity(seq_len * vocab_size);
+        #[allow(clippy::needless_range_loop)] // indexes a 3-D logits tensor
         for seq_pos in 0..seq_len {
             for vocab_idx in 0..vocab_size {
                 let score = data[0][seq_pos][vocab_idx];

--- a/crates/ferritin-plms/src/esm2/esm2.rs
+++ b/crates/ferritin-plms/src/esm2/esm2.rs
@@ -368,7 +368,7 @@ impl ESM2ContactHead {
     /// # Arguments
     /// * `tokens`     – input token IDs, shape `(batch, seq_len)`
     /// * `attentions` – stacked per-layer attention weights,
-    ///                   shape `(batch, layers, heads, seq_len, seq_len)`
+    ///   shape `(batch, layers, heads, seq_len, seq_len)`
     ///
     /// # Returns
     /// Contact probability matrix, shape `(batch, seq_len−2, seq_len−2)`
@@ -628,7 +628,7 @@ impl ESM2 {
         // Transpose to sequence-first format for transformer processing
         xs = xs.transpose(0, 1)?; // (B, T, E) -> (T, B, E)
         // Process through transformer layers
-        for (_layer_idx, layer) in self.layers.iter().enumerate() {
+        for layer in self.layers.iter() {
             let (new_xs, _attn) = layer.forward(&xs)?;
             xs = new_xs;
         }
@@ -648,7 +648,7 @@ impl ESM2 {
     pub fn embed(&self, x: &Tensor, attention_mask: Option<&Tensor>) -> Result<Tensor> {
         let mut xs = self.embeddings.forward(x, attention_mask)?;
         xs = xs.transpose(0, 1)?; // (B, T, E) -> (T, B, E)
-        for (_layer_idx, layer) in self.layers.iter().enumerate() {
+        for layer in self.layers.iter() {
             let (new_xs, _attn) = layer.forward(&xs)?;
             xs = new_xs;
         }
@@ -895,7 +895,7 @@ mod tests {
         let vals: Vec<f32> = contacts.flatten_all()?.to_vec1()?;
         for &v in &vals {
             assert!(
-                v >= 0.0 && v <= 1.0,
+                (0.0..=1.0).contains(&v),
                 "contact probability out of [0,1]: {v}"
             );
         }

--- a/crates/ferritin-plms/src/esm2/esm2_runner.rs
+++ b/crates/ferritin-plms/src/esm2/esm2_runner.rs
@@ -6,8 +6,8 @@ use crate::plm_runner::PlmRunner;
 use crate::types::PseudoProbability;
 use anyhow::{Error as E, Result, anyhow};
 use candle_core::{DType, Device, Tensor};
-use candle_nn::ops::softmax;
 use candle_nn::VarBuilder;
+use candle_nn::ops::softmax;
 use hf_hub::HFClientSync;
 use serde_json;
 use tokenizers::Tokenizer;
@@ -16,10 +16,26 @@ const ESM2_DTYPE: DType = DType::F32;
 
 // ESM2 tokenizer: indices 4-23 are the 20 standard amino acids.
 const ESM2_STD_AA: [(usize, char); 20] = [
-    (4, 'L'), (5, 'A'), (6, 'G'), (7, 'V'), (8, 'S'),
-    (9, 'E'), (10, 'R'), (11, 'T'), (12, 'I'), (13, 'D'),
-    (14, 'P'), (15, 'K'), (16, 'Q'), (17, 'N'), (18, 'F'),
-    (19, 'Y'), (20, 'M'), (21, 'H'), (22, 'W'), (23, 'C'),
+    (4, 'L'),
+    (5, 'A'),
+    (6, 'G'),
+    (7, 'V'),
+    (8, 'S'),
+    (9, 'E'),
+    (10, 'R'),
+    (11, 'T'),
+    (12, 'I'),
+    (13, 'D'),
+    (14, 'P'),
+    (15, 'K'),
+    (16, 'Q'),
+    (17, 'N'),
+    (18, 'F'),
+    (19, 'Y'),
+    (20, 'M'),
+    (21, 'H'),
+    (22, 'W'),
+    (23, 'C'),
 ];
 
 pub enum ESM2Models {

--- a/crates/ferritin-plms/src/esm3/layers/encode_inputs.rs
+++ b/crates/ferritin-plms/src/esm3/layers/encode_inputs.rs
@@ -78,6 +78,7 @@ fn rbf(values: &Tensor, v_min: f64, v_max: f64, n_bins: usize) -> Result<Tensor>
 // ── EncodeInputs ──────────────────────────────────────────────────────────────
 
 pub struct EncodeInputs {
+    #[allow(dead_code)]
     d_model: usize,
     // Sequence track
     sequence_embed: nn::Embedding,
@@ -164,6 +165,7 @@ impl EncodeInputs {
     /// - `per_res_plddt`:             `(B, L)` f32 per-residue pLDDT in [0,1].
     ///
     /// Returns `(B, L, d_model)`.
+    #[allow(clippy::too_many_arguments)] // one arg per ESM3 input track
     pub fn forward(
         &self,
         sequence_tokens: Option<&Tensor>,

--- a/crates/ferritin-plms/src/esm3/models/esm3.rs
+++ b/crates/ferritin-plms/src/esm3/models/esm3.rs
@@ -154,10 +154,7 @@ impl ESM3 {
             Some((ref aff, ref mask)) => {
                 affine_ref = aff;
                 mask_ref = mask;
-                (
-                    Some(affine_ref),
-                    Some(mask_ref),
-                )
+                (Some(affine_ref), Some(mask_ref))
             }
             None => (None, None),
         };

--- a/crates/ferritin-plms/src/esm3/pretrained.rs
+++ b/crates/ferritin-plms/src/esm3/pretrained.rs
@@ -138,6 +138,7 @@ impl PlmRunner for ESM3Runner {
 /// Uses a separate checkpoint (`esm3_structure_encoder_v0.pth`) from the main model.
 pub struct StructureEncoderRunner {
     encoder: StructureTokenEncoder,
+    #[allow(dead_code)]
     device: Device,
 }
 

--- a/crates/ferritin-plms/src/esm3/utils/affine3d.rs
+++ b/crates/ferritin-plms/src/esm3/utils/affine3d.rs
@@ -136,7 +136,7 @@ fn cross_product(a: &Tensor, b: &Tensor) -> Result<Tensor> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use candle_core::{Device, DType, Tensor};
+    use candle_core::{DType, Device, Tensor};
 
     #[test]
     fn test_apply_rot_identity() -> Result<()> {

--- a/crates/ferritin-plms/src/esmc/layers/blocks.rs
+++ b/crates/ferritin-plms/src/esmc/layers/blocks.rs
@@ -56,14 +56,14 @@ pub struct UnifiedTransformerBlock {
 }
 
 impl UnifiedTransformerBlock {
-    /// Creates a new UnifiedTransformerBlock.
-    ///
-    /// # Parameters
-    /// - d_model: The dimensionality of the input and output features
-    /// - n_heads: The number of attention heads
-    /// - use_geom_attn: Whether to use geometric attention
-    /// - use_plain_attn: Whether to use plain attention
-    /// - v_heads: Number of heads for geometric attention
+    // Creates a new UnifiedTransformerBlock.
+    //
+    // # Parameters
+    // - d_model: The dimensionality of the input and output features
+    // - n_heads: The number of attention heads
+    // - use_geom_attn: Whether to use geometric attention
+    // - use_plain_attn: Whether to use plain attention
+    // - v_heads: Number of heads for geometric attention
     // pub fn new(
     //     d_model: i64,
     //     n_heads: i64,
@@ -175,18 +175,18 @@ impl UnifiedTransformerBlock {
         let mut x = x.clone();
 
         // Plain (standard) attention path
-        if self.use_plain_attn {
-            if let Some(attn) = &self.attn {
-                let r1 = attn.forward(&x, sequence_id)?;
-                x = (&x + &(&r1 / self.scaling_factor)?)?;
-            }
+        if self.use_plain_attn
+            && let Some(attn) = &self.attn
+        {
+            let r1 = attn.forward(&x, sequence_id)?;
+            x = (&x + &(&r1 / self.scaling_factor)?)?;
         }
 
         // Geometric attention path (currently disabled/None in load())
-        if self.use_geom_attn {
-            if let Some(_geom_attn) = &self.geom_attn {
-                // geom_attn not yet implemented; skip silently
-            }
+        if self.use_geom_attn
+            && let Some(_geom_attn) = &self.geom_attn
+        {
+            // geom_attn not yet implemented; skip silently
         }
 
         // Feed-forward

--- a/crates/ferritin-plms/src/esmc/models/esmc.rs
+++ b/crates/ferritin-plms/src/esmc/models/esmc.rs
@@ -132,7 +132,10 @@ impl ESMCConfig {
             use_plain_attn: true,
             n_layers_geom: 0,
             scale_residue: true,
-            residue_scaling_factor: (36f64 / 36.).sqrt(), // = 1.0
+            // Mirrors the sqrt(n_layers / 36) scaling of the other sizes; with
+            // n_layers = 36 this is exactly 1.0 (written directly so clippy's
+            // eq_op lint doesn't fire on 36 / 36).
+            residue_scaling_factor: 1.0,
             mask_and_zero_frameless: false,
             bias: false,
             qk_layernorm: true,

--- a/crates/ferritin-plms/src/esmfold2/layers/confidence_head.rs
+++ b/crates/ferritin-plms/src/esmfold2/layers/confidence_head.rs
@@ -73,6 +73,7 @@ pub struct ConfidenceHead {
     pae_head: nn::Linear,
     pde_head: nn::Linear,
     distogram_head: nn::Linear,
+    #[allow(dead_code)]
     num_plddt_bins: usize,
 }
 
@@ -150,7 +151,7 @@ impl ConfidenceHead {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use candle_core::{Device, DType, Tensor};
+    use candle_core::{DType, Device, Tensor};
 
     const B: usize = 1;
     const N: usize = 12;

--- a/crates/ferritin-plms/src/esmfold2/layers/diffusion.rs
+++ b/crates/ferritin-plms/src/esmfold2/layers/diffusion.rs
@@ -43,6 +43,7 @@ use candle_nn::{self as nn, LayerNorm, LayerNormConfig, Module, VarBuilder};
 /// where `w_i` are learnable scalar weights.
 struct FourierEmbedding {
     weights: Tensor, // [fourier_dim / 2]
+    #[allow(dead_code)]
     dim: usize,
 }
 
@@ -208,7 +209,9 @@ pub struct DiffusionModule {
     blocks: Vec<TokenBlock>, // 12 blocks
     out_proj: nn::Linear,    // c_token → 3 (Cα or token centroid)
     // TODO: atom_transformer (3 blocks, c_atom=128) for all-atom output
+    #[allow(dead_code)]
     c_token: usize,
+    #[allow(dead_code)]
     d_single: usize,
     // Noise schedule parameters
     s_max: f64,
@@ -232,6 +235,7 @@ impl DiffusionModule {
     /// * `n_token_blocks` — number of token transformer blocks (12)
     /// * `n_token_heads`  — number of heads per token block (16)
     /// * `fourier_dim`    — Fourier noise embedding dimension (256)
+    #[allow(clippy::too_many_arguments)] // one arg per diffusion-module hyperparameter
     pub fn load(
         vb: VarBuilder,
         c_token: usize,

--- a/crates/ferritin-plms/src/esmfold2/layers/pairformer.rs
+++ b/crates/ferritin-plms/src/esmfold2/layers/pairformer.rs
@@ -262,7 +262,7 @@ impl PairformerBlock {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use candle_core::{Device,DType, Tensor};
+    use candle_core::{DType, Device, Tensor};
 
     const B: usize = 1;
     const N: usize = 8;

--- a/crates/ferritin-plms/src/esmfold2/model.rs
+++ b/crates/ferritin-plms/src/esmfold2/model.rs
@@ -18,6 +18,7 @@ use candle_nn::VarBuilder;
 /// The ESMC-6B backbone (frozen) is loaded separately; this struct holds only
 /// the structure-head components that are fine-tuned for structure prediction.
 pub struct ESMFold2Model {
+    #[allow(dead_code)]
     config: ESMFold2Config,
     lm_encoder: LMEncoder,
     folding_trunk: FoldingTrunk,

--- a/crates/ferritin-plms/src/esmfold2/pretrained.rs
+++ b/crates/ferritin-plms/src/esmfold2/pretrained.rs
@@ -97,7 +97,12 @@ impl ESMFold2Runner {
     pub fn from_pretrained(model_variant: ESMFold2Models, device: Device) -> Result<Self> {
         let (repo_id, config) = model_variant.model_info()?;
         let model = Self::load_structure_head(repo_id, &config, &device)?;
-        Ok(Self { model, config, device, backbone: None })
+        Ok(Self {
+            model,
+            config,
+            device,
+            backbone: None,
+        })
     }
 
     /// Download and load the structure head (~755 MB) **and** the ESMC-6B
@@ -111,7 +116,12 @@ impl ESMFold2Runner {
         eprintln!("ESMFold2Runner: loading ESMC-6B backbone (~12 GB)...");
         let backbone = ESMCRunner::from_pretrained(ESMCModels::ESMC6B, device.clone())?;
         eprintln!("ESMFold2Runner: backbone ready.");
-        Ok(Self { model, config, device, backbone: Some(backbone) })
+        Ok(Self {
+            model,
+            config,
+            device,
+            backbone: Some(backbone),
+        })
     }
 
     fn load_structure_head(
@@ -164,11 +174,7 @@ impl ESMFold2Runner {
                 // Strip BOS (index 0) and EOS (index L+1), keeping L residues.
                 embs.narrow(1, 1, l)?
             }
-            None => Tensor::zeros(
-                &[1, l, self.config.lm_d_model],
-                ESMFOLD2_DTYPE,
-                device,
-            )?,
+            None => Tensor::zeros(&[1, l, self.config.lm_d_model], ESMFOLD2_DTYPE, device)?,
         };
 
         let res_idx: Vec<f32> = (0..l).map(|i| i as f32).collect();
@@ -215,8 +221,8 @@ mod tests {
     #[test]
     fn test_fold_protein_stub_shapes() {
         use super::super::config::ESMFold2Config;
-        use candle_nn::VarBuilder;
         use candle_core::DType;
+        use candle_nn::VarBuilder;
 
         let device = Device::Cpu;
         let cfg = ESMFold2Config {
@@ -239,7 +245,12 @@ mod tests {
         };
         let vb = VarBuilder::zeros(DType::F32, &device);
         let model = ESMFold2Model::load(vb, cfg.clone()).unwrap();
-        let runner = ESMFold2Runner { model, config: cfg, device: device.clone(), backbone: None };
+        let runner = ESMFold2Runner {
+            model,
+            config: cfg,
+            device: device.clone(),
+            backbone: None,
+        };
 
         let seq = "ACDEFGHIK"; // 9 residues
         let out = runner.fold_protein(seq, 1, 2).unwrap();
@@ -281,8 +292,7 @@ mod tests {
     #[ignore = "requires biohub/ESMFold2-Fast (~755 MB) + biohub/ESMC-6B (~12 GB)"]
     fn test_esmfold2_fold_with_backbone() -> Result<()> {
         let device = Device::Cpu;
-        let runner =
-            ESMFold2Runner::from_pretrained_with_backbone(ESMFold2Models::Fast, device)?;
+        let runner = ESMFold2Runner::from_pretrained_with_backbone(ESMFold2Models::Fast, device)?;
 
         let seq = "MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG";
         let out = runner.fold_protein(seq, 3, 14)?;
@@ -291,7 +301,10 @@ mod tests {
         assert_eq!(out.plddt.dims(), &[1, seq.len()]);
 
         let mean_plddt = out.plddt.mean_all()?.to_scalar::<f32>()?;
-        assert!(mean_plddt > 0.5, "expected mean pLDDT > 0.5, got {mean_plddt:.3}");
+        assert!(
+            mean_plddt > 0.5,
+            "expected mean pLDDT > 0.5, got {mean_plddt:.3}"
+        );
 
         Ok(())
     }

--- a/crates/ferritin-plms/src/featurize/structure_features.rs
+++ b/crates/ferritin-plms/src/featurize/structure_features.rs
@@ -1,9 +1,9 @@
 //!  Protein->Tensor utilities useful for Machine Learning
-use super::utilities::{AAAtom, aa1to_int, aa3to1, int_to_aa1, get_nearest_neighbours};
+use super::utilities::{AAAtom, aa1to_int, aa3to1, get_nearest_neighbours, int_to_aa1};
 use crate::ligandmpnn::proteinfeatures::ProteinFeatures;
 use candle_core::{D, DType, Device, IndexOp, Result, Tensor};
-use ferritin_core::{AtomCollection, Model};
 use ferritin_core::info::elements::Element;
+use ferritin_core::{AtomCollection, Model};
 use std::collections::HashSet;
 use strum::IntoEnumIterator;
 
@@ -57,10 +57,10 @@ impl StructureFeatures for AtomCollection {
             .iter_residues_aminoacid()
             .map(|res| res.residue_name().to_string())
             .map(|res| aa3to1(&res))
-            .map(|ch| aa1to_int(ch))
+            .map(aa1to_int)
             .map(|idx| int_to_aa1(idx) as u8)
             .collect();
-        Ok(Tensor::from_iter(s.into_iter(), device)?.reshape((1, n))?)
+        Tensor::from_iter(s, device)?.reshape((1, n))
     }
 
     /// Convert amino acid sequence to numeric representation
@@ -70,9 +70,9 @@ impl StructureFeatures for AtomCollection {
             .iter_residues_aminoacid()
             .map(|res| res.residue_name().to_string())
             .map(|res| aa3to1(&res))
-            .map(|res| aa1to_int(res));
+            .map(aa1to_int);
 
-        Ok(Tensor::from_iter(s, device)?.reshape((1, n))?)
+        Tensor::from_iter(s, device)?.reshape((1, n))
     }
 
     /// Calculate CB for each residue
@@ -142,7 +142,7 @@ impl StructureFeatures for AtomCollection {
         let indices = Tensor::from_slice(
             &[0i64, 1i64, 2i64, 4i64], // index of N/CA/C/O as integers
             (4,),
-            &device,
+            device,
         )?;
         let x = x_37.index_select(&indices, 2)?;
         Ok(ProteinFeatures {
@@ -181,7 +181,7 @@ impl StructureFeatures for AtomCollection {
                 }
             }
         }
-        Tensor::from_vec(backbone_data, (1, res_count, 4, 3), &device)
+        Tensor::from_vec(backbone_data, (1, res_count, 4, 3), device)
     }
 
     /// create numeric Tensor of shape [1, <sequence-length>, 37, 3]
@@ -197,7 +197,7 @@ impl StructureFeatures for AtomCollection {
                 }
             }
         }
-        Tensor::from_vec(atom37_data, (1, res_count, 37, 3), &device)
+        Tensor::from_vec(atom37_data, (1, res_count, 37, 3), device)
     }
 
     // The purpose of this function it to create 3 output tensors that relate
@@ -312,12 +312,11 @@ mod tests {
     #[test]
     fn test_decode_amino_acids_roundtrip() -> candle_core::Result<()> {
         let device = Device::Cpu;
-        let (pdb_file, _temp) = TestFile::protein_01().create_temp().map_err(|e| {
-            candle_core::Error::Msg(format!("test file setup failed: {e}"))
-        })?;
-        let ac = load_structure(pdb_file).map_err(|e| {
-            candle_core::Error::Msg(format!("load_structure failed: {e}"))
-        })?;
+        let (pdb_file, _temp) = TestFile::protein_01()
+            .create_temp()
+            .map_err(|e| candle_core::Error::Msg(format!("test file setup failed: {e}")))?;
+        let ac = load_structure(pdb_file)
+            .map_err(|e| candle_core::Error::Msg(format!("load_structure failed: {e}")))?;
 
         let encoded = ac.encode_amino_acids(&device)?;
         let decoded = ac.decode_amino_acids(&device)?;
@@ -356,12 +355,11 @@ mod tests {
     #[test]
     fn test_decode_amino_acids_shape() -> candle_core::Result<()> {
         let device = Device::Cpu;
-        let (pdb_file, _temp) = TestFile::protein_01().create_temp().map_err(|e| {
-            candle_core::Error::Msg(format!("test file setup failed: {e}"))
-        })?;
-        let ac = load_structure(pdb_file).map_err(|e| {
-            candle_core::Error::Msg(format!("load_structure failed: {e}"))
-        })?;
+        let (pdb_file, _temp) = TestFile::protein_01()
+            .create_temp()
+            .map_err(|e| candle_core::Error::Msg(format!("test file setup failed: {e}")))?;
+        let ac = load_structure(pdb_file)
+            .map_err(|e| candle_core::Error::Msg(format!("load_structure failed: {e}")))?;
 
         let n = ac.iter_residues_aminoacid().count();
         let decoded = ac.decode_amino_acids(&device)?;
@@ -373,12 +371,11 @@ mod tests {
     #[test]
     fn test_encode_amino_acids_shape_and_range() -> candle_core::Result<()> {
         let device = Device::Cpu;
-        let (pdb_file, _temp) = TestFile::protein_01().create_temp().map_err(|e| {
-            candle_core::Error::Msg(format!("test file setup failed: {e}"))
-        })?;
-        let ac = load_structure(pdb_file).map_err(|e| {
-            candle_core::Error::Msg(format!("load_structure failed: {e}"))
-        })?;
+        let (pdb_file, _temp) = TestFile::protein_01()
+            .create_temp()
+            .map_err(|e| candle_core::Error::Msg(format!("test file setup failed: {e}")))?;
+        let ac = load_structure(pdb_file)
+            .map_err(|e| candle_core::Error::Msg(format!("load_structure failed: {e}")))?;
 
         let n = ac.iter_residues_aminoacid().count();
         let encoded = ac.encode_amino_acids(&device)?;
@@ -394,12 +391,11 @@ mod tests {
     /// `get_res_index` returns one entry per amino acid residue.
     #[test]
     fn test_get_res_index_length() -> candle_core::Result<()> {
-        let (pdb_file, _temp) = TestFile::protein_01().create_temp().map_err(|e| {
-            candle_core::Error::Msg(format!("test file setup failed: {e}"))
-        })?;
-        let ac = load_structure(pdb_file).map_err(|e| {
-            candle_core::Error::Msg(format!("load_structure failed: {e}"))
-        })?;
+        let (pdb_file, _temp) = TestFile::protein_01()
+            .create_temp()
+            .map_err(|e| candle_core::Error::Msg(format!("test file setup failed: {e}")))?;
+        let ac = load_structure(pdb_file)
+            .map_err(|e| candle_core::Error::Msg(format!("load_structure failed: {e}")))?;
 
         let n = ac.iter_residues_aminoacid().count();
         let res_index = ac.get_res_index();
@@ -411,12 +407,11 @@ mod tests {
     #[test]
     fn test_create_cb_shape() -> candle_core::Result<()> {
         let device = Device::Cpu;
-        let (pdb_file, _temp) = TestFile::protein_01().create_temp().map_err(|e| {
-            candle_core::Error::Msg(format!("test file setup failed: {e}"))
-        })?;
-        let ac = load_structure(pdb_file).map_err(|e| {
-            candle_core::Error::Msg(format!("load_structure failed: {e}"))
-        })?;
+        let (pdb_file, _temp) = TestFile::protein_01()
+            .create_temp()
+            .map_err(|e| candle_core::Error::Msg(format!("test file setup failed: {e}")))?;
+        let ac = load_structure(pdb_file)
+            .map_err(|e| candle_core::Error::Msg(format!("load_structure failed: {e}")))?;
 
         let n = ac.iter_residues_aminoacid().count();
         let cb = ac.create_cb(&device)?;

--- a/crates/ferritin-plms/src/featurize/utilities.rs
+++ b/crates/ferritin-plms/src/featurize/utilities.rs
@@ -3,7 +3,7 @@ use candle_nn::encoding::one_hot;
 
 // Core biochemistry constants live in ferritin-core; re-export so existing
 // callers (`use crate::featurize::utilities::AAAtom`, etc.) still compile.
-pub use ferritin_core::info::amino_acids::{aa1to_int, aa3to1, int_to_aa1, ALPHABET};
+pub use ferritin_core::info::amino_acids::{ALPHABET, aa1to_int, aa3to1, int_to_aa1};
 pub use ferritin_core::info::atom37::AAAtom;
 
 macro_rules! define_residues {
@@ -187,7 +187,7 @@ pub fn compute_nearest_neighbors(
     let mask_term = ((&mask_2d.to_dtype(DType::F32)? * -1.0)? + 1.0)?;
     let d_adjust = (&masked_distances + mask_term.broadcast_mul(&d_max)?)?;
     let d_adjust = d_adjust.to_dtype(DType::F32)?;
-    Ok(topk_last_dim(&d_adjust, k.min(seq_len))?)
+    topk_last_dim(&d_adjust, k.min(seq_len))
 }
 
 // https://github.com/huggingface/candle/pull/2375/files#diff-e4d52a71060a80ac8c549f2daffcee77f9bf4de8252ad067c47b1c383c3ac828R957
@@ -261,9 +261,8 @@ pub fn calculate_cb(xyz_37: &Tensor) -> Result<Tensor> {
     let a = Tensor::stack(&[&a_x, &a_y, &a_z], 1)?;
 
     // Final CB calculation: -0.58273431 * a + 0.56802827 * b - 0.54067466 * c + CA
-    let cb = (&a * a_coeff)? + (&b * b_coeff)? + (&c * c_coeff)? + &ca;
 
-    Ok(cb?)
+    (&a * a_coeff)? + (&b * b_coeff)? + (&c * c_coeff)? + &ca
 }
 
 /// Custom Cross-Product Fn.
@@ -374,7 +373,7 @@ fn get_score(s: &Tensor, log_probs: &Tensor, mask: &Tensor) -> Result<(Tensor, T
     let s_one_hot = one_hot(s.clone(), 21, 1., 0.)?;
     let loss_per_residue = s_one_hot.mul(&log_probs.neg()?)?.sum(D::Minus1)?;
     let average_loss = loss_per_residue
-        .mul(&mask)?
+        .mul(mask)?
         .sum_keepdim(D::Minus1)?
         .div(&(mask.sum_keepdim(D::Minus1)? + 1e-8f64)?)?
         .squeeze(D::Minus1)?;

--- a/crates/ferritin-plms/src/lib.rs
+++ b/crates/ferritin-plms/src/lib.rs
@@ -5,6 +5,11 @@
 //! cargo run --example amplify
 //! cargo run --example amplify --features metal
 //! ```
+
+// The crate deliberately uses the `foo/mod.rs` + inner `mod foo` layout for
+// each model family, so module_inception is expected throughout.
+#![allow(clippy::module_inception)]
+
 pub use amplify::amplify::{AMPLIFY, AmplifyOutput};
 pub use amplify::amplify_runner::{AmplifyModels, AmplifyRunner};
 pub use amplify::config::AMPLIFYConfig;

--- a/crates/ferritin-plms/src/ligandmpnn/configs.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/configs.rs
@@ -39,6 +39,7 @@ pub struct MPNNExecConfig {
 }
 
 impl MPNNExecConfig {
+    #[allow(clippy::too_many_arguments)] // CLI-driven config; consolidation is ferritin-100.8
     pub fn new(
         device: Device,
         pdb_path: String,

--- a/crates/ferritin-plms/src/ligandmpnn/model.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/model.rs
@@ -3,6 +3,11 @@
 //!
 //! - See the [LigandMPNN Repo](https://github.com/dauparas/LigandMPNN)
 //!
+
+// The layer stacks fold a `Result` accumulator over the encoder/decoder layers;
+// the explicit `fold(Ok(..), ..)` reads more clearly than `try_fold` here.
+#![allow(clippy::manual_try_fold)]
+
 use super::configs::{ModelTypes, ProteinMPNNConfig};
 use super::proteinfeatures::ProteinFeatures;
 use super::proteinfeaturesmodel::ProteinFeaturesModel;
@@ -112,6 +117,7 @@ impl ScoreOutput {
                     pos
                 };
 
+                #[allow(clippy::needless_range_loop)] // aa_idx also names the output amino acid
                 for aa_idx in 0..probs.len() {
                     if probs[aa_idx] > 0.01 {
                         // Only include probabilities above threshold
@@ -494,7 +500,9 @@ impl ProteinMPNN {
                 Ok((h_v, h_e, e_idx))
             }
             ModelTypes::LigandMPNN => {
-                candle_core::bail!("LigandMPNN encode not yet implemented; only ProteinMPNN encode is functional")
+                candle_core::bail!(
+                    "LigandMPNN encode not yet implemented; only ProteinMPNN encode is functional"
+                )
                 //     let (v, e, e_idx, y_nodes, y_edges, y_m) = self.features.forward(feature_dict)?;
                 //     let mut h_v = Tensor::zeros((e.dim(0)?, e.dim(1)?, e.dim(-1)?), device)?;
                 //     let mut h_e = self.w_e.forward(&e)?;

--- a/crates/ferritin-plms/src/ligandmpnn/proteinfeatures.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/proteinfeatures.rs
@@ -49,6 +49,7 @@ impl ProteinFeatures {
     pub fn get_residue_index(&self) -> &Tensor {
         &self.r_idx
     }
+    #[allow(clippy::type_complexity)] // (vocab, tok→id, id→tok) triple; a named type adds little
     pub fn get_encoded(
         &self,
     ) -> Result<(Vec<String>, HashMap<String, usize>, HashMap<usize, String>)> {
@@ -116,13 +117,12 @@ impl ProteinFeatures {
             Some(bias_aa) => {
                 let mut bias_values = vec![0.0f32; 21];
                 for pair in bias_aa.split(',') {
-                    if let Some((aa, value_str)) = pair.split_once(':') {
-                        if let Ok(value) = value_str.parse::<f32>() {
-                            if let Some(aa_char) = aa.chars().next() {
-                                let idx = aa1to_int(aa_char) as usize;
-                                bias_values[idx] = value;
-                            }
-                        }
+                    if let Some((aa, value_str)) = pair.split_once(':')
+                        && let Ok(value) = value_str.parse::<f32>()
+                        && let Some(aa_char) = aa.chars().next()
+                    {
+                        let idx = aa1to_int(aa_char) as usize;
+                        bias_values[idx] = value;
                     }
                 }
                 Tensor::from_slice(&bias_values, 21, device)

--- a/crates/ferritin-plms/src/ligandmpnn/proteinfeaturesmodel.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/proteinfeaturesmodel.rs
@@ -148,6 +148,7 @@ impl ProteinFeaturesModel {
             .gather(edge_indices, 2)?
             .squeeze(D::Minus1)
     }
+    #[allow(clippy::vec_init_then_push)] // long fixed RBF feature list reads better as one-per-line pushes
     pub fn forward(
         &self,
         input_features: &ProteinFeatures,
@@ -158,9 +159,11 @@ impl ProteinFeaturesModel {
         let r_idx = input_features.get_residue_index();
         // Temporary implementation until chain labels are supported
         let chain_labels = Tensor::zeros_like(r_idx)?;
-        let x = (self.augment_eps > 0.0)
-            .then(|| x + x.randn_like(0.0, self.augment_eps as f64)?)
-            .unwrap_or_else(|| Ok(x.clone()))?;
+        let x = if self.augment_eps > 0.0 {
+            x + x.randn_like(0.0, self.augment_eps as f64)?
+        } else {
+            Ok(x.clone())
+        }?;
         let b = (&x.narrow(2, 1, 1)? - &x.narrow(2, 0, 1)?)?
             .squeeze(2)?
             .contiguous()?;
@@ -184,6 +187,8 @@ impl ProteinFeaturesModel {
         let o = x.narrow(2, 3, 1)?.squeeze(2)?.contiguous()?;
 
         let (d_neighbors, e_idx) = self._dist(&ca, mask, self.augment_eps)?;
+        // A long, fixed list of RBF pairwise features; the explicit pushes read
+        // more clearly (one atom-pair per line) than a 25-element vec! literal.
         let mut rbf_all = Vec::new();
         rbf_all.push(self._rbf(&d_neighbors, device)?);
         rbf_all.push(self._get_rbf(&n, &n, &e_idx, device)?);
@@ -271,8 +276,8 @@ impl PositionalEncodings {
         let inverse_mask = (1.0 - &mask)?;
         let d = (clipped.mul(&mask)? + (inverse_mask * ((2.0 * max_rel) + 1.0))?)?;
         let depth = (2 * self.max_relative_feature + 2) as i64;
-        let d_onehot = one_hot(d.to_dtype(DType::U32)?, depth as usize, 1f32, 0f32)?
-            .to_dtype(DType::F32)?;
+        let d_onehot =
+            one_hot(d.to_dtype(DType::U32)?, depth as usize, 1f32, 0f32)?.to_dtype(DType::F32)?;
         self.linear.forward(&d_onehot)
     }
 }

--- a/crates/ferritin-plms/src/utils/residue_constants.rs
+++ b/crates/ferritin-plms/src/utils/residue_constants.rs
@@ -8,7 +8,7 @@
 
 // Re-export core constants from ferritin-core so existing callers don't break.
 pub use ferritin_core::info::atom37::{
-    atom37_index, atom_order, AAAtom, ATOM37_NAMES, NUM_ATOM37, NUM_RESIDUES,
+    AAAtom, ATOM37_NAMES, NUM_ATOM37, NUM_RESIDUES, atom_order, atom37_index,
 };
 
 // ── Chi angle definitions ──────────────────────────────────────────────────
@@ -174,7 +174,8 @@ mod tests {
         assert_eq!(mapping[1], Some(1)); // CA
         assert_eq!(mapping[2], Some(2)); // C
         assert_eq!(mapping[3], Some(4)); // O
-        assert_eq!(mapping[4], None);    // no CB for GLY
+        assert_eq!(mapping[4], None); // no CB for GLY
+        #[allow(clippy::needless_range_loop)] // asserting a fixed index range
         for i in 4..14 {
             assert_eq!(mapping[i], None, "GLY slot {i} should be None");
         }
@@ -201,5 +202,4 @@ mod tests {
         let mapping = atom14_to_atom37_for_residue("UNK");
         assert!(mapping.iter().all(|m| m.is_none()));
     }
-
 }

--- a/crates/ferritin-test-data/src/lib.rs
+++ b/crates/ferritin-test-data/src/lib.rs
@@ -160,7 +160,6 @@ impl TestFile {
     /// use ferritin_test_data::TestFile;
     /// let (mpnn_file, _handle) = TestFile::ligmpnn_gmpnn_01().create_temp()?;
     /// ```
-
     pub fn ligmpnn_gmpnn_01() -> Self {
         Self {
             filebinary: include_bytes!("../data/ligandmpnn/global_label_membrane_mpnn_v_48_020.pt"),

--- a/crates/ferritin/src/lib.rs
+++ b/crates/ferritin/src/lib.rs
@@ -9,8 +9,10 @@ pub use ferritin_bevy as mesh;
 #[cfg(feature = "plms")]
 pub use ferritin_plms as plms;
 
-#[cfg(feature = "molviewspec")]
-pub use ferritin_molviewspec as molviewspec;
+// molviewspec/cellscape integrations are not wired up yet (their features and
+// deps are commented out in Cargo.toml); re-enable these with the features.
+// #[cfg(feature = "molviewspec")]
+// pub use ferritin_molviewspec as molviewspec;
 
 // #[cfg(feature = "cellscape")]
 // pub use ferritin_cellscape as cellscape;


### PR DESCRIPTION
Adds clippy + rustfmt gates to CI (**ferritin-100.5**) and clears the one clippy error blocking them (**ferritin-100.15**).

Two commits, as the issue asked, to keep the diff reviewable:

## 1. Workspace lint/format cleanup
Brings the tree to `cargo clippy --workspace --all-targets -- -D warnings` clean and `cargo fmt --all --check` clean (~65 findings).

- **ferritin-100.15**: `esmc.rs` `residue_scaling_factor` for the 600M size was `(36f64 / 36.).sqrt()`, which tripped `clippy::eq_op` as an **error** and blocked compilation. Written directly as `1.0` with the `sqrt(n_layers/36)` formula in a comment.
- Autofixable lints via `clippy --fix` (needless borrows, redundant closures, `len_zero`, `manual_range_contains`, `collapsible_if`, …).
- Targeted `#[allow(...)]` with a one-line reason where the code reads better as written: `needless_range_loop` over tensor indices, `too_many_arguments` on config/constructor signatures (grouping is 100.8), `manual_try_fold` over layer stacks, `type_complexity` on tuple returns and Bevy queries, `module_inception` (deliberate `foo/mod.rs` layout — crate-level), `large_enum_variant` on an untagged serde enum, `assertions_on_constants` on invariant-guard tests.
- Real fixes for mechanical ones: `strip_prefix`, `&mut [_]` over `&mut Vec`, orphaned doc comments, unnecessary parens, doc indentation, unused fields marked `#[allow(dead_code)]`, and the not-wired-up `molviewspec` re-export commented out to match its `Cargo.toml`.
- `cargo fmt --all` normalises long-standing formatting drift (the bulk of the line count).

## 2. CI gate
Adds to `.github/workflows/tests.yaml` (after the all-targets check), with the `clippy, rustfmt` toolchain components:

```yaml
- name: Format
  run: cargo fmt --all --check
- name: Clippy
  run: cargo clippy --workspace --all-targets -- -D warnings
```

## Test plan
`cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all --check` both pass locally; `cargo test -p ferritin-plms -p ferritin-core` green (behaviour-preserving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
