### PR TITLE
Fix justfile recipes referencing removed ferritin-structure-mesh (ferritin-nzn)

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 
 build:
-    cargo build -p  ferritin-core -p ferritin-structure-mesh
+    cargo build -p ferritin-core
 
 
 # convert all PSEs to msvj folders
@@ -21,7 +21,7 @@ serve: docs
     quarto preview docs
 
 clean:
-    cargo clean -p ferritin-core  -p ferritin-structure-mesh
+    cargo clean -p ferritin-core
     cargo clean --doc
     rm -rf docs/doc/
     rm -rf docs/examples/example


### PR DESCRIPTION
Fixes **ferritin-nzn** — the `justfile` `build`/`clean` recipes referenced `ferritin-structure-mesh`, a crate that was removed, so `just build` (and `just docs`, which depends on it) failed with:

```
error: package ID specification `ferritin-structure-mesh` did not match any packages
```

keeping Docs CI red (the `docs` workflow runs `just docs`).

`ferritin-pymol` is excluded from the workspace (commented out in the root `Cargo.toml`), so it can't be a `-p` target either. The recipes' role in the `docs` chain is just a pre-doc compile, so they now build/clean `ferritin-core` alone. Also removed the stray double spaces.

Verified `just build` succeeds locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
