### PR TITLE
Single HF weight loader; drop ferritin-test-data as a runtime dep (ferritin-100.6, ferritin-100.10)

### DIFF
--- a/crates/ferritin-examples/examples/esmfold2/main.rs
+++ b/crates/ferritin-examples/examples/esmfold2/main.rs
@@ -1,11 +1,11 @@
 //! ESMFold2 structure-prediction demo.
 //!
-//! Downloads ESMFold2-Fast weights from HuggingFace (~755 MB on first run,
-//! cached locally thereafter) and folds the given protein sequence.
-//!
-//! Note: the ESMC-6B backbone is not yet loaded, so coordinates will not be
-//! physically meaningful until that wiring is complete. The mmCIF output and
-//! pLDDT tensors are exercised end-to-end regardless.
+//! **Currently non-functional.** ESMFold2 pretrained weights cannot be loaded:
+//! the ported architecture does not match the released `biohub/ESMFold2-Fast`
+//! checkpoint, so `from_pretrained` refuses (ferritin-100.16). This example
+//! parses and reports the input, then prints that refusal and exits — it does
+//! not write an mmCIF file, because any coordinates it produced would be
+//! meaningless. See `docs/decisions/esmfold2-port-mismatch.md`.
 //!
 //! ```shell
 //! cargo run --example esmfold2 -p ferritin-examples
@@ -56,29 +56,30 @@ fn main() -> Result<()> {
     let input = StructurePredictionInput::new().add_protein(protein);
     println!("Input:    {input}");
 
-    println!("Loading ESMFold2-Fast (downloads ~755 MB on first run)…");
-    let runner = ESMFold2Runner::from_pretrained(ESMFold2Models::Fast, device)?;
-
-    println!(
-        "Folding {} residues (loops={} steps={})…",
-        args.sequence.len(),
-        args.num_loops,
-        args.num_sampling_steps
-    );
-    let output = runner.fold_protein(&args.sequence, args.num_loops, args.num_sampling_steps)?;
-
-    let mmcif = output.to_mmcif(&args.sequence, "A", "esmfold2_pred")?;
-    std::fs::write(&args.out, &mmcif)?;
-
-    let atom_count = mmcif.lines().filter(|l| l.starts_with("ATOM")).count();
-    println!("Wrote {atom_count} ATOM records → '{}'", args.out);
-
-    println!("\n--- mmCIF preview ---");
-    for line in mmcif.lines().take(20) {
-        println!("{line}");
-    }
-    if mmcif.lines().count() > 20 {
-        println!("… ({} total lines)", mmcif.lines().count());
+    println!("Loading ESMFold2-Fast…");
+    match ESMFold2Runner::from_pretrained(ESMFold2Models::Fast, device) {
+        Ok(_runner) => {
+            // Unreachable while the port is mismatched; kept so this example
+            // starts working again the moment loading is restored.
+            unreachable!(
+                "ESMFold2 loading unexpectedly succeeded — restore the folding \
+                 path in this example (ferritin-100.16)"
+            );
+        }
+        Err(e) => {
+            eprintln!("\nESMFold2 cannot fold sequences yet:\n\n{e}\n");
+            eprintln!(
+                "Requested: {} residues, loops={}, steps={} → would have written '{}'.",
+                args.sequence.len(),
+                args.num_loops,
+                args.num_sampling_steps,
+                args.out
+            );
+            eprintln!(
+                "No mmCIF was written: coordinates from a mismatched checkpoint \
+                 would be meaningless."
+            );
+        }
     }
 
     Ok(())

--- a/crates/ferritin-plms/Cargo.toml
+++ b/crates/ferritin-plms/Cargo.toml
@@ -23,7 +23,6 @@ candle-nn.workspace = true
 candle-transformers.workspace = true
 clap.workspace = true
 ferritin-core = { path = "../ferritin-core" }
-ferritin-test-data = { path = "../ferritin-test-data" }
 hf-hub.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/ferritin-plms/src/amplify/amplify_runner.rs
+++ b/crates/ferritin-plms/src/amplify/amplify_runner.rs
@@ -5,25 +5,26 @@
 use super::super::types::{ContactMap, PseudoProbability};
 use super::amplify::{AMPLIFY, AmplifyOutput};
 use super::config::AMPLIFYConfig;
+use crate::loader::{LoadOptions, WeightSource};
 use crate::plm_runner::PlmRunner;
 use anyhow::{Error as E, Result, anyhow};
-use candle_core::{D, DType, Device, Tensor};
-use candle_nn::VarBuilder;
+use candle_core::{D, Device, Tensor};
 use candle_nn::ops;
-use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
-
-const AMPLIFY_DTYPE: DType = DType::F32;
 
 pub enum AmplifyModels {
     AMP120M,
     AMP350M,
 }
 impl AmplifyModels {
-    pub fn get_model_files(model: Self) -> (&'static str, &'static str) {
+    pub fn get_model_files(model: Self) -> WeightSource {
         match model {
-            AmplifyModels::AMP120M => ("chandar-lab/AMPLIFY_120M", "main"),
-            AmplifyModels::AMP350M => ("chandar-lab/AMPLIFY_350M", "main"),
+            AmplifyModels::AMP120M => {
+                WeightSource::safetensors("chandar-lab/AMPLIFY_120M").at_revision("main")
+            }
+            AmplifyModels::AMP350M => {
+                WeightSource::safetensors("chandar-lab/AMPLIFY_350M").at_revision("main")
+            }
         }
     }
 }
@@ -34,37 +35,16 @@ pub struct AmplifyRunner {
 }
 impl AmplifyRunner {
     pub fn load_model(modeltype: AmplifyModels, device: Device) -> Result<AmplifyRunner> {
-        let (model_id, revision) = AmplifyModels::get_model_files(modeltype);
-        let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id));
-        let client = HFClientSync::new()?;
-        let repo = client.model(owner, name);
-        let (config_filename, tokenizer_filename, weights_filename) = {
-            let config = repo
-                .download_file()
-                .filename("config.json")
-                .revision(revision)
-                .send()?;
-            let tokenizer = repo
-                .download_file()
-                .filename("tokenizer.json")
-                .revision(revision)
-                .send()?;
-            let weights = repo
-                .download_file()
-                .filename("model.safetensors")
-                .revision(revision)
-                .send()?;
-            (config, tokenizer, weights)
-        };
+        let source = AmplifyModels::get_model_files(modeltype);
+        let config_filename = source.fetch("config.json")?;
+        let tokenizer_filename = source.fetch("tokenizer.json")?;
         let config_str = std::fs::read_to_string(config_filename)?;
         let config_str = config_str
             .replace("SwiGLU", "swiglu")
             .replace("Swiglu", "swiglu");
         let config: AMPLIFYConfig = serde_json::from_str(&config_str)?;
         let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
-        let vb = unsafe {
-            VarBuilder::from_mmaped_safetensors(&[weights_filename], AMPLIFY_DTYPE, &device)?
-        };
+        let vb = source.var_builder("model.safetensors", &LoadOptions::new(device))?;
         let model = AMPLIFY::load(vb, &config)?;
         Ok(AmplifyRunner { model, tokenizer })
     }

--- a/crates/ferritin-plms/src/esm2/esm2_runner.rs
+++ b/crates/ferritin-plms/src/esm2/esm2_runner.rs
@@ -2,17 +2,14 @@
 //!
 //! Class for loading and running the ESM2 models
 use super::esm2::{ESM2, ESM2Config, ESM2Output};
+use crate::loader::{LoadOptions, WeightSource};
 use crate::plm_runner::PlmRunner;
 use crate::types::PseudoProbability;
 use anyhow::{Error as E, Result, anyhow};
-use candle_core::{DType, Device, Tensor};
-use candle_nn::VarBuilder;
+use candle_core::{Device, Tensor};
 use candle_nn::ops::softmax;
-use hf_hub::HFClientSync;
 use serde_json;
 use tokenizers::Tokenizer;
-
-const ESM2_DTYPE: DType = DType::F32;
 
 // ESM2 tokenizer: indices 4-23 are the 20 standard amino acids.
 const ESM2_STD_AA: [(usize, char); 20] = [
@@ -47,23 +44,16 @@ pub enum ESM2Models {
     T48_15B,
 }
 impl ESM2Models {
-    pub fn get_model_files(model: Self) -> (&'static str, &'static str, ESM2Config) {
-        match model {
-            Self::T6_8M => ("facebook/esm2_t6_8M_UR50D", "main", ESM2Config::t6_8m()),
-            Self::T12_35M => ("facebook/esm2_t12_35M_UR50D", "main", ESM2Config::t12_35m()),
-            Self::T30_150M => (
-                "facebook/esm2_t30_150M_UR50D",
-                "main",
-                ESM2Config::t30_150m(),
-            ),
-            Self::T33_650M => (
-                "facebook/esm2_t33_650M_UR50D",
-                "main",
-                ESM2Config::t33_650m(),
-            ),
-            Self::T36_3B => ("facebook/esm2_t36_3B_UR50D", "main", ESM2Config::t36_3b()),
-            Self::T48_15B => ("facebook/esm2_t48_15B_UR50D", "main", ESM2Config::t48_15b()),
-        }
+    pub fn get_model_files(model: Self) -> (WeightSource, ESM2Config) {
+        let (repo, config) = match model {
+            Self::T6_8M => ("facebook/esm2_t6_8M_UR50D", ESM2Config::t6_8m()),
+            Self::T12_35M => ("facebook/esm2_t12_35M_UR50D", ESM2Config::t12_35m()),
+            Self::T30_150M => ("facebook/esm2_t30_150M_UR50D", ESM2Config::t30_150m()),
+            Self::T33_650M => ("facebook/esm2_t33_650M_UR50D", ESM2Config::t33_650m()),
+            Self::T36_3B => ("facebook/esm2_t36_3B_UR50D", ESM2Config::t36_3b()),
+            Self::T48_15B => ("facebook/esm2_t48_15B_UR50D", ESM2Config::t48_15b()),
+        };
+        (WeightSource::safetensors(repo).at_revision("main"), config)
     }
 }
 
@@ -74,31 +64,16 @@ pub struct ESM2Runner {
 impl ESM2Runner {
     /// Load model from HuggingFace hub, downloading config.json, tokenizer files, and weights.
     pub fn load_model(modeltype: ESM2Models, device: Device) -> Result<ESM2Runner> {
-        let (model_id, revision, fallback_config) = ESM2Models::get_model_files(modeltype);
-        let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id));
-        let client = HFClientSync::new()?;
-        let repo = client.model(owner, name);
+        let (source, fallback_config) = ESM2Models::get_model_files(modeltype);
         // Try to load config from HF hub; fall back to hardcoded config if unavailable.
-        let config = match repo
-            .download_file()
-            .filename("config.json")
-            .revision(revision)
-            .send()
-        {
-            Ok(config_path) => {
+        let config = match source.fetch_optional("config.json") {
+            Some(config_path) => {
                 let config_str = std::fs::read_to_string(config_path)?;
                 serde_json::from_str::<ESM2Config>(&config_str).unwrap_or(fallback_config)
             }
-            Err(_) => fallback_config,
+            None => fallback_config,
         };
-        let weights_filename = repo
-            .download_file()
-            .filename("model.safetensors")
-            .revision(revision)
-            .send()?;
-        let vb = unsafe {
-            VarBuilder::from_mmaped_safetensors(&[weights_filename], ESM2_DTYPE, &device)?
-        };
+        let vb = source.var_builder("model.safetensors", &LoadOptions::new(device))?;
         let model = ESM2::load(vb, config)?;
         let tokenizer = ESM2::load_tokenizer()?;
         Ok(ESM2Runner { model, tokenizer })

--- a/crates/ferritin-plms/src/esm3/pretrained.rs
+++ b/crates/ferritin-plms/src/esm3/pretrained.rs
@@ -25,14 +25,10 @@
 use crate::esm3::models::esm3::{ESM3, ESM3Config};
 use crate::esm3::models::vqvae::{StructureTokenEncoder, VqVaeConfig};
 use crate::esm3::tokenization::sequence::tokenize_sequence;
+use crate::loader::{LoadOptions, WeightSource};
 use crate::plm_runner::PlmRunner;
-use anyhow::{Context, Result};
-use candle_core::pickle::PthTensors;
-use candle_core::{DType, Device, Tensor};
-use candle_nn::VarBuilder;
-use hf_hub::HFClientSync;
-
-const ESM3_DTYPE: DType = DType::F32;
+use anyhow::Result;
+use candle_core::{Device, Tensor};
 
 // ── ESM3Models enum ───────────────────────────────────────────────────────────
 
@@ -42,15 +38,14 @@ pub enum ESM3Models {
     SmOpen,
 }
 
+/// The `esm3-sm-open-v1` repo, whose `.pth` checkpoints store tensors at the root.
+const ESM3_REPO: WeightSource = WeightSource::pth("EvolutionaryScale/esm3-sm-open-v1", None);
+
 impl ESM3Models {
-    /// HuggingFace repo and `.pth` filename for this variant.
-    pub fn model_info(&self) -> (&'static str, &'static str, ESM3Config) {
+    /// Weight source, `.pth` filename, and config for this variant.
+    pub fn model_info(&self) -> (WeightSource, &'static str, ESM3Config) {
         match self {
-            Self::SmOpen => (
-                "EvolutionaryScale/esm3-sm-open-v1",
-                "esm3_sm_open_v1.pth",
-                ESM3Config::sm_open(),
-            ),
+            Self::SmOpen => (ESM3_REPO, "esm3_sm_open_v1.pth", ESM3Config::sm_open()),
         }
     }
 }
@@ -74,21 +69,8 @@ impl ESM3Runner {
     ///
     /// The `.pth` checkpoint is loaded directly via `candle_core::pickle::PthTensors`.
     pub fn from_pretrained(variant: ESM3Models, device: Device) -> Result<Self> {
-        let (repo_id, filename, config) = variant.model_info();
-        let (owner, name) = repo_id.split_once('/').unwrap_or(("", repo_id));
-
-        let client = HFClientSync::new().context("failed to initialise HF client")?;
-        let weights_path = client
-            .model(owner, name)
-            .download_file()
-            .filename(filename)
-            .send()
-            .with_context(|| format!("failed to download {} from {}", filename, repo_id))?;
-
-        let pth = PthTensors::new(&weights_path, None)
-            .with_context(|| format!("failed to parse {}", weights_path.display()))?;
-        let vb = VarBuilder::from_backend(Box::new(pth), ESM3_DTYPE, device.clone());
-
+        let (source, filename, config) = variant.model_info();
+        let vb = source.var_builder(filename, &LoadOptions::new(device.clone()))?;
         let model = ESM3::load(vb, config)?;
         Ok(Self { model, device })
     }
@@ -145,22 +127,10 @@ pub struct StructureEncoderRunner {
 impl StructureEncoderRunner {
     /// Download and load the structure encoder from HuggingFace.
     pub fn from_pretrained(device: Device) -> Result<Self> {
-        let repo_id = "EvolutionaryScale/esm3-sm-open-v1";
-        let filename = "esm3_structure_encoder_v0.pth";
-        let (owner, name) = repo_id.split_once('/').unwrap_or(("", repo_id));
-
-        let client = HFClientSync::new().context("failed to initialise HF client")?;
-        let weights_path = client
-            .model(owner, name)
-            .download_file()
-            .filename(filename)
-            .send()
-            .with_context(|| format!("failed to download {} from {}", filename, repo_id))?;
-
-        let pth = PthTensors::new(&weights_path, None)
-            .with_context(|| format!("failed to parse {}", weights_path.display()))?;
-        let vb = VarBuilder::from_backend(Box::new(pth), ESM3_DTYPE, device.clone());
-
+        let vb = ESM3_REPO.var_builder(
+            "esm3_structure_encoder_v0.pth",
+            &LoadOptions::new(device.clone()),
+        )?;
         let encoder = StructureTokenEncoder::load(vb, VqVaeConfig::default())?;
         Ok(Self { encoder, device })
     }

--- a/crates/ferritin-plms/src/esmc/pretrained.rs
+++ b/crates/ferritin-plms/src/esmc/pretrained.rs
@@ -31,13 +31,10 @@
 //! code works against both the wrapped and unwrapped formats.
 
 use crate::esmc::models::esmc::{ESMC, ESMCConfig};
+use crate::loader::{LoadOptions, WeightSource, optional_prefix};
 use crate::plm_runner::PlmRunner;
 use anyhow::Result;
-use candle_core::{DType, Device, Tensor};
-use candle_nn::VarBuilder;
-use hf_hub::HFClientSync;
-
-const ESMC_DTYPE: DType = DType::F32;
+use candle_core::{Device, Tensor};
 
 /// Available ESMC model variants hosted on HuggingFace.
 pub enum ESMCModels {
@@ -50,12 +47,21 @@ pub enum ESMCModels {
 }
 
 impl ESMCModels {
-    /// Returns `(hf_repo_id, config)` for this variant.
-    pub fn model_info(&self) -> (&'static str, ESMCConfig) {
+    /// Returns `(weight_source, config)` for this variant.
+    pub fn model_info(&self) -> (WeightSource, ESMCConfig) {
         match self {
-            Self::ESMC300M => ("biohub/ESMC-300M", ESMCConfig::esmc_300m()),
-            Self::ESMC600M => ("biohub/ESMC-600M", ESMCConfig::esmc_600m()),
-            Self::ESMC6B => ("biohub/ESMC-6B", ESMCConfig::esmc_6b()),
+            Self::ESMC300M => (
+                WeightSource::safetensors("biohub/ESMC-300M"),
+                ESMCConfig::esmc_300m(),
+            ),
+            Self::ESMC600M => (
+                WeightSource::safetensors("biohub/ESMC-600M"),
+                ESMCConfig::esmc_600m(),
+            ),
+            Self::ESMC6B => (
+                WeightSource::safetensors("biohub/ESMC-6B"),
+                ESMCConfig::esmc_6b(),
+            ),
         }
     }
 }
@@ -73,29 +79,10 @@ impl ESMCRunner {
     /// VarBuilder root to `vb.pp("esmc")` when found, otherwise uses the
     /// flat (unwrapped) layout.
     pub fn from_pretrained(model: ESMCModels, device: Device) -> Result<Self> {
-        let (repo_id, config) = model.model_info();
-        let (owner, name) = repo_id.split_once('/').unwrap_or(("", repo_id));
-        let client = HFClientSync::new()?;
-        let weights_path = client
-            .model(owner, name)
-            .download_file()
-            .filename("model.safetensors")
-            .send()?;
-
-        let vb =
-            unsafe { VarBuilder::from_mmaped_safetensors(&[&weights_path], ESMC_DTYPE, &device)? };
-
-        // Detect whether weights use the HF ESMCForMaskedLM prefix "esmc."
-        // by probing for the embedding matrix at the prefixed path.
-        let vb_root = if vb
-            .get((config.embedding_dim, config.d_model), "esmc.embed.weight")
-            .is_ok()
-        {
-            vb.pp("esmc")
-        } else {
-            vb
-        };
-
+        let (source, config) = model.model_info();
+        let vb = source.var_builder("model.safetensors", &LoadOptions::new(device))?;
+        // Weights saved from ESMCForMaskedLM nest the backbone under "esmc".
+        let vb_root = optional_prefix(vb, "esmc", "embed.weight");
         let esmc = ESMC::load(vb_root, config)?;
         Ok(Self { model: esmc })
     }

--- a/crates/ferritin-plms/src/esmfold2/pretrained.rs
+++ b/crates/ferritin-plms/src/esmfold2/pretrained.rs
@@ -3,40 +3,56 @@
 //! Downloads the structure-head weights from HuggingFace and optionally wires
 //! in the ESMC-6B backbone for end-to-end structure prediction.
 //!
-//! ## Weight layout
+//! ## Pretrained loading is currently refused
 //!
-//! `biohub/ESMFold2-Fast` `model.safetensors` (~755 MB) contains the structure
-//! head only. The ESMC-6B backbone (~12 GB) must be loaded from a second repo
-//! (`biohub/ESMC-6B`).
+//! The ported module graph in this crate does **not** match the released
+//! `biohub/ESMFold2-Fast` checkpoint: none of the checkpoint's 1032 tensors
+//! resolve to a parameter of [`ESMFold2Model`]. This is not a prefix or
+//! rename mismatch — the checkpoint's `lm_encoder` is a pair-track stack of
+//! triangle-multiplication blocks, not the transformer adapter modelled here;
+//! `folding_trunk` has no triangle attention; `structure_head` nests under
+//! `diffusion_module` with AdaLN blocks and an atom decoder; and whole
+//! components (`parcae_*`, `language_model.*`, `inputs_embedder.*`,
+//! `rel_pos`, `z_init_1`/`z_init_2`, `token_bonds`) are not modelled at all.
 //!
-//! | Weight prefix          | Component                                 |
-//! |------------------------|-------------------------------------------|
-//! | `lm_encoder.*`         | LM adapter (4 blocks, 2560 → d_single=384) |
-//! | `folding_trunk.*`      | 24-layer Pairformer trunk                 |
-//! | `inputs.atom_encoder.*`| Atom encoder (3 blocks, d_atom=128→768)   |
-//! | `msa_encoder.*`        | MSA encoder (disabled in Fast)            |
-//! | `structure_head.*`     | Diffusion module (token 12-block + atom 3-block) |
-//! | `confidence_head.*`    | pLDDT / pAE / pDE / distogram heads       |
+//! Both [`ESMFold2Runner::from_pretrained`] and
+//! [`ESMFold2Runner::from_pretrained_with_backbone`] therefore return an error
+//! naming that cause, rather than loading weights that would produce
+//! meaningless coordinates. See `docs/decisions/esmfold2-port-mismatch.md`
+//! for the full evidence and `docs/decisions/esmfold2-checkpoint-tensors.md`
+//! for the checkpoint's real tensor inventory (ferritin-100.16).
 //!
-//! ## Two loading modes
-//!
-//! - [`ESMFold2Runner::from_pretrained`] — structure head only (~755 MB).
-//!   Backbone hidden states are zero-initialised; coordinates will be
-//!   physically meaningless but all shapes are correct (useful for shape testing).
-//!
-//! - [`ESMFold2Runner::from_pretrained_with_backbone`] — structure head +
-//!   ESMC-6B backbone (~12 GB total). Required for real structure predictions.
+//! The layer implementations and [`ESMFold2Model::load`] itself remain usable
+//! with a `VarBuilder` you supply (e.g. `VarBuilder::zeros`) for shape and
+//! pipeline testing; only the pretrained path refuses.
 
 use super::config::ESMFold2Config;
 use super::model::ESMFold2Model;
 use super::output::ESMFold2Output;
-use crate::esmc::pretrained::{ESMCModels, ESMCRunner};
+use crate::esmc::pretrained::ESMCRunner;
 use anyhow::{Result, bail};
 use candle_core::{DType, Device, Tensor};
-use candle_nn::VarBuilder;
-use hf_hub::HFClientSync;
 
 const ESMFOLD2_DTYPE: DType = DType::F32;
+
+/// Why [`ESMFold2Runner::from_pretrained`] and
+/// [`ESMFold2Runner::from_pretrained_with_backbone`] refuse to load.
+///
+/// Not one of the 1032 tensors in `biohub/ESMFold2-Fast` `model.safetensors`
+/// resolves to a parameter of the ported [`ESMFold2Model`]: the checkpoint is
+/// a different network from the one implemented here, so this is not a prefix
+/// or rename mismatch that path-patching could fix.
+pub const ARCHITECTURE_MISMATCH: &str = "\
+ESMFold2 pretrained weights cannot be loaded: the ported architecture does not match the \
+released checkpoint. None of the 1032 tensors in biohub/ESMFold2-Fast model.safetensors \
+resolve to a parameter of this model — the checkpoint's lm_encoder is a pair-track stack of \
+triangle-multiplication blocks (not a transformer adapter), folding_trunk has no triangle \
+attention, structure_head nests under diffusion_module with AdaLN blocks and an atom decoder, \
+and the parcae_*, language_model.*, inputs_embedder.*, rel_pos, z_init_1/z_init_2 and \
+token_bonds components are not modelled at all. Loading is refused rather than patched, \
+because resolving the paths without re-porting the forward pass would emit plausible-looking \
+but meaningless coordinates. See docs/decisions/esmfold2-port-mismatch.md (ferritin-100.16). \
+ESMFold2Model::load still works with a VarBuilder you supply, for shape testing.";
 
 // ── ESMFold2Models enum ───────────────────────────────────────────────────────
 
@@ -88,61 +104,55 @@ pub struct ESMFold2Runner {
 }
 
 impl ESMFold2Runner {
-    /// Download and load the ESMFold2 structure head only (~755 MB).
+    /// Loading the pretrained structure head is **not supported** — this
+    /// always returns an error (ferritin-100.16).
     ///
-    /// The ESMC-6B backbone is **not** loaded; hidden states passed to
-    /// `fold_protein` will be all-zeros, so predicted coordinates are
-    /// physically meaningless. Use this for shape/pipeline testing without
-    /// requiring 12 GB of disk space.
-    pub fn from_pretrained(model_variant: ESMFold2Models, device: Device) -> Result<Self> {
-        let (repo_id, config) = model_variant.model_info()?;
-        let model = Self::load_structure_head(repo_id, &config, &device)?;
-        Ok(Self {
-            model,
-            config,
-            device,
-            backbone: None,
-        })
+    /// The ported module graph does not match the released
+    /// `biohub/ESMFold2-Fast` checkpoint, so there are no weights to load.
+    /// See [`ARCHITECTURE_MISMATCH`] and the module docs for details.
+    ///
+    /// To exercise the pipeline with correct shapes, build an
+    /// [`ESMFold2Model`] directly from a `VarBuilder` you control
+    /// (e.g. `VarBuilder::zeros`) and construct the runner around it.
+    pub fn from_pretrained(model_variant: ESMFold2Models, _device: Device) -> Result<Self> {
+        // Validate the variant first so `Full` still reports its own reason.
+        let (repo_id, _config) = model_variant.model_info()?;
+        bail!("{ARCHITECTURE_MISMATCH} (requested repo: {repo_id})");
     }
 
-    /// Download and load the structure head (~755 MB) **and** the ESMC-6B
-    /// backbone (~12 GB).  Required for predictions with meaningful pLDDT.
+    /// Loading the pretrained structure head plus the ESMC-6B backbone is
+    /// **not supported** — this always returns an error (ferritin-100.16).
+    ///
+    /// The backbone itself loads fine ([`ESMCRunner`]); it is the ESMFold2
+    /// structure head that has no loadable weights. See
+    /// [`ARCHITECTURE_MISMATCH`].
     pub fn from_pretrained_with_backbone(
         model_variant: ESMFold2Models,
-        device: Device,
+        _device: Device,
     ) -> Result<Self> {
-        let (repo_id, config) = model_variant.model_info()?;
-        let model = Self::load_structure_head(repo_id, &config, &device)?;
-        eprintln!("ESMFold2Runner: loading ESMC-6B backbone (~12 GB)...");
-        let backbone = ESMCRunner::from_pretrained(ESMCModels::ESMC6B, device.clone())?;
-        eprintln!("ESMFold2Runner: backbone ready.");
-        Ok(Self {
+        let (repo_id, _config) = model_variant.model_info()?;
+        bail!("{ARCHITECTURE_MISMATCH} (requested repo: {repo_id})");
+    }
+
+    /// Build a runner around an already-constructed model.
+    ///
+    /// This is the only working way to obtain an [`ESMFold2Runner`] while
+    /// pretrained loading is refused: supply your own `VarBuilder` to
+    /// [`ESMFold2Model::load`]. With `backbone: None`, `fold_protein` feeds
+    /// zeroed hidden states, so shapes are correct but coordinates are not
+    /// physically meaningful.
+    pub fn new(
+        model: ESMFold2Model,
+        config: ESMFold2Config,
+        device: Device,
+        backbone: Option<ESMCRunner>,
+    ) -> Self {
+        Self {
             model,
             config,
             device,
-            backbone: Some(backbone),
-        })
-    }
-
-    fn load_structure_head(
-        repo_id: &str,
-        config: &ESMFold2Config,
-        device: &Device,
-    ) -> Result<ESMFold2Model> {
-        eprintln!("ESMFold2Runner: downloading structure head from {repo_id}...");
-        let (owner, name) = repo_id.split_once('/').unwrap_or(("", repo_id));
-        let client = HFClientSync::new()?;
-        let weights_path = client
-            .model(owner, name)
-            .download_file()
-            .filename("model.safetensors")
-            .send()?;
-        eprintln!("ESMFold2Runner: weights at {}", weights_path.display());
-
-        let vb = unsafe {
-            VarBuilder::from_mmaped_safetensors(&[&weights_path], ESMFOLD2_DTYPE, device)?
-        };
-        Ok(ESMFold2Model::load(vb, config.clone())?)
+            backbone,
+        }
     }
 
     /// Fold a single protein sequence.
@@ -209,6 +219,7 @@ mod tests {
 
         let err = ESMFold2Models::Full
             .model_info()
+            .map(|_| ())
             .expect_err("Full must not load with the Fast config");
         assert!(
             err.to_string().contains("not yet supported"),
@@ -245,12 +256,7 @@ mod tests {
         };
         let vb = VarBuilder::zeros(DType::F32, &device);
         let model = ESMFold2Model::load(vb, cfg.clone()).unwrap();
-        let runner = ESMFold2Runner {
-            model,
-            config: cfg,
-            device: device.clone(),
-            backbone: None,
-        };
+        let runner = ESMFold2Runner::new(model, cfg, device.clone(), None);
 
         let seq = "ACDEFGHIK"; // 9 residues
         let out = runner.fold_protein(seq, 1, 2).unwrap();
@@ -261,51 +267,46 @@ mod tests {
         assert_eq!(out.iptm.dims(), &[1]);
     }
 
-    /// Integration test: downloads structure head (~755 MB) and folds ubiquitin.
-    /// The backbone is stubbed with zeros so coordinates are not meaningful,
-    /// but all shapes and the full pipeline must succeed.
+    /// Pretrained loading is refused with an explanation, not with a bare
+    /// `cannot find tensor ...` (ferritin-100.16).
     ///
-    /// Run with:
-    ///   cargo test -p ferritin-plms test_esmfold2_fold_stub_integration -- --ignored
+    /// This replaces the former `test_esmfold2_fold_stub_integration` and
+    /// `test_esmfold2_fold_with_backbone` integration tests, which downloaded
+    /// ~755 MB (and ~12 GB) only to fail on the first missing tensor. Neither
+    /// can pass until the port is rewritten against the real checkpoint, so
+    /// they assert the refusal instead — and need no network to do it.
     #[test]
-    #[ignore = "requires downloading biohub/ESMFold2-Fast weights (~755 MB)"]
-    fn test_esmfold2_fold_stub_integration() {
-        let device = Device::Cpu;
-        let runner =
-            ESMFold2Runner::from_pretrained(ESMFold2Models::Fast, device).expect("load failed");
-
-        // Ubiquitin (76 aa)
-        let seq = "MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG";
-        let out = runner.fold_protein(seq, 1, 2).expect("fold_protein failed");
-
-        assert_eq!(out.sample_atom_coords.dims(), &[1, seq.len(), 3]);
-        assert_eq!(out.plddt.dims(), &[1, seq.len()]);
+    fn test_from_pretrained_refuses_with_reason() {
+        for err in [
+            ESMFold2Runner::from_pretrained(ESMFold2Models::Fast, Device::Cpu)
+                .map(|_| ())
+                .expect_err("Fast must refuse: the port does not match the checkpoint"),
+            ESMFold2Runner::from_pretrained_with_backbone(ESMFold2Models::Fast, Device::Cpu)
+                .map(|_| ())
+                .expect_err("Fast+backbone must refuse: the port does not match the checkpoint"),
+        ] {
+            let msg = err.to_string();
+            assert!(
+                msg.contains("does not match the released checkpoint"),
+                "error should name the architecture mismatch; got: {msg}"
+            );
+            assert!(
+                msg.contains("biohub/ESMFold2-Fast"),
+                "error should name the checkpoint; got: {msg}"
+            );
+        }
     }
 
-    /// Full end-to-end integration: ESMC-6B backbone + structure head.
-    /// Folds ubiquitin and asserts pLDDT > 0.5 on average (backbone gives
-    /// real signal; exact quality depends on diffusion steps).
-    ///
-    /// Run with:
-    ///   cargo test -p ferritin-plms test_esmfold2_fold_with_backbone -- --ignored
+    /// `Full` keeps reporting its own unsupported-variant reason (ferritin-100.4)
+    /// rather than being masked by the architecture-mismatch refusal.
     #[test]
-    #[ignore = "requires biohub/ESMFold2-Fast (~755 MB) + biohub/ESMC-6B (~12 GB)"]
-    fn test_esmfold2_fold_with_backbone() -> Result<()> {
-        let device = Device::Cpu;
-        let runner = ESMFold2Runner::from_pretrained_with_backbone(ESMFold2Models::Fast, device)?;
-
-        let seq = "MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG";
-        let out = runner.fold_protein(seq, 3, 14)?;
-
-        assert_eq!(out.sample_atom_coords.dims(), &[1, seq.len(), 3]);
-        assert_eq!(out.plddt.dims(), &[1, seq.len()]);
-
-        let mean_plddt = out.plddt.mean_all()?.to_scalar::<f32>()?;
+    fn test_from_pretrained_full_reports_variant_error() {
+        let err = ESMFold2Runner::from_pretrained(ESMFold2Models::Full, Device::Cpu)
+            .map(|_| ())
+            .expect_err("Full must refuse");
         assert!(
-            mean_plddt > 0.5,
-            "expected mean pLDDT > 0.5, got {mean_plddt:.3}"
+            err.to_string().contains("not yet supported"),
+            "Full should report the unsupported-variant error; got: {err}"
         );
-
-        Ok(())
     }
 }

--- a/crates/ferritin-plms/src/lib.rs
+++ b/crates/ferritin-plms/src/lib.rs
@@ -39,6 +39,7 @@ pub mod esmc;
 pub mod esmfold2;
 pub mod featurize;
 pub mod ligandmpnn;
+pub mod loader;
 pub mod plm_runner;
 pub mod types;
 pub mod utils;

--- a/crates/ferritin-plms/src/ligandmpnn/configs.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/configs.rs
@@ -14,15 +14,13 @@
 //! - `RunConfig` - Runtime execution parameters// Core Configs for handling CLI ARGs and Model Params
 
 use super::model::ProteinMPNN;
+use super::pmpnn_runner::{ProteinMPNNModels, ProteinMPNNRunner};
 use super::proteinfeatures::ProteinFeatures;
 use crate::StructureFeatures;
-use anyhow::Error;
-use candle_core::pickle::PthTensors;
+use anyhow::{Error, anyhow};
 use candle_core::{DType, Device, Tensor};
-use candle_nn::VarBuilder;
 use clap::ValueEnum;
 use ferritin_core::load_structure;
-use ferritin_test_data::TestFile;
 
 /// Responsible for taking CLI args and returning the Features and Model
 ///
@@ -61,21 +59,26 @@ impl MPNNExecConfig {
             device,
         })
     }
-    // Todo: refactor this to use loader.
+    /// Load the weights for `model_type`.
+    ///
+    /// Delegates to [`ProteinMPNNRunner::load_model`], which downloads from
+    /// `zcpbx/ligandmpnn-weights`. This previously extracted an embedded test
+    /// fixture (`TestFile::ligmpnn_pmpnn_01`) to a temp file, which made the
+    /// 37 MB `ferritin-test-data` crate a runtime dependency of every
+    /// downstream consumer (ferritin-100.10).
     pub fn load_model(&self, model_type: ModelTypes) -> Result<ProteinMPNN, Error> {
-        let default_dtype = DType::F32;
         match model_type {
-            ModelTypes::ProteinMPNN => {
-                // this is a hidden dep....
-                // todo: use hf_hub
-                let (mpnn_file, _handle) = TestFile::ligmpnn_pmpnn_01().create_temp()?;
-                let pth = PthTensors::new(mpnn_file, Some("model_state_dict"))?;
-                let vb =
-                    VarBuilder::from_backend(Box::new(pth), default_dtype, self.device.clone());
-                let pconf = ProteinMPNNConfig::proteinmpnn();
-                Ok(ProteinMPNN::load(vb, &pconf).expect("Unable to load the PMPNN Model"))
-            }
-            _ => panic!("not implented!"),
+            ModelTypes::ProteinMPNN => Ok(ProteinMPNNRunner::load_model(
+                ProteinMPNNModels::V48_020,
+                self.device.clone(),
+            )?
+            .into_model()),
+            // Reachable from `--model-type ligand_mpnn` on the CLI, so this
+            // must be an error rather than a panic (ferritin-100.11).
+            ModelTypes::LigandMPNN => Err(anyhow!(
+                "LigandMPNN weight loading is not implemented; only --model-type protein_mpnn \
+                 is supported (ferritin-100.11)"
+            )),
         }
     }
     pub fn generate_protein_features(&self) -> Result<ProteinFeatures, Error> {
@@ -274,4 +277,61 @@ pub struct RunConfig {
     pub zero_indexed: Option<i32>,
     pub homo_oligomer: Option<i32>,
     pub fasta_seq_separation: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn exec_config() -> MPNNExecConfig {
+        MPNNExecConfig::new(
+            Device::Cpu,
+            // load_model never reads the structure, so a placeholder is fine.
+            "unused.pdb".to_string(),
+            RunConfig {
+                model_type: None,
+                seed: None,
+                temperature: None,
+                verbose: None,
+                save_stats: None,
+                batch_size: None,
+                number_of_batches: None,
+                file_ending: None,
+                zero_indexed: None,
+                homo_oligomer: None,
+                fasta_seq_separation: None,
+            },
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("MPNNExecConfig::new should not fail")
+    }
+
+    /// `--model-type ligand_mpnn` is reachable from the CLI, so the unsupported
+    /// variant must return an error rather than aborting the process
+    /// (ferritin-100.11).
+    #[test]
+    fn test_load_model_ligandmpnn_errors_not_panics() {
+        let err = exec_config()
+            .load_model(ModelTypes::LigandMPNN)
+            .map(|_| ())
+            .expect_err("LigandMPNN is unsupported and must return an error");
+        assert!(
+            err.to_string().contains("not implemented"),
+            "error should say LigandMPNN is unimplemented; got: {err}"
+        );
+    }
+
+    /// The ProteinMPNN branch loads from HuggingFace rather than extracting the
+    /// `ferritin-test-data` fixture it used to depend on (ferritin-100.10).
+    #[test]
+    #[ignore = "downloads zcpbx/ligandmpnn-weights from HuggingFace"]
+    fn test_load_model_proteinmpnn_loads_from_hub() {
+        exec_config()
+            .load_model(ModelTypes::ProteinMPNN)
+            .expect("ProteinMPNN should load from the hub");
+    }
 }

--- a/crates/ferritin-plms/src/ligandmpnn/pmpnn_runner.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/pmpnn_runner.rs
@@ -4,15 +4,16 @@
 use super::configs::ProteinMPNNConfig;
 use super::model::ProteinMPNN;
 use super::proteinfeatures::ProteinFeatures;
+use crate::loader::{Format, LoadOptions, WeightSource, var_builder_from_path};
 use crate::types::PseudoProbability;
 use anyhow::{Result, anyhow};
-use candle_core::pickle::PthTensors;
-use candle_core::{DType, Device, Tensor};
-use candle_nn::VarBuilder;
-use hf_hub::HFClientSync;
+use candle_core::{Device, Tensor};
 use std::path::Path;
 
-const PMPNN_DTYPE: DType = DType::F32;
+/// ProteinMPNN `.pt` checkpoints nest their tensors under `model_state_dict`.
+const PMPNN_FORMAT: Format = Format::Pth {
+    root_key: Some("model_state_dict"),
+};
 
 pub enum ProteinMPNNModels {
     /// proteinmpnn_v_48_020: k_neighbors=48, dropout=0.2
@@ -20,13 +21,12 @@ pub enum ProteinMPNNModels {
 }
 
 impl ProteinMPNNModels {
-    fn hf_info(&self) -> (&'static str, &'static str, &'static str, &'static str) {
-        // (owner, repo, revision, filename)
+    /// Weight source and file for this variant.
+    pub fn hf_info(&self) -> (WeightSource, &'static str) {
         match self {
             Self::V48_020 => (
-                "zcpbx",
-                "ligandmpnn-weights",
-                "main",
+                WeightSource::pth("zcpbx/ligandmpnn-weights", Some("model_state_dict"))
+                    .at_revision("main"),
                 "model_params/proteinmpnn_v_48_020.pt",
             ),
         }
@@ -40,28 +40,28 @@ pub struct ProteinMPNNRunner {
 impl ProteinMPNNRunner {
     /// Load a ProteinMPNN model from HuggingFace hub.
     pub fn load_model(modeltype: ProteinMPNNModels, device: Device) -> Result<Self> {
-        let (owner, repo, revision, filename) = modeltype.hf_info();
-        let client = HFClientSync::new()?;
-        let hf_repo = client.model(owner, repo);
-        let weights_path = hf_repo
-            .download_file()
-            .filename(filename)
-            .revision(revision)
-            .send()
-            .map_err(|e| anyhow!("Failed to download ProteinMPNN weights from HF hub: {e}"))?;
+        let (source, filename) = modeltype.hf_info();
+        let weights_path = source.fetch(filename)?;
         Self::from_path(&weights_path, device)
     }
 
     /// Load from a local .pt file (e.g. from ferritin-test-data or a cached download).
     pub fn from_path(path: impl AsRef<Path>, device: Device) -> Result<Self> {
         let path = path.as_ref();
-        let pth = PthTensors::new(path, Some("model_state_dict"))
-            .map_err(|e| anyhow!("Failed to open {}: {e}", path.display()))?;
-        let vb = VarBuilder::from_backend(Box::new(pth), PMPNN_DTYPE, device);
+        let vb = var_builder_from_path(path, PMPNN_FORMAT, &LoadOptions::new(device))?;
         let config = ProteinMPNNConfig::proteinmpnn();
         let model = ProteinMPNN::load(vb, &config)
             .map_err(|e| anyhow!("Failed to load ProteinMPNN weights: {e}"))?;
         Ok(Self { model })
+    }
+
+    /// Consume the runner and yield the loaded model.
+    ///
+    /// Lets callers that need the bare [`ProteinMPNN`] — such as
+    /// `MPNNExecConfig::load_model` — go through this tested loading path
+    /// instead of duplicating the download (ferritin-100.10).
+    pub fn into_model(self) -> ProteinMPNN {
+        self.model
     }
 
     /// Run ProteinMPNN and return a (L, 21) log-probability tensor for all positions.

--- a/crates/ferritin-plms/src/loader.rs
+++ b/crates/ferritin-plms/src/loader.rs
@@ -1,0 +1,356 @@
+//! One place to describe where a model's weights live and how to load them.
+//!
+//! Before this module every runner reimplemented the same download block:
+//! split the repo id, build an [`HFClientSync`], download a file, then either
+//! `unsafe { VarBuilder::from_mmaped_safetensors(..) }` or
+//! `PthTensors::new(..)`. Six near-identical copies drifted apart — only ESM3
+//! attached any error context, and every one of them inherited the same
+//! silently-wrong repo-id split (`split_once('/').unwrap_or(("", repo_id))`,
+//! which turns a malformed id into an empty owner and a confusing 404 rather
+//! than a clear error).
+//!
+//! The pieces here are:
+//!
+//! - [`WeightSource`] — plain `const` data on each model enum: which repo,
+//!   which revision, and which on-disk [`Format`] the weights use.
+//! - [`LoadOptions`] — the device and dtype to load onto, so the six
+//!   per-module `const *_DTYPE` definitions collapse into one field.
+//! - [`WeightSource::var_builder`] — the single place holding the `unsafe`
+//!   mmap.
+//! - [`optional_prefix`] — the "is this checkpoint wrapped in an HF
+//!   `*ForMaskedLM` class?" probe, generalised from ESMC's `esmc.` special
+//!   case.
+//!
+//! ```no_run
+//! # use ferritin_plms::loader::{LoadOptions, WeightSource};
+//! # use candle_core::Device;
+//! const WEIGHTS: WeightSource = WeightSource::safetensors("facebook/esm2_t6_8M_UR50D");
+//!
+//! let opts = LoadOptions::new(Device::Cpu);
+//! let vb = WEIGHTS.var_builder("model.safetensors", &opts)?;
+//! # Ok::<(), anyhow::Error>(())
+//! ```
+
+use anyhow::{Context, Result, bail};
+use candle_core::pickle::PthTensors;
+use candle_core::{DType, Device};
+use candle_nn::VarBuilder;
+use hf_hub::{HFClientSync, HFRepositorySync, RepoTypeModel};
+use std::path::{Path, PathBuf};
+
+// ── LoadOptions ───────────────────────────────────────────────────────────────
+
+/// Device and dtype to load a model onto.
+///
+/// Defaults to `F32`, which is what every runner used before this existed.
+#[derive(Debug, Clone)]
+pub struct LoadOptions {
+    /// Element type to materialise weights as.
+    pub dtype: DType,
+    /// Device to place weights on.
+    pub device: Device,
+}
+
+impl LoadOptions {
+    /// `F32` on `device`.
+    pub fn new(device: Device) -> Self {
+        Self {
+            dtype: DType::F32,
+            device,
+        }
+    }
+
+    /// Override the dtype (builder style).
+    pub fn with_dtype(mut self, dtype: DType) -> Self {
+        self.dtype = dtype;
+        self
+    }
+}
+
+// ── Format ────────────────────────────────────────────────────────────────────
+
+/// How a checkpoint is stored on disk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Format {
+    /// `.safetensors`, loaded by mmap.
+    Safetensors,
+    /// PyTorch `.pth`/`.pt` pickle.
+    Pth {
+        /// Sub-dictionary holding the tensors, when the checkpoint nests them
+        /// (e.g. ProteinMPNN's `model_state_dict`). `None` = tensors at the root.
+        root_key: Option<&'static str>,
+    },
+}
+
+// ── WeightSource ──────────────────────────────────────────────────────────────
+
+/// Where a model's weights live on the HuggingFace hub, and how to read them.
+///
+/// Intended to be a `const` on each model enum:
+///
+/// ```
+/// # use ferritin_plms::loader::WeightSource;
+/// const AMP120M: WeightSource = WeightSource::safetensors("chandar-lab/AMPLIFY_120M");
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct WeightSource {
+    /// Full `owner/name` repo id.
+    pub repo_id: &'static str,
+    /// Git revision; `None` means the hub default (`main`).
+    pub revision: Option<&'static str>,
+    /// On-disk format of the weight files.
+    pub format: Format,
+}
+
+impl WeightSource {
+    /// A safetensors repo at the default revision.
+    pub const fn safetensors(repo_id: &'static str) -> Self {
+        Self {
+            repo_id,
+            revision: None,
+            format: Format::Safetensors,
+        }
+    }
+
+    /// A PyTorch-pickle repo at the default revision.
+    ///
+    /// `root_key` names the sub-dictionary holding the tensors, or `None` if
+    /// they sit at the root.
+    pub const fn pth(repo_id: &'static str, root_key: Option<&'static str>) -> Self {
+        Self {
+            repo_id,
+            revision: None,
+            format: Format::Pth { root_key },
+        }
+    }
+
+    /// Pin to a specific revision.
+    pub const fn at_revision(mut self, revision: &'static str) -> Self {
+        self.revision = Some(revision);
+        self
+    }
+
+    /// Split and validate `repo_id` into `(owner, name)`.
+    ///
+    /// Unlike `split_once('/').unwrap_or(("", repo_id))` — which every runner
+    /// used to do — a malformed id is an error here rather than an empty owner
+    /// and a 404 several seconds later.
+    fn owner_and_name(&self) -> Result<(&'static str, &'static str)> {
+        let (owner, name) = self.repo_id.split_once('/').ok_or_else(|| {
+            anyhow::anyhow!(
+                "malformed HuggingFace repo id {:?}: expected 'owner/name'",
+                self.repo_id
+            )
+        })?;
+        if owner.is_empty() || name.is_empty() || name.contains('/') {
+            bail!(
+                "malformed HuggingFace repo id {:?}: expected 'owner/name' with both parts non-empty",
+                self.repo_id
+            );
+        }
+        Ok((owner, name))
+    }
+
+    fn repo(&self) -> Result<HFRepositorySync<RepoTypeModel>> {
+        let (owner, name) = self.owner_and_name()?;
+        let client = HFClientSync::new().with_context(|| {
+            format!(
+                "failed to initialise the HuggingFace client while loading {}",
+                self.repo_id
+            )
+        })?;
+        Ok(client.model(owner, name))
+    }
+
+    /// Download `filename`, returning its cached path.
+    ///
+    /// Errors name both the repo and the file — previously only ESM3 did this,
+    /// so a failure elsewhere surfaced as a bare transport error.
+    pub fn fetch(&self, filename: &str) -> Result<PathBuf> {
+        self.repo()?
+            .download_file()
+            .filename(filename.to_string())
+            .maybe_revision(self.revision.map(str::to_string))
+            .send()
+            .with_context(|| format!("failed to download {filename} from {}", self.repo_id))
+    }
+
+    /// Download `filename`, returning `None` if it is absent or unreachable.
+    ///
+    /// For genuinely optional files such as ESM-2's `config.json`, where the
+    /// runner falls back to a built-in config.
+    pub fn fetch_optional(&self, filename: &str) -> Option<PathBuf> {
+        self.fetch(filename).ok()
+    }
+
+    /// Download `filename` and build a [`VarBuilder`] over it.
+    ///
+    /// This is the only place in the crate that performs the safetensors mmap,
+    /// and the only place the dtype is applied.
+    pub fn var_builder(&self, filename: &str, opts: &LoadOptions) -> Result<VarBuilder<'static>> {
+        let path = self.fetch(filename)?;
+        self.var_builder_from_path(&path, opts)
+    }
+
+    /// Build a [`VarBuilder`] over an already-downloaded (or local) file.
+    ///
+    /// Used by loaders that also accept a path directly, such as
+    /// `ProteinMPNNRunner::from_path`.
+    pub fn var_builder_from_path(
+        &self,
+        path: &Path,
+        opts: &LoadOptions,
+    ) -> Result<VarBuilder<'static>> {
+        var_builder_from_path(path, self.format, opts)
+    }
+}
+
+/// Build a [`VarBuilder`] over a local weight file of the given [`Format`].
+///
+/// Free-standing counterpart to [`WeightSource::var_builder_from_path`], for
+/// paths with no associated hub repo.
+pub fn var_builder_from_path(
+    path: &Path,
+    format: Format,
+    opts: &LoadOptions,
+) -> Result<VarBuilder<'static>> {
+    match format {
+        Format::Safetensors => {
+            // SAFETY: mmap of a file we just materialised in the HF cache. As
+            // everywhere in candle, this assumes nothing else mutates the file
+            // while it is mapped.
+            let vb = unsafe {
+                VarBuilder::from_mmaped_safetensors(&[path], opts.dtype, &opts.device)
+                    .with_context(|| format!("failed to mmap {}", path.display()))?
+            };
+            Ok(vb)
+        }
+        Format::Pth { root_key } => {
+            let pth = PthTensors::new(path, root_key)
+                .with_context(|| format!("failed to parse {}", path.display()))?;
+            Ok(VarBuilder::from_backend(
+                Box::new(pth),
+                opts.dtype,
+                opts.device.clone(),
+            ))
+        }
+    }
+}
+
+// ── Optional wrapper prefix ───────────────────────────────────────────────────
+
+/// Descend into `prefix` when the checkpoint nests the backbone under it.
+///
+/// HuggingFace wrapper classes (`EsmForMaskedLM`, `ESMCForMaskedLM`, …) store
+/// the backbone under an attribute, so the same architecture ships both flat
+/// and prefixed. `probe` is a tensor that always exists in the backbone; if
+/// `{prefix}.{probe}` is present the prefixed root is returned, otherwise `vb`
+/// is returned unchanged.
+///
+/// ```no_run
+/// # use ferritin_plms::loader::optional_prefix;
+/// # fn f(vb: candle_nn::VarBuilder<'static>) {
+/// // "esmc.embed.weight" present → root at "esmc", else flat.
+/// let root = optional_prefix(vb, "esmc", "embed.weight");
+/// # }
+/// ```
+pub fn optional_prefix<'a>(vb: VarBuilder<'a>, prefix: &str, probe: &str) -> VarBuilder<'a> {
+    if vb.contains_tensor(&format!("{prefix}.{probe}")) {
+        vb.pp(prefix)
+    } else {
+        vb
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_owner_and_name_splits_valid_id() {
+        let src = WeightSource::safetensors("chandar-lab/AMPLIFY_120M");
+        assert_eq!(
+            src.owner_and_name().unwrap(),
+            ("chandar-lab", "AMPLIFY_120M")
+        );
+    }
+
+    /// The old `split_once('/').unwrap_or(("", repo_id))` turned each of these
+    /// into an empty owner and a confusing 404 after a network round-trip.
+    #[test]
+    fn test_owner_and_name_rejects_malformed_ids() {
+        for bad in ["no-slash", "/leading", "trailing/", "a/b/c", ""] {
+            let err = WeightSource::safetensors(bad)
+                .owner_and_name()
+                .expect_err("{bad} should be rejected");
+            assert!(
+                err.to_string().contains("malformed HuggingFace repo id"),
+                "error should name the malformed id for {bad:?}; got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_revision_defaults_to_none_and_is_pinnable() {
+        let src = WeightSource::safetensors("owner/name");
+        assert_eq!(src.revision, None);
+        assert_eq!(src.at_revision("v2").revision, Some("v2"));
+    }
+
+    #[test]
+    fn test_format_constructors() {
+        assert_eq!(WeightSource::safetensors("o/n").format, Format::Safetensors);
+        assert_eq!(
+            WeightSource::pth("o/n", Some("model_state_dict")).format,
+            Format::Pth {
+                root_key: Some("model_state_dict")
+            }
+        );
+    }
+
+    #[test]
+    fn test_load_options_defaults_to_f32() {
+        let opts = LoadOptions::new(Device::Cpu);
+        assert_eq!(opts.dtype, DType::F32);
+        assert_eq!(opts.with_dtype(DType::F16).dtype, DType::F16);
+    }
+
+    /// `optional_prefix` picks the prefixed root only when the probe resolves.
+    #[test]
+    fn test_optional_prefix_falls_back_when_absent() {
+        use candle_core::Tensor;
+        use std::collections::HashMap;
+
+        let device = Device::Cpu;
+        let mut flat = HashMap::new();
+        flat.insert(
+            "embed.weight".to_string(),
+            Tensor::zeros((2, 2), DType::F32, &device).unwrap(),
+        );
+        let vb = VarBuilder::from_tensors(flat, DType::F32, &device);
+        // No "esmc." prefix present → unchanged, so "embed.weight" resolves.
+        let root = optional_prefix(vb, "esmc", "embed.weight");
+        assert!(root.contains_tensor("embed.weight"));
+    }
+
+    #[test]
+    fn test_optional_prefix_descends_when_present() {
+        use candle_core::Tensor;
+        use std::collections::HashMap;
+
+        let device = Device::Cpu;
+        let mut wrapped = HashMap::new();
+        wrapped.insert(
+            "esmc.embed.weight".to_string(),
+            Tensor::zeros((2, 2), DType::F32, &device).unwrap(),
+        );
+        let vb = VarBuilder::from_tensors(wrapped, DType::F32, &device);
+        let root = optional_prefix(vb, "esmc", "embed.weight");
+        assert!(
+            root.contains_tensor("embed.weight"),
+            "after descending into 'esmc' the leaf should resolve unprefixed"
+        );
+    }
+}

--- a/crates/ferritin-plms/tests/test_plm_esm3.rs
+++ b/crates/ferritin-plms/tests/test_plm_esm3.rs
@@ -212,22 +212,13 @@ fn test_esm3_sm_open_embed_short_sequence() -> Result<()> {
 #[test]
 #[ignore = "requires downloading EvolutionaryScale/esm3-sm-open-v1 weights (~5 GB)"]
 fn test_esm3_sm_open_gfp_logit_shape() -> Result<()> {
-    use candle_core::DType;
-    use candle_core::pickle::PthTensors;
-    use candle_nn::VarBuilder;
-    use hf_hub::HFClientSync;
+    use ferritin_plms::esm3::pretrained::ESM3Models;
+    use ferritin_plms::loader::LoadOptions;
 
     let device = Device::Cpu;
-    let client = HFClientSync::new()?;
-    let weights_path = client
-        .model("EvolutionaryScale", "esm3-sm-open-v1")
-        .download_file()
-        .filename("esm3_sm_open_v1.pth")
-        .send()?;
-
-    let pth = PthTensors::new(&weights_path, None)?;
-    let vb = VarBuilder::from_backend(Box::new(pth), DType::F32, device.clone());
-    let model = ESM3::load(vb, ESM3Config::sm_open())?;
+    let (source, filename, config) = ESM3Models::SmOpen.model_info();
+    let vb = source.var_builder(filename, &LoadOptions::new(device.clone()))?;
+    let model = ESM3::load(vb, config)?;
 
     let token_ids = tokenize_sequence(GFP, true);
     let tokens = Tensor::new(token_ids.as_slice(), &device)?.unsqueeze(0)?;

--- a/crates/ferritin-plms/tests/test_plm_esmc.rs
+++ b/crates/ferritin-plms/tests/test_plm_esmc.rs
@@ -178,29 +178,13 @@ fn test_esmc_300m_embed_gfp() -> Result<()> {
 #[test]
 #[ignore = "requires downloading biohub/ESMC-300M weights (~1.3 GB)"]
 fn test_esmc_300m_logits_shape() -> Result<()> {
-    use candle_core::DType;
-    use candle_nn::VarBuilder;
     use ferritin_plms::esmc::pretrained::ESMCModels as Variants;
-    use hf_hub::HFClientSync;
+    use ferritin_plms::loader::{LoadOptions, optional_prefix};
 
     let device = Device::Cpu;
-    let (repo_id, config) = Variants::ESMC300M.model_info();
-    let (owner, name) = repo_id.split_once('/').unwrap_or(("", repo_id));
-    let client = HFClientSync::new()?;
-    let weights_path = client
-        .model(owner, name)
-        .download_file()
-        .filename("model.safetensors")
-        .send()?;
-    let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[&weights_path], DType::F32, &device)? };
-    let vb_root = if vb
-        .get((config.embedding_dim, config.d_model), "esmc.embed.weight")
-        .is_ok()
-    {
-        vb.pp("esmc")
-    } else {
-        vb
-    };
+    let (source, config) = Variants::ESMC300M.model_info();
+    let vb = source.var_builder("model.safetensors", &LoadOptions::new(device.clone()))?;
+    let vb_root = optional_prefix(vb, "esmc", "embed.weight");
     let model = ESMC::load(vb_root, config)?;
 
     let short_seq = "MQIFVKTLTGKTITLEVEP"; // 19 residues → 21 tokens

--- a/crates/ferritin-plms/tests/test_plm_esmfold2.rs
+++ b/crates/ferritin-plms/tests/test_plm_esmfold2.rs
@@ -175,36 +175,27 @@ fn test_esmfold2_mmcif_bfactor_from_plddt() -> Result<()> {
 }
 
 // ---------------------------------------------------------------------------
-// Integration test (requires weights + forward-pass implementation)
+// Pretrained loading (currently refused — ferritin-100.16)
 // ---------------------------------------------------------------------------
 
+/// `from_pretrained` refuses with an explanation instead of downloading
+/// ~755 MB and then failing on the first missing tensor.
+///
+/// This replaces the former `test_esmfold2_fold_protein_integration`, which
+/// could not pass: the ported architecture does not match the released
+/// `biohub/ESMFold2-Fast` checkpoint (none of its 1032 tensors resolve to a
+/// model parameter). See `docs/decisions/esmfold2-port-mismatch.md`. The test
+/// is no longer `#[ignore]`d because it needs no network.
 #[test]
-#[ignore = "requires downloading ESMFold2-Fast weights (~755 MB) and forward pass implementation"]
-fn test_esmfold2_fold_protein_integration() -> Result<()> {
+fn test_esmfold2_from_pretrained_refuses() {
     use ferritin_plms::{ESMFold2Models, ESMFold2Runner};
 
-    let device = Device::Cpu;
-    let runner = ESMFold2Runner::from_pretrained(ESMFold2Models::Fast, device)?;
-
-    let sequence = "MKTAYIAKQRQISFVKSHFSRQLEERLKK";
-    let output = runner.fold_protein(sequence, 3, 14)?;
-
-    // pLDDT should be in [0, 1]
-    let plddt_vals = output.plddt.to_vec1::<f32>()?;
-    assert_eq!(plddt_vals.len(), sequence.len());
-    for v in &plddt_vals {
-        assert!(*v >= 0.0 && *v <= 1.0, "pLDDT out of range: {v}");
-    }
-
-    // Should produce valid mmCIF
-    let mmcif = output.to_mmcif(sequence, "A", "integration_test")?;
-    assert!(mmcif.contains("data_integration_test"));
-    assert!(mmcif.lines().any(|l| l.starts_with("ATOM")));
-
-    println!(
-        "pLDDT mean: {:.3}",
-        plddt_vals.iter().sum::<f32>() / plddt_vals.len() as f32
+    let err = ESMFold2Runner::from_pretrained(ESMFold2Models::Fast, Device::Cpu)
+        .map(|_| ())
+        .expect_err("pretrained loading must refuse while the port is mismatched");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("does not match the released checkpoint"),
+        "error should name the architecture mismatch; got: {msg}"
     );
-    println!("mmCIF size: {} bytes", mmcif.len());
-    Ok(())
 }

--- a/docs/decisions/esmfold2-checkpoint-tensors.md
+++ b/docs/decisions/esmfold2-checkpoint-tensors.md
@@ -1,0 +1,293 @@
+# ESMFold2-Fast checkpoint tensor inventory
+
+Ground truth read from `biohub/ESMFold2-Fast` `model.safetensors` on 2026-09-05.
+Numeric path segments are collapsed to `{i}`. See [esmfold2-port-mismatch.md](./esmfold2-port-mismatch.md).
+
+Total tensors: 1032
+
+### `confidence_head` — 101 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `confidence_head.boundaries` | `[38]` | 1 |
+| `confidence_head.dist_bin_pairwise_embed.weight` | `[39, 256]` | 1 |
+| `confidence_head.folding_trunk.blocks.{i}.pair_transition.ffn.w12.weight` | `[2048, 256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.pair_transition.ffn.w3.weight` | `[256, 1024]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.pair_transition.norm.bias` | `[256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.pair_transition.norm.weight` | `[256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_in._engine.norm_mix.bias` | `[256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_in._engine.norm_mix.weight` | `[256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_in._engine.norm_start.bias` | `[256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_in._engine.norm_start.weight` | `[256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_in._engine.proj_bundle.weight` | `[1024, 256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_in._engine.proj_emit.weight` | `[256, 256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_in._engine.proj_gate.weight` | `[256, 256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_out._engine.norm_mix.bias` | `[256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_out._engine.norm_mix.weight` | `[256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_out._engine.norm_start.bias` | `[256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_out._engine.norm_start.weight` | `[256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_out._engine.proj_bundle.weight` | `[1024, 256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_out._engine.proj_emit.weight` | `[256, 256]` | 4 |
+| `confidence_head.folding_trunk.blocks.{i}.tri_mul_out._engine.proj_gate.weight` | `[256, 256]` | 4 |
+| `confidence_head.pae_head.weight` | `[64, 256]` | 1 |
+| `confidence_head.pae_ln.bias` | `[256]` | 1 |
+| `confidence_head.pae_ln.weight` | `[256]` | 1 |
+| `confidence_head.pde_head.weight` | `[64, 256]` | 1 |
+| `confidence_head.pde_ln.bias` | `[256]` | 1 |
+| `confidence_head.pde_ln.weight` | `[256]` | 1 |
+| `confidence_head.plddt_ln.bias` | `[384]` | 1 |
+| `confidence_head.plddt_ln.weight` | `[384]` | 1 |
+| `confidence_head.plddt_weight` | `[23, 384, 50]` | 1 |
+| `confidence_head.resolved_ln.bias` | `[384]` | 1 |
+| `confidence_head.resolved_ln.weight` | `[384]` | 1 |
+| `confidence_head.resolved_weight` | `[23, 384, 2]` | 1 |
+| `confidence_head.row_attention_pooling.attn_proj.weight` | `[1, 256]` | 1 |
+| `confidence_head.row_attention_pooling.out_proj.weight` | `[384, 256]` | 1 |
+| `confidence_head.s_input_to_s.weight` | `[384, 451]` | 1 |
+| `confidence_head.s_inputs_norm.bias` | `[451]` | 1 |
+| `confidence_head.s_inputs_norm.weight` | `[451]` | 1 |
+| `confidence_head.s_inputs_to_single.weight` | `[384, 451]` | 1 |
+| `confidence_head.s_norm.bias` | `[384]` | 1 |
+| `confidence_head.s_norm.weight` | `[384]` | 1 |
+| `confidence_head.s_to_z.weight` | `[256, 451]` | 1 |
+| `confidence_head.s_to_z_prod_in1.weight` | `[256, 451]` | 1 |
+| `confidence_head.s_to_z_prod_in2.weight` | `[256, 451]` | 1 |
+| `confidence_head.s_to_z_prod_out.weight` | `[256, 256]` | 1 |
+| `confidence_head.s_to_z_transpose.weight` | `[256, 451]` | 1 |
+| `confidence_head.z_norm.bias` | `[256]` | 1 |
+| `confidence_head.z_norm.weight` | `[256]` | 1 |
+
+### `distogram_head` — 2 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `distogram_head.bias` | `[64]` | 1 |
+| `distogram_head.weight` | `[64, 256]` | 1 |
+
+### `folding_trunk` — 432 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `folding_trunk.blocks.{i}.pair_transition.ffn.w12.weight` | `[2048, 256]` | 24 |
+| `folding_trunk.blocks.{i}.pair_transition.ffn.w3.weight` | `[256, 1024]` | 24 |
+| `folding_trunk.blocks.{i}.pair_transition.norm.bias` | `[256]` | 24 |
+| `folding_trunk.blocks.{i}.pair_transition.norm.weight` | `[256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_in._engine.norm_mix.bias` | `[256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_in._engine.norm_mix.weight` | `[256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_in._engine.norm_start.bias` | `[256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_in._engine.norm_start.weight` | `[256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_in._engine.proj_bundle.weight` | `[1024, 256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_in._engine.proj_emit.weight` | `[256, 256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_in._engine.proj_gate.weight` | `[256, 256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_out._engine.norm_mix.bias` | `[256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_out._engine.norm_mix.weight` | `[256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_out._engine.norm_start.bias` | `[256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_out._engine.norm_start.weight` | `[256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_out._engine.proj_bundle.weight` | `[1024, 256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_out._engine.proj_emit.weight` | `[256, 256]` | 24 |
+| `folding_trunk.blocks.{i}.tri_mul_out._engine.proj_gate.weight` | `[256, 256]` | 24 |
+
+### `inputs_embedder` — 22 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `inputs_embedder.atom_attention_encoder.atom_linear.weight` | `[128, 389]` | 1 |
+| `inputs_embedder.atom_attention_encoder.atom_norm.bias` | `[128]` | 1 |
+| `inputs_embedder.atom_attention_encoder.atom_norm.weight` | `[128]` | 1 |
+| `inputs_embedder.atom_attention_encoder.atom_to_token_linear.weight` | `[384, 128]` | 1 |
+| `inputs_embedder.atom_attention_encoder.atom_transformer.blocks.{i}.adaln_modulation.{i}.weight` | `[768, 128]` | 3 |
+| `inputs_embedder.atom_attention_encoder.atom_transformer.blocks.{i}.attn.Wqkv.weight` | `[384, 128]` | 3 |
+| `inputs_embedder.atom_attention_encoder.atom_transformer.blocks.{i}.attn.gate_proj.weight` | `[128, 128]` | 3 |
+| `inputs_embedder.atom_attention_encoder.atom_transformer.blocks.{i}.attn.out_proj.weight` | `[128, 128]` | 3 |
+| `inputs_embedder.atom_attention_encoder.atom_transformer.blocks.{i}.ffn.w_down.weight` | `[128, 256]` | 3 |
+| `inputs_embedder.atom_attention_encoder.atom_transformer.blocks.{i}.ffn.w_up.weight` | `[512, 128]` | 3 |
+
+### `language_model` — 12 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `language_model.base_z_combine` | `[81]` | 1 |
+| `language_model.base_z_linear.{i}.bias` | `[2560]` | 1 |
+| `language_model.base_z_linear.{i}.weight` | `[2560]` | 2 |
+| `language_model.base_z_mlp.{i}.downproject.bias` | `[256]` | 1 |
+| `language_model.base_z_mlp.{i}.downproject.weight` | `[256, 256]` | 1 |
+| `language_model.base_z_mlp.{i}.output_mlp.{i}.bias` | `[256]` | 2 |
+| `language_model.base_z_mlp.{i}.output_mlp.{i}.weight` | `[256, 512]` | 2 |
+| `language_model.base_z_mlp.{i}.bias` | `[256]` | 1 |
+| `language_model.base_z_mlp.{i}.weight` | `[256]` | 1 |
+
+### `lm_encoder` — 72 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `lm_encoder.blocks.{i}.pair_transition.ffn.w12.weight` | `[2048, 256]` | 4 |
+| `lm_encoder.blocks.{i}.pair_transition.ffn.w3.weight` | `[256, 1024]` | 4 |
+| `lm_encoder.blocks.{i}.pair_transition.norm.bias` | `[256]` | 4 |
+| `lm_encoder.blocks.{i}.pair_transition.norm.weight` | `[256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_in._engine.norm_mix.bias` | `[256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_in._engine.norm_mix.weight` | `[256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_in._engine.norm_start.bias` | `[256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_in._engine.norm_start.weight` | `[256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_in._engine.proj_bundle.weight` | `[1024, 256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_in._engine.proj_emit.weight` | `[256, 256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_in._engine.proj_gate.weight` | `[256, 256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_out._engine.norm_mix.bias` | `[256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_out._engine.norm_mix.weight` | `[256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_out._engine.norm_start.bias` | `[256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_out._engine.norm_start.weight` | `[256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_out._engine.proj_bundle.weight` | `[1024, 256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_out._engine.proj_emit.weight` | `[256, 256]` | 4 |
+| `lm_encoder.blocks.{i}.tri_mul_out._engine.proj_gate.weight` | `[256, 256]` | 4 |
+
+### `parcae_b_cont` — 1 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `parcae_b_cont` | `[256, 256]` | 1 |
+
+### `parcae_coda` — 36 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `parcae_coda.blocks.{i}.pair_transition.ffn.w12.weight` | `[2048, 256]` | 2 |
+| `parcae_coda.blocks.{i}.pair_transition.ffn.w3.weight` | `[256, 1024]` | 2 |
+| `parcae_coda.blocks.{i}.pair_transition.norm.bias` | `[256]` | 2 |
+| `parcae_coda.blocks.{i}.pair_transition.norm.weight` | `[256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_in._engine.norm_mix.bias` | `[256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_in._engine.norm_mix.weight` | `[256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_in._engine.norm_start.bias` | `[256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_in._engine.norm_start.weight` | `[256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_in._engine.proj_bundle.weight` | `[1024, 256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_in._engine.proj_emit.weight` | `[256, 256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_in._engine.proj_gate.weight` | `[256, 256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_out._engine.norm_mix.bias` | `[256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_out._engine.norm_mix.weight` | `[256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_out._engine.norm_start.bias` | `[256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_out._engine.norm_start.weight` | `[256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_out._engine.proj_bundle.weight` | `[1024, 256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_out._engine.proj_emit.weight` | `[256, 256]` | 2 |
+| `parcae_coda.blocks.{i}.tri_mul_out._engine.proj_gate.weight` | `[256, 256]` | 2 |
+
+### `parcae_input_norm` — 2 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `parcae_input_norm.bias` | `[256]` | 1 |
+| `parcae_input_norm.weight` | `[256]` | 1 |
+
+### `parcae_log_a` — 1 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `parcae_log_a` | `[256]` | 1 |
+
+### `parcae_log_delta` — 1 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `parcae_log_delta` | `[256]` | 1 |
+
+### `parcae_readout` — 1 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `parcae_readout.weight` | `[256, 256]` | 1 |
+
+### `rel_pos` — 1 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `rel_pos.embed.weight` | `[256, 139]` | 1 |
+
+### `structure_head` — 345 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `structure_head.diffusion_module.atom_decoder.atom_transformer.blocks.{i}.adaln_modulation.{i}.weight` | `[768, 128]` | 3 |
+| `structure_head.diffusion_module.atom_decoder.atom_transformer.blocks.{i}.attn.Wqkv.weight` | `[384, 128]` | 3 |
+| `structure_head.diffusion_module.atom_decoder.atom_transformer.blocks.{i}.attn.gate_proj.weight` | `[128, 128]` | 3 |
+| `structure_head.diffusion_module.atom_decoder.atom_transformer.blocks.{i}.attn.out_proj.weight` | `[128, 128]` | 3 |
+| `structure_head.diffusion_module.atom_decoder.atom_transformer.blocks.{i}.ffn.w_down.weight` | `[128, 256]` | 3 |
+| `structure_head.diffusion_module.atom_decoder.atom_transformer.blocks.{i}.ffn.w_up.weight` | `[512, 128]` | 3 |
+| `structure_head.diffusion_module.atom_decoder.norm.bias` | `[128]` | 1 |
+| `structure_head.diffusion_module.atom_decoder.norm.weight` | `[128]` | 1 |
+| `structure_head.diffusion_module.atom_decoder.output_linear.weight` | `[3, 128]` | 1 |
+| `structure_head.diffusion_module.atom_decoder.token_to_atom_linear.weight` | `[128, 768]` | 1 |
+| `structure_head.diffusion_module.atom_encoder.atom_linear.weight` | `[128, 389]` | 1 |
+| `structure_head.diffusion_module.atom_encoder.atom_norm.bias` | `[128]` | 1 |
+| `structure_head.diffusion_module.atom_encoder.atom_norm.weight` | `[128]` | 1 |
+| `structure_head.diffusion_module.atom_encoder.atom_to_token_linear.weight` | `[768, 128]` | 1 |
+| `structure_head.diffusion_module.atom_encoder.atom_transformer.blocks.{i}.adaln_modulation.{i}.weight` | `[768, 128]` | 3 |
+| `structure_head.diffusion_module.atom_encoder.atom_transformer.blocks.{i}.attn.Wqkv.weight` | `[384, 128]` | 3 |
+| `structure_head.diffusion_module.atom_encoder.atom_transformer.blocks.{i}.attn.gate_proj.weight` | `[128, 128]` | 3 |
+| `structure_head.diffusion_module.atom_encoder.atom_transformer.blocks.{i}.attn.out_proj.weight` | `[128, 128]` | 3 |
+| `structure_head.diffusion_module.atom_encoder.atom_transformer.blocks.{i}.ffn.w_down.weight` | `[128, 256]` | 3 |
+| `structure_head.diffusion_module.atom_encoder.atom_transformer.blocks.{i}.ffn.w_up.weight` | `[512, 128]` | 3 |
+| `structure_head.diffusion_module.atom_encoder.coords_linear.weight` | `[128, 6]` | 1 |
+| `structure_head.diffusion_module.conditioning.fourier.b` | `[256]` | 1 |
+| `structure_head.diffusion_module.conditioning.fourier.w` | `[256]` | 1 |
+| `structure_head.diffusion_module.conditioning.noise_norm.bias` | `[256]` | 1 |
+| `structure_head.diffusion_module.conditioning.noise_norm.weight` | `[256]` | 1 |
+| `structure_head.diffusion_module.conditioning.noise_proj.weight` | `[768, 256]` | 1 |
+| `structure_head.diffusion_module.conditioning.s_input_norm.bias` | `[451]` | 1 |
+| `structure_head.diffusion_module.conditioning.s_input_norm.weight` | `[451]` | 1 |
+| `structure_head.diffusion_module.conditioning.s_proj.weight` | `[768, 451]` | 1 |
+| `structure_head.diffusion_module.conditioning.s_transitions.{i}.a_proj.weight` | `[1536, 768]` | 2 |
+| `structure_head.diffusion_module.conditioning.s_transitions.{i}.b_proj.weight` | `[1536, 768]` | 2 |
+| `structure_head.diffusion_module.conditioning.s_transitions.{i}.norm.bias` | `[768]` | 2 |
+| `structure_head.diffusion_module.conditioning.s_transitions.{i}.norm.weight` | `[768]` | 2 |
+| `structure_head.diffusion_module.conditioning.s_transitions.{i}.out_proj.weight` | `[768, 1536]` | 2 |
+| `structure_head.diffusion_module.conditioning.z_input_norm.bias` | `[512]` | 1 |
+| `structure_head.diffusion_module.conditioning.z_input_norm.weight` | `[512]` | 1 |
+| `structure_head.diffusion_module.conditioning.z_proj.weight` | `[256, 512]` | 1 |
+| `structure_head.diffusion_module.conditioning.z_transitions.{i}.a_proj.weight` | `[512, 256]` | 2 |
+| `structure_head.diffusion_module.conditioning.z_transitions.{i}.b_proj.weight` | `[512, 256]` | 2 |
+| `structure_head.diffusion_module.conditioning.z_transitions.{i}.norm.bias` | `[256]` | 2 |
+| `structure_head.diffusion_module.conditioning.z_transitions.{i}.norm.weight` | `[256]` | 2 |
+| `structure_head.diffusion_module.conditioning.z_transitions.{i}.out_proj.weight` | `[256, 512]` | 2 |
+| `structure_head.diffusion_module.s_step_norm.bias` | `[768]` | 1 |
+| `structure_head.diffusion_module.s_step_norm.weight` | `[768]` | 1 |
+| `structure_head.diffusion_module.s_to_token.weight` | `[768, 768]` | 1 |
+| `structure_head.diffusion_module.token_norm.bias` | `[768]` | 1 |
+| `structure_head.diffusion_module.token_norm.weight` | `[768]` | 1 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.adaln.s_gate.bias` | `[768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.adaln.s_gate.weight` | `[768, 768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.adaln.s_scale` | `[768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.adaln.s_shift.weight` | `[768, 768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.g_proj.weight` | `[768, 768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.kv_proj.weight` | `[1536, 768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.out_gate.bias` | `[768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.out_gate.weight` | `[768, 768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.out_proj.weight` | `[768, 768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.pair_bias_proj.weight` | `[16, 256]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.pair_norm.bias` | `[256]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.pair_norm.weight` | `[256]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.q_proj.bias` | `[768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.attn_blocks.{i}.q_proj.weight` | `[768, 768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.transition_blocks.{i}.adaln.s_gate.bias` | `[768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.transition_blocks.{i}.adaln.s_gate.weight` | `[768, 768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.transition_blocks.{i}.adaln.s_scale` | `[768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.transition_blocks.{i}.adaln.s_shift.weight` | `[768, 768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.transition_blocks.{i}.lin_out.weight` | `[768, 1536]` | 12 |
+| `structure_head.diffusion_module.token_transformer.transition_blocks.{i}.lin_swish.weight` | `[3072, 768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.transition_blocks.{i}.output_gate.bias` | `[768]` | 12 |
+| `structure_head.diffusion_module.token_transformer.transition_blocks.{i}.output_gate.weight` | `[768, 768]` | 12 |
+
+### `token_bonds` — 1 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `token_bonds.weight` | `[256, 1]` | 1 |
+
+### `z_init_1` — 1 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `z_init_1.weight` | `[256, 451]` | 1 |
+
+### `z_init_2` — 1 tensors
+
+| path pattern | shape | count |
+|---|---|---|
+| `z_init_2.weight` | `[256, 451]` | 1 |
+

--- a/docs/decisions/esmfold2-port-mismatch.md
+++ b/docs/decisions/esmfold2-port-mismatch.md
@@ -1,0 +1,71 @@
+# ESMFold2: the ported architecture does not match the released checkpoint
+
+**Status:** accepted — `ESMFold2Runner::from_pretrained*` refuses to load (ferritin-100.16)
+**Date:** 2026-09-05
+
+## Summary
+
+The `ferritin-plms` ESMFold2 port cannot load `biohub/ESMFold2-Fast`
+`model.safetensors`. This was originally filed as a weight-key-path mismatch —
+a wrong prefix or a rename. It is not. **Not one of the checkpoint's 1032
+tensors resolves to a parameter of the ported model**, because the ported
+module graph is a different network from the one that was released.
+
+The port's *scalar* hyper-parameters are mostly right (`d_single=384`,
+`d_pair=256`, `d_inputs=451`, `c_token=768`, `c_atom=128`, 24 trunk blocks,
+4 LM-encoder blocks, 12 token blocks, 3 atom blocks, `fourier_dim=256`).
+The *module layouts* were evidently written from an architecture sketch rather
+than read off the checkpoint.
+
+## Evidence
+
+| Component | What the port loads | What the checkpoint contains |
+|---|---|---|
+| `lm_encoder` | 4 pre-norm **transformer** blocks over `d=2560` (`attn.layernorm_qkv.{0,1}`, `attn.out_proj`, `attn.q_ln`/`k_ln`, `ffn.{0,1,3}`), then `norm` + `proj` to 384 | 4 **pair-track** blocks at `d=256`: `tri_mul_in`/`tri_mul_out` (`_engine.{norm_start,norm_mix,proj_bundle,proj_emit,proj_gate}`) + `pair_transition.{norm,ffn.w12,ffn.w3}`. No attention, no `norm`, no `proj` |
+| `folding_trunk` | `pair_init.*`, then blocks of `tri_attn_row`, `tri_attn_col`, `tri_mult_out`, `tri_mult_in`, `pair_trans`, then `norm` | 24 blocks of `tri_mul_in`/`tri_mul_out`/`pair_transition` **only**. No triangle attention, no `pair_init`, no trailing `norm` |
+| `structure_head` | flat `token_proj`, `noise_embedding`, `noise_proj`, `token_transformer.blocks.{i}.{attn,ffn}`, `out_proj` | one more nesting level (`structure_head.diffusion_module.*`), `conditioning.*`, `atom_encoder`/`atom_decoder` with `atom_transformer`, and a token transformer split into separate `attn_blocks` and `transition_blocks` with AdaLN modulation |
+| `confidence_head` | `trunk.blocks.{i}`, plus `plddt_head`/`pae_head`/`pde_head`/`distogram_head` linears | its own 4-block `folding_trunk`, `plddt_weight` as a rank-3 `[23, 384, 50]` tensor (not a `Linear`), `s_to_z*`, `row_attention_pooling`, `boundaries`, `dist_bin_pairwise_embed` |
+| — | not modelled at all | `parcae_coda.*`, `parcae_log_a`, `parcae_log_delta`, `parcae_b_cont`, `parcae_readout`, `parcae_input_norm` (a selective-SSM-style block), `language_model.base_z_*`, `inputs_embedder.atom_attention_encoder.*`, and top-level `rel_pos`, `token_bonds`, `z_init_1`, `z_init_2`, `distogram_head` |
+
+Two smaller discrepancies worth noting: the checkpoint's top-level
+`distogram_head.weight` is `[64, 256]` (64 bins), while `ESMFold2Config`
+declares `distogram_bins: 39` — 39 is the size of
+`confidence_head.dist_bin_pairwise_embed`, so the two were transposed.
+
+The complete tensor inventory is in
+[`esmfold2-checkpoint-tensors.md`](./esmfold2-checkpoint-tensors.md).
+
+## Decision
+
+`from_pretrained` and `from_pretrained_with_backbone` **refuse to load**, with
+an error that names the real cause, rather than surfacing a
+`cannot find tensor lm_encoder.blocks.0.attn.layernorm_qkv.0.weight` that
+invites another round of prefix-patching.
+
+This follows the precedent set for `ESMFold2Models::Full` (ferritin-100.4):
+when a checkpoint cannot be loaded faithfully, refusing is the honest failure.
+
+### Why not "just fix the paths"
+
+Renaming load paths would let tensors resolve but would not make the forward
+pass correct — the port has no triangle-multiplication engine of the released
+shape, no AdaLN diffusion transformer, no atom decoder, and no `parcae` block
+at all. Patching until `load` returns `Ok` would convert a loud, obvious
+failure into a silent one that emits plausible-looking but meaningless
+coordinates. That is strictly worse, and it is close to how the current state
+arose.
+
+### What stays
+
+The layer implementations and their shape tests are untouched and still pass;
+they exercise the modules under `VarBuilder::zeros`. Only the pretrained
+loading path refuses.
+
+## Follow-up
+
+A faithful re-port is tracked separately. It needs the reference
+implementation (or reference activations) to validate against — the checkpoint
+gives us exact shapes but not the semantics of `proj_bundle`/`proj_emit`, the
+`parcae_*` block, or the construction of the 451-dim input features, the
+139-bin `rel_pos` embedding, and the 389/6-dim atom features. Guessing those a
+second time would reproduce this bug.


### PR DESCRIPTION
> Stacked on #179 — review that one first. The base will retarget to `main` when #179 merges.

## The duplication

Every runner reimplemented the same download block: split the repo id, build an `HFClientSync`, download a file, then either an `unsafe` mmap or `PthTensors::new`. The copies had drifted — only ESM3 attached any error context, and all of them inherited the same silently-wrong split:

```rust
let (owner, name) = repo_id.split_once('/').unwrap_or(("", repo_id));
```

which turns a malformed id into an empty owner and a confusing 404 several seconds later rather than a clear error. (`hf_hub::split_id` has the identical fallback, so it was no help.)

## The helper — `crates/ferritin-plms/src/loader.rs`

- **`WeightSource`** — plain `const` data on each model enum: repo, revision, and the on-disk `Format` (`Safetensors`, or `Pth { root_key }`).
- **`LoadOptions`** — device and dtype, so the six per-module `const *_DTYPE` definitions collapse into one field and F16/BF16 (ferritin-100.9) has somewhere to land.
- **`fetch` / `fetch_optional`** — repo-id validation up front; errors name both the repo and the file. `fetch_optional` covers genuinely optional files like ESM-2's `config.json`.
- **`var_builder`** — the crate's only `unsafe` safetensors mmap, and the only place the dtype is applied.
- **`optional_prefix`** — ESMC's `esmc.` probe generalised into the HF wrapper-class mechanism it always was, and switched from a shape-dependent `vb.get()` probe to `VarBuilder::contains_tensor`.

Migrated all five remaining call sites (esmfold2's went away in #179): amplify, esm2, esmc, esm3 (×2), ligandmpnn — plus the two integration tests that had copied the block. `loader.rs` is now the only place in the crate touching `HFClientSync`, `from_mmaped_safetensors`, or `PthTensors::new`.

## Also fixes ferritin-100.10

The refactor resolves the `// Todo: refactor this to use loader` in `MPNNExecConfig::load_model`, and with it 100.10. That function loaded the **production** ProteinMPNN weights by extracting an embedded test fixture to a temp file:

```rust
let (mpnn_file, _handle) = TestFile::ligmpnn_pmpnn_01().create_temp()?;
```

That was the sole non-test use of `ferritin-test-data`, making 37 MB of fixtures a hard runtime dependency of `ferritin-plms` — and of the `ferritin` umbrella crate, whose default features include `plms`. It now delegates to `ProteinMPNNRunner::load_model`, the already-tested hub path, via a new `ProteinMPNNRunner::into_model`.

`ferritin-test-data` moves to `[dev-dependencies]`; every other `TestFile` reference in `src/` is inside a `#[cfg(test)] mod`. Confirmed gone from the runtime graph:

```
$ cargo tree -p ferritin-plms --edges normal -i ferritin-test-data
warning: nothing to print.
```

## Drive-by (ferritin-100.11)

That same function's `_ => panic!("not implented!")` arm becomes a proper `Err`. It is reachable from `--model-type ligand_mpnn` on the CLI, so a `Result`-returning function had no business aborting the process. **Whether to actually implement LigandMPNN loading remains ferritin-100.11** — this only removes the panic.

## Verification

- 7 loader unit tests, including that every malformed repo id the old split silently accepted (`no-slash`, `/leading`, `trailing/`, `a/b/c`, `""`) is now rejected with a clear error.
- New coverage for both `MPNNExecConfig::load_model` branches — there was none before.
- The real download paths exercised end to end: the **ESM2 and AMPLIFY numerical parity tests against the Python reference still pass** through the new loader, as does loading ProteinMPNN from the hub.
- `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` clean; full workspace tests pass.

`test_amplify_120m_probabilities` still fails, unchanged and unrelated (ferritin-100.18, pre-existing on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
