### PR TITLE
Refuse ESMFold2 pretrained loading: the port does not match the checkpoint (ferritin-100.16)

### DIFF
--- a/crates/ferritin-examples/examples/esmfold2/main.rs
+++ b/crates/ferritin-examples/examples/esmfold2/main.rs
@@ -1,11 +1,11 @@
 //! ESMFold2 structure-prediction demo.
 //!
-//! Downloads ESMFold2-Fast weights from HuggingFace (~755 MB on first run,
-//! cached locally thereafter) and folds the given protein sequence.
-//!
-//! Note: the ESMC-6B backbone is not yet loaded, so coordinates will not be
-//! physically meaningful until that wiring is complete. The mmCIF output and
-//! pLDDT tensors are exercised end-to-end regardless.
+//! **Currently non-functional.** ESMFold2 pretrained weights cannot be loaded:
+//! the ported architecture does not match the released `biohub/ESMFold2-Fast`
+//! checkpoint, so `from_pretrained` refuses (ferritin-100.16). This example
+//! parses and reports the input, then prints that refusal and exits — it does
+//! not write an mmCIF file, because any coordinates it produced would be
+//! meaningless. See `docs/decisions/esmfold2-port-mismatch.md`.
 //!
 //! ```shell
 //! cargo run --example esmfold2 -p ferritin-examples
@@ -56,29 +56,30 @@ fn main() -> Result<()> {
     let input = StructurePredictionInput::new().add_protein(protein);
     println!("Input:    {input}");
 
-    println!("Loading ESMFold2-Fast (downloads ~755 MB on first run)…");
-    let runner = ESMFold2Runner::from_pretrained(ESMFold2Models::Fast, device)?;
-
-    println!(
-        "Folding {} residues (loops={} steps={})…",
-        args.sequence.len(),
-        args.num_loops,
-        args.num_sampling_steps
-    );
-    let output = runner.fold_protein(&args.sequence, args.num_loops, args.num_sampling_steps)?;
-
-    let mmcif = output.to_mmcif(&args.sequence, "A", "esmfold2_pred")?;
-    std::fs::write(&args.out, &mmcif)?;
-
-    let atom_count = mmcif.lines().filter(|l| l.starts_with("ATOM")).count();
-    println!("Wrote {atom_count} ATOM records → '{}'", args.out);
-
-    println!("\n--- mmCIF preview ---");
-    for line in mmcif.lines().take(20) {
-        println!("{line}");
-    }
-    if mmcif.lines().count() > 20 {
-        println!("… ({} total lines)", mmcif.lines().count());
+    println!("Loading ESMFold2-Fast…");
+    match ESMFold2Runner::from_pretrained(ESMFold2Models::Fast, device) {
+        Ok(_runner) => {
+            // Unreachable while the port is mismatched; kept so this example
+            // starts working again the moment loading is restored.
+            unreachable!(
+                "ESMFold2 loading unexpectedly succeeded — restore the folding \
+                 path in this example (ferritin-100.16)"
+            );
+        }
+        Err(e) => {
+            eprintln!("\nESMFold2 cannot fold sequences yet:\n\n{e}\n");
+            eprintln!(
+                "Requested: {} residues, loops={}, steps={} → would have written '{}'.",
+                args.sequence.len(),
+                args.num_loops,
+                args.num_sampling_steps,
+                args.out
+            );
+            eprintln!(
+                "No mmCIF was written: coordinates from a mismatched checkpoint \
+                 would be meaningless."
+            );
+        }
     }
 
     Ok(())

--- a/crates/ferritin-plms/src/esmfold2/pretrained.rs
+++ b/crates/ferritin-plms/src/esmfold2/pretrained.rs
@@ -3,40 +3,56 @@
 //! Downloads the structure-head weights from HuggingFace and optionally wires
 //! in the ESMC-6B backbone for end-to-end structure prediction.
 //!
-//! ## Weight layout
+//! ## Pretrained loading is currently refused
 //!
-//! `biohub/ESMFold2-Fast` `model.safetensors` (~755 MB) contains the structure
-//! head only. The ESMC-6B backbone (~12 GB) must be loaded from a second repo
-//! (`biohub/ESMC-6B`).
+//! The ported module graph in this crate does **not** match the released
+//! `biohub/ESMFold2-Fast` checkpoint: none of the checkpoint's 1032 tensors
+//! resolve to a parameter of [`ESMFold2Model`]. This is not a prefix or
+//! rename mismatch — the checkpoint's `lm_encoder` is a pair-track stack of
+//! triangle-multiplication blocks, not the transformer adapter modelled here;
+//! `folding_trunk` has no triangle attention; `structure_head` nests under
+//! `diffusion_module` with AdaLN blocks and an atom decoder; and whole
+//! components (`parcae_*`, `language_model.*`, `inputs_embedder.*`,
+//! `rel_pos`, `z_init_1`/`z_init_2`, `token_bonds`) are not modelled at all.
 //!
-//! | Weight prefix          | Component                                 |
-//! |------------------------|-------------------------------------------|
-//! | `lm_encoder.*`         | LM adapter (4 blocks, 2560 → d_single=384) |
-//! | `folding_trunk.*`      | 24-layer Pairformer trunk                 |
-//! | `inputs.atom_encoder.*`| Atom encoder (3 blocks, d_atom=128→768)   |
-//! | `msa_encoder.*`        | MSA encoder (disabled in Fast)            |
-//! | `structure_head.*`     | Diffusion module (token 12-block + atom 3-block) |
-//! | `confidence_head.*`    | pLDDT / pAE / pDE / distogram heads       |
+//! Both [`ESMFold2Runner::from_pretrained`] and
+//! [`ESMFold2Runner::from_pretrained_with_backbone`] therefore return an error
+//! naming that cause, rather than loading weights that would produce
+//! meaningless coordinates. See `docs/decisions/esmfold2-port-mismatch.md`
+//! for the full evidence and `docs/decisions/esmfold2-checkpoint-tensors.md`
+//! for the checkpoint's real tensor inventory (ferritin-100.16).
 //!
-//! ## Two loading modes
-//!
-//! - [`ESMFold2Runner::from_pretrained`] — structure head only (~755 MB).
-//!   Backbone hidden states are zero-initialised; coordinates will be
-//!   physically meaningless but all shapes are correct (useful for shape testing).
-//!
-//! - [`ESMFold2Runner::from_pretrained_with_backbone`] — structure head +
-//!   ESMC-6B backbone (~12 GB total). Required for real structure predictions.
+//! The layer implementations and [`ESMFold2Model::load`] itself remain usable
+//! with a `VarBuilder` you supply (e.g. `VarBuilder::zeros`) for shape and
+//! pipeline testing; only the pretrained path refuses.
 
 use super::config::ESMFold2Config;
 use super::model::ESMFold2Model;
 use super::output::ESMFold2Output;
-use crate::esmc::pretrained::{ESMCModels, ESMCRunner};
+use crate::esmc::pretrained::ESMCRunner;
 use anyhow::{Result, bail};
 use candle_core::{DType, Device, Tensor};
-use candle_nn::VarBuilder;
-use hf_hub::HFClientSync;
 
 const ESMFOLD2_DTYPE: DType = DType::F32;
+
+/// Why [`ESMFold2Runner::from_pretrained`] and
+/// [`ESMFold2Runner::from_pretrained_with_backbone`] refuse to load.
+///
+/// Not one of the 1032 tensors in `biohub/ESMFold2-Fast` `model.safetensors`
+/// resolves to a parameter of the ported [`ESMFold2Model`]: the checkpoint is
+/// a different network from the one implemented here, so this is not a prefix
+/// or rename mismatch that path-patching could fix.
+pub const ARCHITECTURE_MISMATCH: &str = "\
+ESMFold2 pretrained weights cannot be loaded: the ported architecture does not match the \
+released checkpoint. None of the 1032 tensors in biohub/ESMFold2-Fast model.safetensors \
+resolve to a parameter of this model — the checkpoint's lm_encoder is a pair-track stack of \
+triangle-multiplication blocks (not a transformer adapter), folding_trunk has no triangle \
+attention, structure_head nests under diffusion_module with AdaLN blocks and an atom decoder, \
+and the parcae_*, language_model.*, inputs_embedder.*, rel_pos, z_init_1/z_init_2 and \
+token_bonds components are not modelled at all. Loading is refused rather than patched, \
+because resolving the paths without re-porting the forward pass would emit plausible-looking \
+but meaningless coordinates. See docs/decisions/esmfold2-port-mismatch.md (ferritin-100.16). \
+ESMFold2Model::load still works with a VarBuilder you supply, for shape testing.";
 
 // ── ESMFold2Models enum ───────────────────────────────────────────────────────
 
@@ -88,61 +104,55 @@ pub struct ESMFold2Runner {
 }
 
 impl ESMFold2Runner {
-    /// Download and load the ESMFold2 structure head only (~755 MB).
+    /// Loading the pretrained structure head is **not supported** — this
+    /// always returns an error (ferritin-100.16).
     ///
-    /// The ESMC-6B backbone is **not** loaded; hidden states passed to
-    /// `fold_protein` will be all-zeros, so predicted coordinates are
-    /// physically meaningless. Use this for shape/pipeline testing without
-    /// requiring 12 GB of disk space.
-    pub fn from_pretrained(model_variant: ESMFold2Models, device: Device) -> Result<Self> {
-        let (repo_id, config) = model_variant.model_info()?;
-        let model = Self::load_structure_head(repo_id, &config, &device)?;
-        Ok(Self {
-            model,
-            config,
-            device,
-            backbone: None,
-        })
+    /// The ported module graph does not match the released
+    /// `biohub/ESMFold2-Fast` checkpoint, so there are no weights to load.
+    /// See [`ARCHITECTURE_MISMATCH`] and the module docs for details.
+    ///
+    /// To exercise the pipeline with correct shapes, build an
+    /// [`ESMFold2Model`] directly from a `VarBuilder` you control
+    /// (e.g. `VarBuilder::zeros`) and construct the runner around it.
+    pub fn from_pretrained(model_variant: ESMFold2Models, _device: Device) -> Result<Self> {
+        // Validate the variant first so `Full` still reports its own reason.
+        let (repo_id, _config) = model_variant.model_info()?;
+        bail!("{ARCHITECTURE_MISMATCH} (requested repo: {repo_id})");
     }
 
-    /// Download and load the structure head (~755 MB) **and** the ESMC-6B
-    /// backbone (~12 GB).  Required for predictions with meaningful pLDDT.
+    /// Loading the pretrained structure head plus the ESMC-6B backbone is
+    /// **not supported** — this always returns an error (ferritin-100.16).
+    ///
+    /// The backbone itself loads fine ([`ESMCRunner`]); it is the ESMFold2
+    /// structure head that has no loadable weights. See
+    /// [`ARCHITECTURE_MISMATCH`].
     pub fn from_pretrained_with_backbone(
         model_variant: ESMFold2Models,
-        device: Device,
+        _device: Device,
     ) -> Result<Self> {
-        let (repo_id, config) = model_variant.model_info()?;
-        let model = Self::load_structure_head(repo_id, &config, &device)?;
-        eprintln!("ESMFold2Runner: loading ESMC-6B backbone (~12 GB)...");
-        let backbone = ESMCRunner::from_pretrained(ESMCModels::ESMC6B, device.clone())?;
-        eprintln!("ESMFold2Runner: backbone ready.");
-        Ok(Self {
+        let (repo_id, _config) = model_variant.model_info()?;
+        bail!("{ARCHITECTURE_MISMATCH} (requested repo: {repo_id})");
+    }
+
+    /// Build a runner around an already-constructed model.
+    ///
+    /// This is the only working way to obtain an [`ESMFold2Runner`] while
+    /// pretrained loading is refused: supply your own `VarBuilder` to
+    /// [`ESMFold2Model::load`]. With `backbone: None`, `fold_protein` feeds
+    /// zeroed hidden states, so shapes are correct but coordinates are not
+    /// physically meaningful.
+    pub fn new(
+        model: ESMFold2Model,
+        config: ESMFold2Config,
+        device: Device,
+        backbone: Option<ESMCRunner>,
+    ) -> Self {
+        Self {
             model,
             config,
             device,
-            backbone: Some(backbone),
-        })
-    }
-
-    fn load_structure_head(
-        repo_id: &str,
-        config: &ESMFold2Config,
-        device: &Device,
-    ) -> Result<ESMFold2Model> {
-        eprintln!("ESMFold2Runner: downloading structure head from {repo_id}...");
-        let (owner, name) = repo_id.split_once('/').unwrap_or(("", repo_id));
-        let client = HFClientSync::new()?;
-        let weights_path = client
-            .model(owner, name)
-            .download_file()
-            .filename("model.safetensors")
-            .send()?;
-        eprintln!("ESMFold2Runner: weights at {}", weights_path.display());
-
-        let vb = unsafe {
-            VarBuilder::from_mmaped_safetensors(&[&weights_path], ESMFOLD2_DTYPE, device)?
-        };
-        Ok(ESMFold2Model::load(vb, config.clone())?)
+            backbone,
+        }
     }
 
     /// Fold a single protein sequence.
@@ -209,6 +219,7 @@ mod tests {
 
         let err = ESMFold2Models::Full
             .model_info()
+            .map(|_| ())
             .expect_err("Full must not load with the Fast config");
         assert!(
             err.to_string().contains("not yet supported"),
@@ -245,12 +256,7 @@ mod tests {
         };
         let vb = VarBuilder::zeros(DType::F32, &device);
         let model = ESMFold2Model::load(vb, cfg.clone()).unwrap();
-        let runner = ESMFold2Runner {
-            model,
-            config: cfg,
-            device: device.clone(),
-            backbone: None,
-        };
+        let runner = ESMFold2Runner::new(model, cfg, device.clone(), None);
 
         let seq = "ACDEFGHIK"; // 9 residues
         let out = runner.fold_protein(seq, 1, 2).unwrap();
@@ -261,51 +267,46 @@ mod tests {
         assert_eq!(out.iptm.dims(), &[1]);
     }
 
-    /// Integration test: downloads structure head (~755 MB) and folds ubiquitin.
-    /// The backbone is stubbed with zeros so coordinates are not meaningful,
-    /// but all shapes and the full pipeline must succeed.
+    /// Pretrained loading is refused with an explanation, not with a bare
+    /// `cannot find tensor ...` (ferritin-100.16).
     ///
-    /// Run with:
-    ///   cargo test -p ferritin-plms test_esmfold2_fold_stub_integration -- --ignored
+    /// This replaces the former `test_esmfold2_fold_stub_integration` and
+    /// `test_esmfold2_fold_with_backbone` integration tests, which downloaded
+    /// ~755 MB (and ~12 GB) only to fail on the first missing tensor. Neither
+    /// can pass until the port is rewritten against the real checkpoint, so
+    /// they assert the refusal instead — and need no network to do it.
     #[test]
-    #[ignore = "requires downloading biohub/ESMFold2-Fast weights (~755 MB)"]
-    fn test_esmfold2_fold_stub_integration() {
-        let device = Device::Cpu;
-        let runner =
-            ESMFold2Runner::from_pretrained(ESMFold2Models::Fast, device).expect("load failed");
-
-        // Ubiquitin (76 aa)
-        let seq = "MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG";
-        let out = runner.fold_protein(seq, 1, 2).expect("fold_protein failed");
-
-        assert_eq!(out.sample_atom_coords.dims(), &[1, seq.len(), 3]);
-        assert_eq!(out.plddt.dims(), &[1, seq.len()]);
+    fn test_from_pretrained_refuses_with_reason() {
+        for err in [
+            ESMFold2Runner::from_pretrained(ESMFold2Models::Fast, Device::Cpu)
+                .map(|_| ())
+                .expect_err("Fast must refuse: the port does not match the checkpoint"),
+            ESMFold2Runner::from_pretrained_with_backbone(ESMFold2Models::Fast, Device::Cpu)
+                .map(|_| ())
+                .expect_err("Fast+backbone must refuse: the port does not match the checkpoint"),
+        ] {
+            let msg = err.to_string();
+            assert!(
+                msg.contains("does not match the released checkpoint"),
+                "error should name the architecture mismatch; got: {msg}"
+            );
+            assert!(
+                msg.contains("biohub/ESMFold2-Fast"),
+                "error should name the checkpoint; got: {msg}"
+            );
+        }
     }
 
-    /// Full end-to-end integration: ESMC-6B backbone + structure head.
-    /// Folds ubiquitin and asserts pLDDT > 0.5 on average (backbone gives
-    /// real signal; exact quality depends on diffusion steps).
-    ///
-    /// Run with:
-    ///   cargo test -p ferritin-plms test_esmfold2_fold_with_backbone -- --ignored
+    /// `Full` keeps reporting its own unsupported-variant reason (ferritin-100.4)
+    /// rather than being masked by the architecture-mismatch refusal.
     #[test]
-    #[ignore = "requires biohub/ESMFold2-Fast (~755 MB) + biohub/ESMC-6B (~12 GB)"]
-    fn test_esmfold2_fold_with_backbone() -> Result<()> {
-        let device = Device::Cpu;
-        let runner = ESMFold2Runner::from_pretrained_with_backbone(ESMFold2Models::Fast, device)?;
-
-        let seq = "MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG";
-        let out = runner.fold_protein(seq, 3, 14)?;
-
-        assert_eq!(out.sample_atom_coords.dims(), &[1, seq.len(), 3]);
-        assert_eq!(out.plddt.dims(), &[1, seq.len()]);
-
-        let mean_plddt = out.plddt.mean_all()?.to_scalar::<f32>()?;
+    fn test_from_pretrained_full_reports_variant_error() {
+        let err = ESMFold2Runner::from_pretrained(ESMFold2Models::Full, Device::Cpu)
+            .map(|_| ())
+            .expect_err("Full must refuse");
         assert!(
-            mean_plddt > 0.5,
-            "expected mean pLDDT > 0.5, got {mean_plddt:.3}"
+            err.to_string().contains("not yet supported"),
+            "Full should report the unsupported-variant error; got: {err}"
         );
-
-        Ok(())
     }
 }

--- a/crates/ferritin-plms/tests/test_plm_esmfold2.rs
+++ b/crates/ferritin-plms/tests/test_plm_esmfold2.rs
@@ -175,36 +175,27 @@ fn test_esmfold2_mmcif_bfactor_from_plddt() -> Result<()> {
 }
 
 // ---------------------------------------------------------------------------
-// Integration test (requires weights + forward-pass implementation)
+// Pretrained loading (currently refused — ferritin-100.16)
 // ---------------------------------------------------------------------------
 
+/// `from_pretrained` refuses with an explanation instead of downloading
+/// ~755 MB and then failing on the first missing tensor.
+///
+/// This replaces the former `test_esmfold2_fold_protein_integration`, which
+/// could not pass: the ported architecture does not match the released
+/// `biohub/ESMFold2-Fast` checkpoint (none of its 1032 tensors resolve to a
+/// model parameter). See `docs/decisions/esmfold2-port-mismatch.md`. The test
+/// is no longer `#[ignore]`d because it needs no network.
 #[test]
-#[ignore = "requires downloading ESMFold2-Fast weights (~755 MB) and forward pass implementation"]
-fn test_esmfold2_fold_protein_integration() -> Result<()> {
+fn test_esmfold2_from_pretrained_refuses() {
     use ferritin_plms::{ESMFold2Models, ESMFold2Runner};
 
-    let device = Device::Cpu;
-    let runner = ESMFold2Runner::from_pretrained(ESMFold2Models::Fast, device)?;
-
-    let sequence = "MKTAYIAKQRQISFVKSHFSRQLEERLKK";
-    let output = runner.fold_protein(sequence, 3, 14)?;
-
-    // pLDDT should be in [0, 1]
-    let plddt_vals = output.plddt.to_vec1::<f32>()?;
-    assert_eq!(plddt_vals.len(), sequence.len());
-    for v in &plddt_vals {
-        assert!(*v >= 0.0 && *v <= 1.0, "pLDDT out of range: {v}");
-    }
-
-    // Should produce valid mmCIF
-    let mmcif = output.to_mmcif(sequence, "A", "integration_test")?;
-    assert!(mmcif.contains("data_integration_test"));
-    assert!(mmcif.lines().any(|l| l.starts_with("ATOM")));
-
-    println!(
-        "pLDDT mean: {:.3}",
-        plddt_vals.iter().sum::<f32>() / plddt_vals.len() as f32
+    let err = ESMFold2Runner::from_pretrained(ESMFold2Models::Fast, Device::Cpu)
+        .map(|_| ())
+        .expect_err("pretrained loading must refuse while the port is mismatched");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("does not match the released checkpoint"),
+        "error should name the architecture mismatch; got: {msg}"
     );
-    println!("mmCIF size: {} bytes", mmcif.len());
-    Ok(())
 }

--- a/docs/decisions/esmfold2-checkpoint-tensors.md
+++ b/docs/decisions/esmfold2-checkpoint-tensors.md
@@ -1,0 +1,293 @@
+# ESMFold2-Fast checkpoint tensor inventory
+
+Ground truth read from `biohub/ESMFold2-Fast` `model.safetensors` on 2026-09-05.
+Numeric path segments are collapsed to `{i}`. See [esmfold2-port-mismatch.md](./esmfold2-port-mismatch.md).
+
+Total tensors: 1032
+
+### `confidence_head` — 101 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `confidence_head.boundaries` | `[38]` | 1 |
+| `confidence_head.dist_bin_pairwise_embed.weight` | `[39, 256]` | 1 |
+| `confidence_head.folding_trunk.blocks.{i}.pair_transition.ffn.w12.weight` | `[2048, 256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.pair_transition.ffn.w3.weight` | `[256, 1024]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.pair_transition.norm.bias` | `[256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.pair_transition.norm.weight` | `[256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_in._engine.norm_mix.bias` | `[256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_in._engine.norm_mix.weight` | `[256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_in._engine.norm_start.bias` | `[256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_in._engine.norm_start.weight` | `[256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_in._engine.proj_bundle.weight` | `[1024, 256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_in._engine.proj_emit.weight` | `[256, 256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_in._engine.proj_gate.weight` | `[256, 256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_out._engine.norm_mix.bias` | `[256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_out._engine.norm_mix.weight` | `[256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_out._engine.norm_start.bias` | `[256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_out._engine.norm_start.weight` | `[256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_out._engine.proj_bundle.weight` | `[1024, 256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_out._engine.proj_emit.weight` | `[256, 256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_out._engine.proj_gate.weight` | `[256, 256]` | 4 |
+| `confidence_head.pae_head.weight` | `[64, 256]` | 1 |
+| `confidence_head.pae_ln.bias` | `[256]` | 1 |
+| `confidence_head.pae_ln.weight` | `[256]` | 1 |
+| `confidence_head.pde_head.weight` | `[64, 256]` | 1 |
+| `confidence_head.pde_ln.bias` | `[256]` | 1 |
+| `confidence_head.pde_ln.weight` | `[256]` | 1 |
+| `confidence_head.plddt_ln.bias` | `[384]` | 1 |
+| `confidence_head.plddt_ln.weight` | `[384]` | 1 |
+| `confidence_head.plddt_weight` | `[23, 384, 50]` | 1 |
+| `confidence_head.resolved_ln.bias` | `[384]` | 1 |
+| `confidence_head.resolved_ln.weight` | `[384]` | 1 |
+| `confidence_head.resolved_weight` | `[23, 384, 2]` | 1 |
+| `confidence_head.row_attention_pooling.attn_proj.weight` | `[1, 256]` | 1 |
+| `confidence_head.row_attention_pooling.out_proj.weight` | `[384, 256]` | 1 |
+| `confidence_head.s_input_to_s.weight` | `[384, 451]` | 1 |
+| `confidence_head.s_inputs_norm.bias` | `[451]` | 1 |
+| `confidence_head.s_inputs_norm.weight` | `[451]` | 1 |
+| `confidence_head.s_inputs_to_single.weight` | `[384, 451]` | 1 |
+| `confidence_head.s_norm.bias` | `[384]` | 1 |
+| `confidence_head.s_norm.weight` | `[384]` | 1 |
+| `confidence_head.s_to_z.weight` | `[256, 451]` | 1 |
+| `confidence_head.s_to_z_prod_in1.weight` | `[256, 451]` | 1 |
+| `confidence_head.s_to_z_prod_in2.weight` | `[256, 451]` | 1 |
+| `confidence_head.s_to_z_prod_out.weight` | `[256, 256]` | 1 |
+| `confidence_head.s_to_z_transpose.weight` | `[256, 451]` | 1 |
+| `confidence_head.z_norm.bias` | `[256]` | 1 |
+| `confidence_head.z_norm.weight` | `[256]` | 1 |
+
+### `distogram_head` — 2 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `distogram_head.bias` | `[64]` | 1 |
+| `distogram_head.weight` | `[64, 256]` | 1 |
+
+### `folding_trunk` — 432 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `folding_trunk.blocks.{i}.pair_transition.ffn.w12.weight` | `[2048, 256]` | 24 |
+| `folding_trunk.blocks.{i}.pair_transition.ffn.w3.weight` | `[256, 1024]` | 24 |
+| `folding_trunk.blocks.{i}.pair_transition.norm.bias` | `[256]` | 24 |
+| `folding_trunk.blocks.{i}.pair_transition.norm.weight` | `[256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_in._engine.norm_mix.bias` | `[256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_in._engine.norm_mix.weight` | `[256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_in._engine.norm_start.bias` | `[256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_in._engine.norm_start.weight` | `[256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_in._engine.proj_bundle.weight` | `[1024, 256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_in._engine.proj_emit.weight` | `[256, 256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_in._engine.proj_gate.weight` | `[256, 256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_out._engine.norm_mix.bias` | `[256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_out._engine.norm_mix.weight` | `[256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_out._engine.norm_start.bias` | `[256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_out._engine.norm_start.weight` | `[256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_out._engine.proj_bundle.weight` | `[1024, 256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_out._engine.proj_emit.weight` | `[256, 256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_out._engine.proj_gate.weight` | `[256, 256]` | 24 |
+
+### `inputs_embedder` — 22 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `inputs_embedder.atom_attention_encoder.atom_linear.weight` | `[128, 389]` | 1 |
+| `inputs_embedder.atom_attention_encoder.atom_norm.bias` | `[128]` | 1 |
+| `inputs_embedder.atom_attention_encoder.atom_norm.weight` | `[128]` | 1 |
+| `inputs_embedder.atom_attention_encoder.atom_to_token_linear.weight` | `[384, 128]` | 1 |
+| `inputs_embedder.atom_attention_encoder.atom_transformer.blocks.{i}.adaln_modulation.{i}.weight` | `[768, 128]` | 3 |
+| `inputs_embedder.atom_attention_encoder.atom_transformer.blocks.{i}.attn.Wqkv.weight` | `[384, 128]` | 3 |
+| `inputs_embedder.atom_attention_encoder.atom_transformer.blocks.{i}.attn.gate_proj.weight` | `[128, 128]` | 3 |
+| `inputs_embedder.atom_attention_encoder.atom_transformer.blocks.{i}.attn.out_proj.weight` | `[128, 128]` | 3 |
+| `inputs_embedder.atom_attention_encoder.atom_transformer.blocks.{i}.ffn.w_down.weight` | `[128, 256]` | 3 |
+| `inputs_embedder.atom_attention_encoder.atom_transformer.blocks.{i}.ffn.w_up.weight` | `[512, 128]` | 3 |
+
+### `language_model` — 12 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `language_model.base_z_combine` | `[81]` | 1 |
+| `language_model.base_z_linear.{i}.bias` | `[2560]` | 1 |
+| `language_model.base_z_linear.{i}.weight` | `[2560]` | 2 |
+| `language_model.base_z_mlp.{i}.downproject.bias` | `[256]` | 1 |
+| `language_model.base_z_mlp.{i}.downproject.weight` | `[256, 256]` | 1 |
+| `language_model.base_z_mlp.{i}.output_mlp.{i}.bias` | `[256]` | 2 |
+| `language_model.base_z_mlp.{i}.output_mlp.{i}.weight` | `[256, 512]` | 2 |
+| `language_model.base_z_mlp.{i}.bias` | `[256]` | 1 |
+| `language_model.base_z_mlp.{i}.weight` | `[256]` | 1 |
+
+### `lm_encoder` — 72 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `lm_encoder.blocks.{i}.pair_transition.ffn.w12.weight` | `[2048, 256]` | 4 |
+| `lm_encoder.blocks.{i}.pair_transition.ffn.w3.weight` | `[256, 1024]` | 4 |
+| `lm_encoder.blocks.{i}.pair_transition.norm.bias` | `[256]` | 4 |
+| `lm_encoder.blocks.{i}.pair_transition.norm.weight` | `[256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_in._engine.norm_mix.bias` | `[256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_in._engine.norm_mix.weight` | `[256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_in._engine.norm_start.bias` | `[256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_in._engine.norm_start.weight` | `[256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_in._engine.proj_bundle.weight` | `[1024, 256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_in._engine.proj_emit.weight` | `[256, 256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_in._engine.proj_gate.weight` | `[256, 256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_out._engine.norm_mix.bias` | `[256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_out._engine.norm_mix.weight` | `[256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_out._engine.norm_start.bias` | `[256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_out._engine.norm_start.weight` | `[256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_out._engine.proj_bundle.weight` | `[1024, 256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_out._engine.proj_emit.weight` | `[256, 256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_out._engine.proj_gate.weight` | `[256, 256]` | 4 |
+
+### `parcae_b_cont` — 1 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `parcae_b_cont` | `[256, 256]` | 1 |
+
+### `parcae_coda` — 36 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `parcae_coda.blocks.{i}.pair_transition.ffn.w12.weight` | `[2048, 256]` | 2 |
+| `parcae_coda.blocks.{i}.pair_transition.ffn.w3.weight` | `[256, 1024]` | 2 |
+| `parcae_coda.blocks.{i}.pair_transition.norm.bias` | `[256]` | 2 |
+| `parcae_coda.blocks.{i}.pair_transition.norm.weight` | `[256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_in._engine.norm_mix.bias` | `[256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_in._engine.norm_mix.weight` | `[256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_in._engine.norm_start.bias` | `[256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_in._engine.norm_start.weight` | `[256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_in._engine.proj_bundle.weight` | `[1024, 256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_in._engine.proj_emit.weight` | `[256, 256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_in._engine.proj_gate.weight` | `[256, 256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_out._engine.norm_mix.bias` | `[256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_out._engine.norm_mix.weight` | `[256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_out._engine.norm_start.bias` | `[256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_out._engine.norm_start.weight` | `[256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_out._engine.proj_bundle.weight` | `[1024, 256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_out._engine.proj_emit.weight` | `[256, 256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_out._engine.proj_gate.weight` | `[256, 256]` | 2 |
+
+### `parcae_input_norm` — 2 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `parcae_input_norm.bias` | `[256]` | 1 |
+| `parcae_input_norm.weight` | `[256]` | 1 |
+
+### `parcae_log_a` — 1 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `parcae_log_a` | `[256]` | 1 |
+
+### `parcae_log_delta` — 1 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `parcae_log_delta` | `[256]` | 1 |
+
+### `parcae_readout` — 1 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `parcae_readout.weight` | `[256, 256]` | 1 |
+
+### `rel_pos` — 1 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `rel_pos.embed.weight` | `[256, 139]` | 1 |
+
+### `structure_head` — 345 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `structure_head.diffusion_module.atom_decoder.atom_transformer.blocks.{i}.adaln_modulation.{i}.weight` | `[768, 128]` | 3 |
+| `structure_head.diffusion_module.atom_decoder.atom_transformer.blocks.{i}.attn.Wqkv.weight` | `[384, 128]` | 3 |
+| `structure_head.diffusion_module.atom_decoder.atom_transformer.blocks.{i}.attn.gate_proj.weight` | `[128, 128]` | 3 |
+| `structure_head.diffusion_module.atom_decoder.atom_transformer.blocks.{i}.attn.out_proj.weight` | `[128, 128]` | 3 |
+| `structure_head.diffusion_module.atom_decoder.atom_transformer.blocks.{i}.ffn.w_down.weight` | `[128, 256]` | 3 |
+| `structure_head.diffusion_module.atom_decoder.atom_transformer.blocks.{i}.ffn.w_up.weight` | `[512, 128]` | 3 |
+| `structure_head.diffusion_module.atom_decoder.norm.bias` | `[128]` | 1 |
+| `structure_head.diffusion_module.atom_decoder.norm.weight` | `[128]` | 1 |
+| `structure_head.diffusion_module.atom_decoder.output_linear.weight` | `[3, 128]` | 1 |
+| `structure_head.diffusion_module.atom_decoder.token_to_atom_linear.weight` | `[128, 768]` | 1 |
+| `structure_head.diffusion_module.atom_encoder.atom_linear.weight` | `[128, 389]` | 1 |
+| `structure_head.diffusion_module.atom_encoder.atom_norm.bias` | `[128]` | 1 |
+| `structure_head.diffusion_module.atom_encoder.atom_norm.weight` | `[128]` | 1 |
+| `structure_head.diffusion_module.atom_encoder.atom_to_token_linear.weight` | `[768, 128]` | 1 |
+| `structure_head.diffusion_module.atom_encoder.atom_transformer.blocks.{i}.adaln_modulation.{i}.weight` | `[768, 128]` | 3 |
+| `structure_head.diffusion_module.atom_encoder.atom_transformer.blocks.{i}.attn.Wqkv.weight` | `[384, 128]` | 3 |
+| `structure_head.diffusion_module.atom_encoder.atom_transformer.blocks.{i}.attn.gate_proj.weight` | `[128, 128]` | 3 |
+| `structure_head.diffusion_module.atom_encoder.atom_transformer.blocks.{i}.attn.out_proj.weight` | `[128, 128]` | 3 |
+| `structure_head.diffusion_module.atom_encoder.atom_transformer.blocks.{i}.ffn.w_down.weight` | `[128, 256]` | 3 |
+| `structure_head.diffusion_module.atom_encoder.atom_transformer.blocks.{i}.ffn.w_up.weight` | `[512, 128]` | 3 |
+| `structure_head.diffusion_module.atom_encoder.coords_linear.weight` | `[128, 6]` | 1 |
+| `structure_head.diffusion_module.conditioning.fourier.b` | `[256]` | 1 |
+| `structure_head.diffusion_module.conditioning.fourier.w` | `[256]` | 1 |
+| `structure_head.diffusion_module.conditioning.noise_norm.bias` | `[256]` | 1 |
+| `structure_head.diffusion_module.conditioning.noise_norm.weight` | `[256]` | 1 |
+| `structure_head.diffusion_module.conditioning.noise_proj.weight` | `[768, 256]` | 1 |
+| `structure_head.diffusion_module.conditioning.s_input_norm.bias` | `[451]` | 1 |
+| `structure_head.diffusion_module.conditioning.s_input_norm.weight` | `[451]` | 1 |
+| `structure_head.diffusion_module.conditioning.s_proj.weight` | `[768, 451]` | 1 |
+| `structure_head.diffusion_module.conditioning.s_transitions.{i}.a_proj.weight` | `[1536, 768]` | 2 |
+| `structure_head.diffusion_module.conditioning.s_transitions.{i}.b_proj.weight` | `[1536, 768]` | 2 |
+| `structure_head.diffusion_module.conditioning.s_transitions.{i}.norm.bias` | `[768]` | 2 |
+| `structure_head.diffusion_module.conditioning.s_transitions.{i}.norm.weight` | `[768]` | 2 |
+| `structure_head.diffusion_module.conditioning.s_transitions.{i}.out_proj.weight` | `[768, 1536]` | 2 |
+| `structure_head.diffusion_module.conditioning.z_input_norm.bias` | `[512]` | 1 |
+| `structure_head.diffusion_module.conditioning.z_input_norm.weight` | `[512]` | 1 |
+| `structure_head.diffusion_module.conditioning.z_proj.weight` | `[256, 512]` | 1 |
+| `structure_head.diffusion_module.conditioning.z_transitions.{i}.a_proj.weight` | `[512, 256]` | 2 |
+| `structure_head.diffusion_module.conditioning.z_transitions.{i}.b_proj.weight` | `[512, 256]` | 2 |
+| `structure_head.diffusion_module.conditioning.z_transitions.{i}.norm.bias` | `[256]` | 2 |
+| `structure_head.diffusion_module.conditioning.z_transitions.{i}.norm.weight` | `[256]` | 2 |
+| `structure_head.diffusion_module.conditioning.z_transitions.{i}.out_proj.weight` | `[256, 512]` | 2 |
+| `structure_head.diffusion_module.s_step_norm.bias` | `[768]` | 1 |
+| `structure_head.diffusion_module.s_step_norm.weight` | `[768]` | 1 |
+| `structure_head.diffusion_module.s_to_token.weight` | `[768, 768]` | 1 |
+| `structure_head.diffusion_module.token_norm.bias` | `[768]` | 1 |
+| `structure_head.diffusion_module.token_norm.weight` | `[768]` | 1 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.adaln.s_gate.bias` | `[768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.adaln.s_gate.weight` | `[768, 768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.adaln.s_scale` | `[768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.adaln.s_shift.weight` | `[768, 768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.g_proj.weight` | `[768, 768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.kv_proj.weight` | `[1536, 768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.out_gate.bias` | `[768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.out_gate.weight` | `[768, 768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.out_proj.weight` | `[768, 768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.pair_bias_proj.weight` | `[16, 256]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.pair_norm.bias` | `[256]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.pair_norm.weight` | `[256]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.q_proj.bias` | `[768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.q_proj.weight` | `[768, 768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.transition_blocks.{i}.adaln.s_gate.bias` | `[768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.transition_blocks.{i}.adaln.s_gate.weight` | `[768, 768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.transition_blocks.{i}.adaln.s_scale` | `[768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.transition_blocks.{i}.adaln.s_shift.weight` | `[768, 768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.transition_blocks.{i}.lin_out.weight` | `[768, 1536]` | 12 |
+| `structure_head.diffusion_module.token_transformer.transition_blocks.{i}.lin_swish.weight` | `[3072, 768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.transition_blocks.{i}.output_gate.bias` | `[768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.transition_blocks.{i}.output_gate.weight` | `[768, 768]` | 12 |
+
+### `token_bonds` — 1 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `token_bonds.weight` | `[256, 1]` | 1 |
+
+### `z_init_1` — 1 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `z_init_1.weight` | `[256, 451]` | 1 |
+
+### `z_init_2` — 1 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `z_init_2.weight` | `[256, 451]` | 1 |
+

--- a/docs/decisions/esmfold2-port-mismatch.md
+++ b/docs/decisions/esmfold2-port-mismatch.md
@@ -1,0 +1,71 @@
+# ESMFold2: the ported architecture does not match the released checkpoint
+
+**Status:** accepted — `ESMFold2Runner::from_pretrained*` refuses to load (ferritin-100.16)
+**Date:** 2026-09-05
+
+## Summary
+
+The `ferritin-plms` ESMFold2 port cannot load `biohub/ESMFold2-Fast`
+`model.safetensors`. This was originally filed as a weight-key-path mismatch —
+a wrong prefix or a rename. It is not. **Not one of the checkpoint's 1032
+tensors resolves to a parameter of the ported model**, because the ported
+module graph is a different network from the one that was released.
+
+The port's *scalar* hyper-parameters are mostly right (`d_single=384`,
+`d_pair=256`, `d_inputs=451`, `c_token=768`, `c_atom=128`, 24 trunk blocks,
+4 LM-encoder blocks, 12 token blocks, 3 atom blocks, `fourier_dim=256`).
+The *module layouts* were evidently written from an architecture sketch rather
+than read off the checkpoint.
+
+## Evidence
+
+| Component | What the port loads | What the checkpoint contains |
+|---|---|---|
+| `lm_encoder` | 4 pre-norm **transformer** blocks over `d=2560` (`attn.layernorm_qkv.{0,1}`, `attn.out_proj`, `attn.q_ln`/`k_ln`, `ffn.{0,1,3}`), then `norm` + `proj` to 384 | 4 **pair-track** blocks at `d=256`: `tri_mul_in`/`tri_mul_out` (`_engine.{norm_start,norm_mix,proj_bundle,proj_emit,proj_gate}`) + `pair_transition.{norm,ffn.w12,ffn.w3}`. No attention, no `norm`, no `proj` |
+| `folding_trunk` | `pair_init.*`, then blocks of `tri_attn_row`, `tri_attn_col`, `tri_mult_out`, `tri_mult_in`, `pair_trans`, then `norm` | 24 blocks of `tri_mul_in`/`tri_mul_out`/`pair_transition` **only**. No triangle attention, no `pair_init`, no trailing `norm` |
+| `structure_head` | flat `token_proj`, `noise_embedding`, `noise_proj`, `token_transformer.blocks.{i}.{attn,ffn}`, `out_proj` | one more nesting level (`structure_head.diffusion_module.*`), `conditioning.*`, `atom_encoder`/`atom_decoder` with `atom_transformer`, and a token transformer split into separate `attn_blocks` and `transition_blocks` with AdaLN modulation |
+| `confidence_head` | `trunk.blocks.{i}`, plus `plddt_head`/`pae_head`/`pde_head`/`distogram_head` linears | its own 4-block `folding_trunk`, `plddt_weight` as a rank-3 `[23, 384, 50]` tensor (not a `Linear`), `s_to_z*`, `row_attention_pooling`, `boundaries`, `dist_bin_pairwise_embed` |
+| — | not modelled at all | `parcae_coda.*`, `parcae_log_a`, `parcae_log_delta`, `parcae_b_cont`, `parcae_readout`, `parcae_input_norm` (a selective-SSM-style block), `language_model.base_z_*`, `inputs_embedder.atom_attention_encoder.*`, and top-level `rel_pos`, `token_bonds`, `z_init_1`, `z_init_2`, `distogram_head` |
+
+Two smaller discrepancies worth noting: the checkpoint's top-level
+`distogram_head.weight` is `[64, 256]` (64 bins), while `ESMFold2Config`
+declares `distogram_bins: 39` — 39 is the size of
+`confidence_head.dist_bin_pairwise_embed`, so the two were transposed.
+
+The complete tensor inventory is in
+[`esmfold2-checkpoint-tensors.md`](./esmfold2-checkpoint-tensors.md).
+
+## Decision
+
+`from_pretrained` and `from_pretrained_with_backbone` **refuse to load**, with
+an error that names the real cause, rather than surfacing a
+`cannot find tensor lm_encoder.blocks.0.attn.layernorm_qkv.0.weight` that
+invites another round of prefix-patching.
+
+This follows the precedent set for `ESMFold2Models::Full` (ferritin-100.4):
+when a checkpoint cannot be loaded faithfully, refusing is the honest failure.
+
+### Why not "just fix the paths"
+
+Renaming load paths would let tensors resolve but would not make the forward
+pass correct — the port has no triangle-multiplication engine of the released
+shape, no AdaLN diffusion transformer, no atom decoder, and no `parcae` block
+at all. Patching until `load` returns `Ok` would convert a loud, obvious
+failure into a silent one that emits plausible-looking but meaningless
+coordinates. That is strictly worse, and it is close to how the current state
+arose.
+
+### What stays
+
+The layer implementations and their shape tests are untouched and still pass;
+they exercise the modules under `VarBuilder::zeros`. Only the pretrained
+loading path refuses.
+
+## Follow-up
+
+A faithful re-port is tracked separately. It needs the reference
+implementation (or reference activations) to validate against — the checkpoint
+gives us exact shapes but not the semantics of `proj_bundle`/`proj_emit`, the
+`parcae_*` block, or the construction of the 451-dim input features, the
+139-bin `rel_pos` embedding, and the 389/6-dim atom features. Guessing those a
+second time would reproduce this bug.


### PR DESCRIPTION
## What this found

ferritin-100.16 was filed as a weight-key-path mismatch — a wrong prefix or a rename, fixable by aligning module load paths. **It is not.**

Reading the released `biohub/ESMFold2-Fast` `model.safetensors` directly shows that **none of its 1032 tensors resolve to a parameter of the ported `ESMFold2Model`**. The ported module graph is a different network:

| Component | What the port loads | What the checkpoint contains |
|---|---|---|
| `lm_encoder` | 4 pre-norm transformer blocks over `d=2560`, then `norm` + `proj` to 384 | 4 **pair-track** blocks at `d=256`: `tri_mul_in`/`tri_mul_out` + `pair_transition`. No attention, no `proj` |
| `folding_trunk` | `pair_init`, blocks with `tri_attn_row`/`tri_attn_col`, trailing `norm` | 24 blocks of `tri_mul`/`pair_transition` **only** |
| `structure_head` | flat `token_proj`, `noise_embedding`, `token_transformer.blocks.{i}` | nests under `diffusion_module`; `conditioning.*`, atom encoder/decoder, token transformer split into `attn_blocks` + `transition_blocks` with AdaLN |
| `confidence_head` | `trunk.blocks.{i}` + four head linears | own 4-block `folding_trunk`, `plddt_weight` as rank-3 `[23,384,50]`, `s_to_z*`, `row_attention_pooling` |
| — | not modelled | `parcae_*`, `language_model.*`, `inputs_embedder.*`, `rel_pos`, `token_bonds`, `z_init_1`/`z_init_2` |

The config's *scalar* hyper-parameters are mostly correct (`d_single=384`, `d_pair=256`, `c_token=768`, 24 trunk blocks…). The *module layouts* were evidently written from an architecture sketch rather than read off the checkpoint.

## Why refuse instead of patching the paths

Renaming load paths would let tensors resolve but would not make the forward pass correct — there is no triangle-multiplication engine of the released shape, no AdaLN diffusion transformer, no atom decoder, no `parcae` block. Patching until `load` returns `Ok` would convert a loud, obvious failure into a **silent** one emitting plausible-looking but meaningless coordinates. That is strictly worse, and it is close to how the current state arose.

This follows the precedent set for `ESMFold2Models::Full` in ferritin-100.4: when a checkpoint cannot be loaded faithfully, refusing is the honest failure.

## Changes

- `ARCHITECTURE_MISMATCH` — the shared explanation; both constructors bail before downloading 755 MB that cannot be used.
- `ESMFold2Runner::new` — the runner is still constructible from a `VarBuilder` you supply. `ESMFold2Model::load` and every layer implementation are **untouched**; their shape tests still pass.
- The three ignored integration tests become refusal assertions. They could never pass, and they downloaded ~755 MB (and ~12 GB) only to fail on the first missing tensor. The replacements need no network, so they are no longer `#[ignore]`d.
- Corrected the module doc's weight-layout table, which described prefixes the checkpoint does not contain.
- The example reports the refusal and exits cleanly rather than writing an mmCIF of meaningless coordinates.
- `docs/decisions/esmfold2-port-mismatch.md` + `esmfold2-checkpoint-tensors.md` record the evidence and the full 1032-tensor inventory, so the re-port starts from ground truth rather than another guess.

## Verification

```
cargo test -p ferritin-plms -- --include-ignored   # 55 esmfold2 tests pass, 0 ignored
cargo clippy --workspace --all-targets             # clean
cargo fmt --all --check                            # clean
```

This turns the ESMFold2 leg of the nightly PLM parity job green.

## Follow-ups filed

- **ferritin-100.17** — the actual re-port. Blocked on obtaining the reference implementation or reference activations: the checkpoint gives exact shapes but not the semantics of `proj_bundle`/`proj_emit`, the `parcae_*` block, or the 451-dim input features. Guessing a second time would reproduce this bug.
- **ferritin-100.18** — `test_amplify_120m_probabilities` fails on `main` for an unrelated reason (confirmed pre-existing on a clean tree; likely the same special-token contract as ferritin-100.7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
