### PR TITLE
Give PlmRunner a documented special-token contract (ferritin-100.7, ferritin-100.18)

### DIFF
--- a/crates/ferritin-plms/src/amplify/amplify.rs
+++ b/crates/ferritin-plms/src/amplify/amplify.rs
@@ -109,6 +109,10 @@ impl AMPLIFY {
             config: cfg.clone(),
         })
     }
+    /// The configuration this model was loaded with.
+    pub fn config(&self) -> &AMPLIFYConfig {
+        &self.config
+    }
     pub fn get_device(&self) -> &Device {
         self.freqs_cis.device()
     }

--- a/crates/ferritin-plms/src/amplify/amplify_runner.rs
+++ b/crates/ferritin-plms/src/amplify/amplify_runner.rs
@@ -6,7 +6,7 @@ use super::super::types::{ContactMap, PseudoProbability};
 use super::amplify::{AMPLIFY, AmplifyOutput};
 use super::config::AMPLIFYConfig;
 use crate::loader::{LoadOptions, WeightSource};
-use crate::plm_runner::PlmRunner;
+use crate::plm_runner::{ModelMetadata, PlmRunner, SpecialTokenLayout};
 use anyhow::{Error as E, Result, anyhow};
 use candle_core::{D, Device, Tensor};
 use candle_nn::ops;
@@ -71,9 +71,23 @@ impl AmplifyRunner {
         let decoded = decoded.replace(" ", "");
         Ok(decoded)
     }
+    /// Per-residue pseudo-probabilities over the full AMPLIFY vocabulary.
+    ///
+    /// `position` is the residue index: BOS and EOS rows are stripped first,
+    /// so there is exactly one position per input residue. Previously these
+    /// rows were included, which both over-counted positions by two and
+    /// shifted every label by one — position 0 was BOS, not the first residue
+    /// (ferritin-100.18).
+    ///
+    /// Unlike [`ESM2Runner::get_pseudo_probabilities`], every amino acid is
+    /// returned rather than only those above a probability threshold.
     pub fn get_pseudo_probabilities(&self, prot_sequence: &str) -> Result<Vec<PseudoProbability>> {
         let model_output: AmplifyOutput = self.run_forward(prot_sequence)?;
-        let predictions = model_output.logits;
+        let layout = <Self as PlmRunner>::special_tokens(self);
+        let residue_rows = model_output.logits.dim(1)?.saturating_sub(layout.total());
+        let predictions = model_output
+            .logits
+            .narrow(1, layout.leading, residue_rows)?;
         let outputs = self.extract_logits(&predictions)?;
         Ok(outputs)
     }
@@ -126,7 +140,10 @@ impl AmplifyRunner {
         }
         Ok(contacts)
     }
-    // Softmax and simplify
+    /// Softmax `tensor` and flatten it into per-(position, amino acid) rows.
+    ///
+    /// `tensor` must already have its special-token rows stripped, so
+    /// `seq_pos` is a residue index.
     fn extract_logits(&self, tensor: &Tensor) -> Result<Vec<PseudoProbability>> {
         let tensor = ops::softmax(tensor, D::Minus1)?;
         let data = tensor.to_vec3::<f32>()?;
@@ -178,5 +195,31 @@ impl PlmRunner for AmplifyRunner {
 
     fn model_name(&self) -> &str {
         "amplify"
+    }
+
+    /// AMPLIFY's `tokenizer.json` has a `TemplateProcessing` post-processor
+    /// that adds `<bos>` (3) and `<eos>` (4), so `encode(.., true)` wraps the
+    /// sequence.
+    fn special_tokens(&self) -> SpecialTokenLayout {
+        SpecialTokenLayout::BOS_EOS
+    }
+
+    fn metadata(&self) -> ModelMetadata {
+        let config = self.model.config();
+        ModelMetadata {
+            d_model: config.hidden_size,
+            n_layers: config.num_hidden_layers,
+            vocab_size: config.vocab_size,
+            max_positions: Some(config.max_length),
+        }
+    }
+
+    fn device(&self) -> &Device {
+        self.model.get_device()
+    }
+
+    /// Masked-LM logits `(1, L + 2, vocab_size)`.
+    fn logits(&self, sequence: &str) -> Result<Tensor> {
+        Ok(self.run_forward(sequence)?.logits)
     }
 }

--- a/crates/ferritin-plms/src/esm2/esm2_runner.rs
+++ b/crates/ferritin-plms/src/esm2/esm2_runner.rs
@@ -3,7 +3,7 @@
 //! Class for loading and running the ESM2 models
 use super::esm2::{ESM2, ESM2Config, ESM2Output};
 use crate::loader::{LoadOptions, WeightSource};
-use crate::plm_runner::PlmRunner;
+use crate::plm_runner::{ModelMetadata, PlmRunner, SpecialTokenLayout};
 use crate::types::PseudoProbability;
 use anyhow::{Error as E, Result, anyhow};
 use candle_core::{Device, Tensor};
@@ -60,6 +60,9 @@ impl ESM2Models {
 pub struct ESM2Runner {
     model: ESM2,
     tokenizer: Tokenizer,
+    /// Retained so `PlmRunner::metadata` can report dimensions without
+    /// hardcoding them per variant.
+    config: ESM2Config,
 }
 impl ESM2Runner {
     /// Load model from HuggingFace hub, downloading config.json, tokenizer files, and weights.
@@ -74,9 +77,13 @@ impl ESM2Runner {
             None => fallback_config,
         };
         let vb = source.var_builder("model.safetensors", &LoadOptions::new(device))?;
-        let model = ESM2::load(vb, config)?;
+        let model = ESM2::load(vb, config.clone())?;
         let tokenizer = ESM2::load_tokenizer()?;
-        Ok(ESM2Runner { model, tokenizer })
+        Ok(ESM2Runner {
+            model,
+            tokenizer,
+            config,
+        })
     }
     /// Encode a sequence to token ids **with** ESM-2's BOS (`<cls>`) and EOS
     /// (`<eos>`) special tokens.
@@ -190,5 +197,29 @@ impl PlmRunner for ESM2Runner {
 
     fn model_name(&self) -> &str {
         "esm2"
+    }
+
+    /// ESM-2 wraps sequences in `<cls>` and `<eos>`; `encode_with_special`
+    /// adds them because the bundled `tokenizer.json` has no post-processor.
+    fn special_tokens(&self) -> SpecialTokenLayout {
+        SpecialTokenLayout::BOS_EOS
+    }
+
+    fn metadata(&self) -> ModelMetadata {
+        ModelMetadata {
+            d_model: self.config.hidden_size,
+            n_layers: self.config.num_hidden_layers as usize,
+            vocab_size: self.config.vocab_size as usize,
+            max_positions: Some(self.config.max_position_embeddings as usize),
+        }
+    }
+
+    fn device(&self) -> &Device {
+        self.model.get_device()
+    }
+
+    /// Masked-LM logits `(1, L + 2, vocab_size)`.
+    fn logits(&self, sequence: &str) -> Result<Tensor> {
+        Ok(self.run_forward(sequence)?.logits)
     }
 }

--- a/crates/ferritin-plms/src/esm3/pretrained.rs
+++ b/crates/ferritin-plms/src/esm3/pretrained.rs
@@ -26,7 +26,7 @@ use crate::esm3::models::esm3::{ESM3, ESM3Config};
 use crate::esm3::models::vqvae::{StructureTokenEncoder, VqVaeConfig};
 use crate::esm3::tokenization::sequence::tokenize_sequence;
 use crate::loader::{LoadOptions, WeightSource};
-use crate::plm_runner::PlmRunner;
+use crate::plm_runner::{ModelMetadata, PlmRunner, SpecialTokenLayout};
 use anyhow::Result;
 use candle_core::{Device, Tensor};
 
@@ -110,6 +110,51 @@ impl PlmRunner for ESM3Runner {
 
     fn model_name(&self) -> &str {
         "esm3"
+    }
+
+    /// `embed_sequence` calls `tokenize_sequence(.., true)`, which prepends
+    /// `SEQUENCE_BOS_TOKEN` and appends `SEQUENCE_EOS_TOKEN`.
+    fn special_tokens(&self) -> SpecialTokenLayout {
+        SpecialTokenLayout::BOS_EOS
+    }
+
+    fn metadata(&self) -> ModelMetadata {
+        let config = &self.model.config;
+        ModelMetadata {
+            d_model: config.d_model,
+            n_layers: config.n_layers,
+            vocab_size: config.d_sequence_vocab,
+            // Rotary positions: no hard architectural cap.
+            max_positions: None,
+        }
+    }
+
+    fn device(&self) -> &Device {
+        &self.device
+    }
+
+    /// Sequence-track logits `(1, L + 2, d_sequence_vocab)`.
+    ///
+    /// Only the sequence track is supplied; the other tracks are `None`.
+    fn logits(&self, sequence: &str) -> Result<Tensor> {
+        let token_ids = tokenize_sequence(sequence, true);
+        let tokens = Tensor::new(token_ids.as_slice(), &self.device)?.unsqueeze(0)?;
+        let output = self.model.forward(
+            Some(&tokens),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )?;
+        output
+            .sequence_logits
+            .ok_or_else(|| anyhow::anyhow!("ESM3 forward() returned no sequence logits"))
     }
 }
 

--- a/crates/ferritin-plms/src/esmc/models/esmc.rs
+++ b/crates/ferritin-plms/src/esmc/models/esmc.rs
@@ -268,6 +268,11 @@ impl ESMC {
         Tensor::from_vec(token_ids, len, &self.device)
     }
 
+    /// Device the model's weights live on.
+    pub fn device(&self) -> &Device {
+        &self.device
+    }
+
     /// Decode a 1-D or 2-D token-ID tensor back to an amino-acid string.
     ///
     /// Handles a batched `(1, L)` tensor by squeezing the batch dimension.

--- a/crates/ferritin-plms/src/esmc/pretrained.rs
+++ b/crates/ferritin-plms/src/esmc/pretrained.rs
@@ -30,9 +30,9 @@
 //! present and sets the VarBuilder root accordingly, so the same Rust model
 //! code works against both the wrapped and unwrapped formats.
 
-use crate::esmc::models::esmc::{ESMC, ESMCConfig};
+use crate::esmc::models::esmc::{ESMC, ESMCConfig, LogitsConfig};
 use crate::loader::{LoadOptions, WeightSource, optional_prefix};
-use crate::plm_runner::PlmRunner;
+use crate::plm_runner::{ModelMetadata, PlmRunner, SpecialTokenLayout};
 use anyhow::Result;
 use candle_core::{Device, Tensor};
 
@@ -69,6 +69,8 @@ impl ESMCModels {
 /// Wraps a loaded ESMC model for sequence embedding inference.
 pub struct ESMCRunner {
     model: ESMC,
+    /// Retained so `PlmRunner::metadata` can report dimensions.
+    config: ESMCConfig,
 }
 
 impl ESMCRunner {
@@ -83,8 +85,11 @@ impl ESMCRunner {
         let vb = source.var_builder("model.safetensors", &LoadOptions::new(device))?;
         // Weights saved from ESMCForMaskedLM nest the backbone under "esmc".
         let vb_root = optional_prefix(vb, "esmc", "embed.weight");
-        let esmc = ESMC::load(vb_root, config)?;
-        Ok(Self { model: esmc })
+        let esmc = ESMC::load(vb_root, config.clone())?;
+        Ok(Self {
+            model: esmc,
+            config,
+        })
     }
 
     /// Tokenize `sequence` and run a forward pass.
@@ -109,5 +114,40 @@ impl PlmRunner for ESMCRunner {
 
     fn model_name(&self) -> &str {
         "esmc"
+    }
+
+    /// `ESMC::encode` calls `tokenize_sequence(.., true)`, which wraps the
+    /// sequence in BOS and EOS.
+    fn special_tokens(&self) -> SpecialTokenLayout {
+        SpecialTokenLayout::BOS_EOS
+    }
+
+    fn metadata(&self) -> ModelMetadata {
+        ModelMetadata {
+            d_model: self.config.d_model,
+            n_layers: self.config.n_layers,
+            vocab_size: self.config.embedding_dim,
+            // Rotary positions: no hard architectural cap.
+            max_positions: None,
+        }
+    }
+
+    fn device(&self) -> &Device {
+        self.model.device()
+    }
+
+    /// Sequence logits `(1, L + 2, vocab_size)`.
+    fn logits(&self, sequence: &str) -> Result<Tensor> {
+        let tokens = self.model.encode(sequence)?.unsqueeze(0)?;
+        let out = self.model.logits(
+            &tokens,
+            LogitsConfig {
+                sequence: true,
+                return_embeddings: false,
+                return_hidden_states: false,
+            },
+        )?;
+        out.sequence_logits
+            .ok_or_else(|| anyhow::anyhow!("ESMC logits() returned no sequence logits"))
     }
 }

--- a/crates/ferritin-plms/src/esmfold2/pretrained.rs
+++ b/crates/ferritin-plms/src/esmfold2/pretrained.rs
@@ -30,6 +30,7 @@ use super::config::ESMFold2Config;
 use super::model::ESMFold2Model;
 use super::output::ESMFold2Output;
 use crate::esmc::pretrained::ESMCRunner;
+use crate::plm_runner::PlmRunner;
 use anyhow::{Result, bail};
 use candle_core::{DType, Device, Tensor};
 
@@ -178,12 +179,10 @@ impl ESMFold2Runner {
         // ESMC-6B backbone → (1, L, 2560).
         // When backbone is None, use zeros (stub for shape testing).
         let hidden_states = match &self.backbone {
-            Some(esmc) => {
-                // embed_sequence returns (1, L+2, d_model) with BOS and EOS tokens.
-                let embs = esmc.embed_sequence(sequence)?;
-                // Strip BOS (index 0) and EOS (index L+1), keeping L residues.
-                embs.narrow(1, 1, l)?
-            }
+            // `embed_residues` strips the backbone's special tokens per its own
+            // declared layout, so this no longer hardcodes ESMC's BOS/EOS
+            // (ferritin-100.7).
+            Some(esmc) => esmc.embed_residues(sequence)?,
             None => Tensor::zeros(&[1, l, self.config.lm_d_model], ESMFOLD2_DTYPE, device)?,
         };
 

--- a/crates/ferritin-plms/src/lib.rs
+++ b/crates/ferritin-plms/src/lib.rs
@@ -43,7 +43,7 @@ pub mod loader;
 pub mod plm_runner;
 pub mod types;
 pub mod utils;
-pub use plm_runner::PlmRunner;
+pub use plm_runner::{ModelMetadata, PlmRunner, SpecialTokenLayout};
 
 /// Returns the best available device for computation.
 ///

--- a/crates/ferritin-plms/src/plm_runner.rs
+++ b/crates/ferritin-plms/src/plm_runner.rs
@@ -1,51 +1,305 @@
 //! Unified trait for protein language model runners.
 //!
-//! `PlmRunner` provides a common interface for sequence embedding across
-//! ESM2, AMPLIFY, and ESMC. Downstream code can be generic over the runner
-//! type (e.g., for benchmarking or ensemble inference).
+//! [`PlmRunner`] provides a common interface for sequence embedding across
+//! ESM2, AMPLIFY, ESMC and ESM3, so downstream code can be generic over the
+//! runner type (benchmarking, ensembles, parity harnesses).
+//!
+//! # The special-token contract
+//!
+//! This is the part that matters for correctness. Every runner's tokenizer
+//! wraps the amino-acid sequence in special tokens, so [`PlmRunner::embed`]
+//! returns *more* rows than the sequence has residues. The old doc comment
+//! said `(1, L, d_model)` where `L` includes "any BOS/EOS tokens" — and "any"
+//! was doing far too much work: a caller comparing two runners' embeddings had
+//! no way to know whether their rows were aligned, so a mismatch showed up as
+//! silently misaligned residues rather than an error.
+//!
+//! Each runner now declares its layout via [`PlmRunner::special_tokens`], and
+//! the provided [`PlmRunner::embed_residues`] strips it:
+//!
+//! | method | rows | use it when |
+//! |---|---|---|
+//! | [`embed`][PlmRunner::embed] | `L + leading + trailing` | you want the raw model output, specials included |
+//! | [`embed_residues`][PlmRunner::embed_residues] | exactly `sequence.len()` | you are indexing by residue, or comparing across models |
+//!
+//! All four current runners are `BOS_EOS` (one leading, one trailing), but
+//! that is a fact about these checkpoints, not a guarantee — declare the
+//! layout in the impl rather than assuming it at the call site.
+//!
+//! ```no_run
+//! # use ferritin_plms::plm_runner::PlmRunner;
+//! # fn compare(a: &dyn PlmRunner, b: &dyn PlmRunner, seq: &str) -> anyhow::Result<()> {
+//! // Row i of each corresponds to residue i, whatever the tokenizers do.
+//! let x = a.embed_residues(seq)?;
+//! let y = b.embed_residues(seq)?;
+//! assert_eq!(x.dim(1)?, y.dim(1)?);
+//! # Ok(())
+//! # }
+//! ```
 
-use anyhow::Result;
-use candle_core::Tensor;
+use anyhow::{Result, bail};
+use candle_core::{Device, Tensor};
+
+// ── SpecialTokenLayout ────────────────────────────────────────────────────────
+
+/// How many special tokens a runner's tokenizer wraps a sequence in.
+///
+/// Named counts rather than an enum of model names, so porting a new model
+/// means declaring its shape rather than editing a `match` somewhere else.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SpecialTokenLayout {
+    /// Tokens prepended before the first residue (e.g. BOS / `<cls>`).
+    pub leading: usize,
+    /// Tokens appended after the last residue (e.g. EOS).
+    pub trailing: usize,
+}
+
+impl SpecialTokenLayout {
+    /// No special tokens: model output rows map 1:1 onto residues.
+    pub const NONE: Self = Self {
+        leading: 0,
+        trailing: 0,
+    };
+
+    /// One leading BOS and one trailing EOS — what every currently ported
+    /// model does.
+    pub const BOS_EOS: Self = Self {
+        leading: 1,
+        trailing: 1,
+    };
+
+    /// Total number of non-residue rows.
+    pub const fn total(&self) -> usize {
+        self.leading + self.trailing
+    }
+}
+
+// ── ModelMetadata ─────────────────────────────────────────────────────────────
+
+/// Architecture facts a caller needs to size downstream layers.
+///
+/// Without this, callers had to hardcode `d_model` per model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ModelMetadata {
+    /// Hidden width of the embeddings returned by [`PlmRunner::embed`].
+    pub d_model: usize,
+    /// Number of transformer layers.
+    pub n_layers: usize,
+    /// Token vocabulary size — the last dimension of [`PlmRunner::logits`].
+    pub vocab_size: usize,
+    /// Maximum supported sequence length, when the architecture has one.
+    /// `None` for models with relative or rotary positions and no hard cap.
+    pub max_positions: Option<usize>,
+}
+
+// ── PlmRunner ─────────────────────────────────────────────────────────────────
 
 /// Trait implemented by all PLM runner types.
+///
+/// Structure-prediction and inverse-folding runners (`ESMFold2Runner`,
+/// `ProteinMPNNRunner`) deliberately stay outside this trait — they are not
+/// embedding models.
 pub trait PlmRunner {
-    /// Run a forward pass on `sequence` and return per-residue embeddings.
+    /// Run a forward pass on `sequence` and return raw per-residue embeddings.
     ///
-    /// Shape: `(1, L, d_model)` where `L` includes any BOS/EOS tokens.
+    /// Shape: `(1, L + special, d_model)`, where `special` is
+    /// [`special_tokens().total()`][PlmRunner::special_tokens]. Rows for
+    /// special tokens are **included**; use
+    /// [`embed_residues`][Self::embed_residues] to get one row per residue.
     fn embed(&self, sequence: &str) -> Result<Tensor>;
 
     /// Model name / identifier string (e.g. "esm2", "amplify", "esmc").
     fn model_name(&self) -> &str;
+
+    /// The special tokens this runner's tokenizer adds around a sequence.
+    fn special_tokens(&self) -> SpecialTokenLayout;
+
+    /// Architecture dimensions, for sizing downstream layers.
+    fn metadata(&self) -> ModelMetadata;
+
+    /// Device the model's weights live on.
+    fn device(&self) -> &Device;
+
+    /// Per-residue embeddings with special-token rows removed.
+    ///
+    /// Shape: `(1, sequence.len(), d_model)` — guaranteed, and therefore
+    /// comparable row-for-row across models.
+    ///
+    /// Provided in terms of [`embed`][Self::embed] and
+    /// [`special_tokens`][Self::special_tokens], so an implementor declares
+    /// its layout rather than reimplementing the strip. This is what
+    /// `ESMFold2Runner::fold_protein` used to hand-roll as
+    /// `.narrow(1, 1, l)` against ESMC specifically.
+    fn embed_residues(&self, sequence: &str) -> Result<Tensor> {
+        let raw = self.embed(sequence)?;
+        let layout = self.special_tokens();
+        let rows = raw.dim(1)?;
+        let expected = sequence.len() + layout.total();
+        if rows != expected {
+            bail!(
+                "{}: embed() returned {rows} rows for a {}-residue sequence, but its \
+                 declared special-token layout ({} leading, {} trailing) implies {expected}. \
+                 The runner's SpecialTokenLayout does not match its tokenizer.",
+                self.model_name(),
+                sequence.len(),
+                layout.leading,
+                layout.trailing,
+            );
+        }
+        Ok(raw.narrow(1, layout.leading, sequence.len())?)
+    }
+
+    /// Masked-LM logits over the token vocabulary.
+    ///
+    /// Shape: `(1, L + special, vocab_size)` — the raw form, aligned with
+    /// [`embed`][Self::embed] rather than
+    /// [`embed_residues`][Self::embed_residues].
+    ///
+    /// Defaults to an error: not every runner has a masked-LM head, and
+    /// silently returning something else would be worse than refusing.
+    fn logits(&self, _sequence: &str) -> Result<Tensor> {
+        bail!("{} does not expose masked-LM logits", self.model_name())
+    }
 }
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use candle_core::{DType, Device};
 
-    struct MockRunner;
+    /// Emits `sequence.len() + layout.total()` rows, so `embed_residues` has
+    /// something consistent to strip.
+    struct MockRunner {
+        layout: SpecialTokenLayout,
+        /// When set, `embed` lies about its row count to exercise the guard.
+        rows_override: Option<usize>,
+    }
+
+    impl MockRunner {
+        fn new(layout: SpecialTokenLayout) -> Self {
+            Self {
+                layout,
+                rows_override: None,
+            }
+        }
+    }
 
     impl PlmRunner for MockRunner {
-        fn embed(&self, _sequence: &str) -> Result<Tensor> {
-            Tensor::zeros((1usize, 3usize, 16usize), DType::F32, &Device::Cpu)
+        fn embed(&self, sequence: &str) -> Result<Tensor> {
+            let rows = self
+                .rows_override
+                .unwrap_or(sequence.len() + self.layout.total());
+            Tensor::zeros((1usize, rows, 16usize), DType::F32, &Device::Cpu)
                 .map_err(anyhow::Error::from)
         }
 
         fn model_name(&self) -> &str {
             "mock"
         }
+
+        fn special_tokens(&self) -> SpecialTokenLayout {
+            self.layout
+        }
+
+        fn metadata(&self) -> ModelMetadata {
+            ModelMetadata {
+                d_model: 16,
+                n_layers: 2,
+                vocab_size: 33,
+                max_positions: Some(1024),
+            }
+        }
+
+        fn device(&self) -> &Device {
+            &Device::Cpu
+        }
+    }
+
+    #[test]
+    fn test_special_token_layout_totals() {
+        assert_eq!(SpecialTokenLayout::NONE.total(), 0);
+        assert_eq!(SpecialTokenLayout::BOS_EOS.total(), 2);
     }
 
     #[test]
     fn test_mock_runner_model_name() {
-        let runner = MockRunner;
-        assert_eq!(runner.model_name(), "mock");
+        assert_eq!(
+            MockRunner::new(SpecialTokenLayout::BOS_EOS).model_name(),
+            "mock"
+        );
+    }
+
+    /// `embed` keeps the special-token rows.
+    #[test]
+    fn test_embed_includes_special_tokens() {
+        let runner = MockRunner::new(SpecialTokenLayout::BOS_EOS);
+        let t = runner.embed("ACDE").unwrap();
+        assert_eq!(t.dims(), &[1, 6, 16], "4 residues + BOS + EOS");
+    }
+
+    /// `embed_residues` strips them, giving exactly one row per residue.
+    #[test]
+    fn test_embed_residues_strips_special_tokens() {
+        let runner = MockRunner::new(SpecialTokenLayout::BOS_EOS);
+        let t = runner.embed_residues("ACDE").unwrap();
+        assert_eq!(t.dims(), &[1, 4, 16]);
+    }
+
+    /// A runner with no special tokens is passed through unchanged.
+    #[test]
+    fn test_embed_residues_noop_for_no_special_tokens() {
+        let runner = MockRunner::new(SpecialTokenLayout::NONE);
+        let t = runner.embed_residues("ACDE").unwrap();
+        assert_eq!(t.dims(), &[1, 4, 16]);
+    }
+
+    /// Asymmetric layouts strip from the correct end.
+    #[test]
+    fn test_embed_residues_handles_leading_only() {
+        let runner = MockRunner::new(SpecialTokenLayout {
+            leading: 1,
+            trailing: 0,
+        });
+        let t = runner.embed_residues("ACDE").unwrap();
+        assert_eq!(t.dims(), &[1, 4, 16]);
+    }
+
+    /// A layout that disagrees with the tokenizer is reported, not silently
+    /// turned into misaligned residues — the whole point of the contract.
+    #[test]
+    fn test_embed_residues_rejects_layout_mismatch() {
+        let runner = MockRunner {
+            layout: SpecialTokenLayout::BOS_EOS,
+            rows_override: Some(4), // claims BOS_EOS but returns bare residues
+        };
+        let err = runner
+            .embed_residues("ACDE")
+            .map(|_| ())
+            .expect_err("a layout that does not match the row count must error");
+        assert!(
+            err.to_string().contains("does not match its tokenizer"),
+            "error should name the contract violation; got: {err}"
+        );
     }
 
     #[test]
-    fn test_mock_runner_embed_shape() {
-        let runner = MockRunner;
-        let tensor = runner.embed("ACDE").unwrap();
-        assert_eq!(tensor.dims(), &[1, 3, 16]);
+    fn test_metadata_is_reported() {
+        let md = MockRunner::new(SpecialTokenLayout::BOS_EOS).metadata();
+        assert_eq!(md.d_model, 16);
+        assert_eq!(md.vocab_size, 33);
+        assert_eq!(md.max_positions, Some(1024));
+    }
+
+    /// Runners without a masked-LM head refuse rather than returning something
+    /// that is not logits.
+    #[test]
+    fn test_logits_defaults_to_unsupported() {
+        let err = MockRunner::new(SpecialTokenLayout::BOS_EOS)
+            .logits("ACDE")
+            .map(|_| ())
+            .expect_err("the default logits() must refuse");
+        assert!(err.to_string().contains("does not expose masked-LM logits"));
     }
 }

--- a/crates/ferritin-plms/tests/test_plm_runner_contract.rs
+++ b/crates/ferritin-plms/tests/test_plm_runner_contract.rs
@@ -1,0 +1,133 @@
+//! Conformance tests for the [`PlmRunner`] special-token contract (ferritin-100.7).
+//!
+//! Each runner *declares* how many special tokens its tokenizer wraps a
+//! sequence in. That declaration is only useful if it is true, so these tests
+//! check it against the real models: `embed` must return
+//! `L + leading + trailing` rows and `embed_residues` exactly `L`.
+//!
+//! A runner whose `SpecialTokenLayout` drifts from its tokenizer fails here
+//! rather than silently handing callers misaligned residues — which is the
+//! failure mode the contract exists to prevent.
+//!
+//! These download weights, so they are `#[ignore]`d:
+//!
+//! ```shell
+//! cargo test -p ferritin-plms --test test_plm_runner_contract -- --include-ignored
+//! ```
+
+use anyhow::Result;
+use ferritin_plms::plm_runner::{PlmRunner, SpecialTokenLayout};
+use ferritin_plms::{AmplifyModels, AmplifyRunner, ESM2Models, ESM2Runner, device};
+
+/// Ubiquitin (76 aa).
+const SEQ: &str = "MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG";
+
+/// Assert that a runner's declared layout matches what its tokenizer actually does.
+fn assert_contract_holds(runner: &dyn PlmRunner) -> Result<()> {
+    let name = runner.model_name();
+    let layout = runner.special_tokens();
+
+    let raw = runner.embed(SEQ)?;
+    assert_eq!(
+        raw.dim(1)?,
+        SEQ.len() + layout.total(),
+        "{name}: embed() rows should be L + {} specials",
+        layout.total()
+    );
+
+    // The contract: one row per residue, whatever the tokenizer does.
+    let residues = runner.embed_residues(SEQ)?;
+    assert_eq!(
+        residues.dim(1)?,
+        SEQ.len(),
+        "{name}: embed_residues() must return exactly one row per residue"
+    );
+
+    // Width is unchanged by stripping, and matches the declared metadata.
+    let metadata = runner.metadata();
+    assert_eq!(
+        residues.dim(2)?,
+        metadata.d_model,
+        "{name}: embedding width should match ModelMetadata::d_model"
+    );
+    assert_eq!(raw.dim(0)?, 1, "{name}: batch dimension should be 1");
+
+    Ok(())
+}
+
+#[test]
+#[ignore = "requires downloading facebook/esm2_t6_8M_UR50D weights"]
+fn test_esm2_special_token_contract() -> Result<()> {
+    let runner = ESM2Runner::load_model(ESM2Models::T6_8M, device(false)?)?;
+    assert_eq!(runner.special_tokens(), SpecialTokenLayout::BOS_EOS);
+    assert_contract_holds(&runner)
+}
+
+#[test]
+#[ignore = "requires downloading chandar-lab/AMPLIFY_120M weights"]
+fn test_amplify_special_token_contract() -> Result<()> {
+    let runner = AmplifyRunner::load_model(AmplifyModels::AMP120M, device(false)?)?;
+    assert_eq!(runner.special_tokens(), SpecialTokenLayout::BOS_EOS);
+    assert_contract_holds(&runner)
+}
+
+/// The point of the contract: rows from two different models line up, so a
+/// caller can compare residue `i` to residue `i` without knowing either
+/// tokenizer.
+#[test]
+#[ignore = "requires downloading both ESM2 and AMPLIFY weights"]
+fn test_embed_residues_aligns_across_models() -> Result<()> {
+    let esm2 = ESM2Runner::load_model(ESM2Models::T6_8M, device(false)?)?;
+    let amplify = AmplifyRunner::load_model(AmplifyModels::AMP120M, device(false)?)?;
+
+    let a = esm2.embed_residues(SEQ)?;
+    let b = amplify.embed_residues(SEQ)?;
+
+    assert_eq!(
+        a.dim(1)?,
+        b.dim(1)?,
+        "residue counts must agree across runners"
+    );
+    assert_eq!(a.dim(1)?, SEQ.len());
+    Ok(())
+}
+
+/// `logits` is aligned with `embed`, not `embed_residues`, and its last
+/// dimension is the declared vocabulary size.
+#[test]
+#[ignore = "requires downloading facebook/esm2_t6_8M_UR50D weights"]
+fn test_logits_shape_matches_metadata() -> Result<()> {
+    let runner = ESM2Runner::load_model(ESM2Models::T6_8M, device(false)?)?;
+    let logits = runner.logits(SEQ)?;
+    let metadata = runner.metadata();
+
+    assert_eq!(
+        logits.dim(1)?,
+        SEQ.len() + runner.special_tokens().total(),
+        "logits should be aligned with embed(), specials included"
+    );
+    assert_eq!(
+        logits.dim(2)?,
+        metadata.vocab_size,
+        "logits width should match ModelMetadata::vocab_size"
+    );
+    Ok(())
+}
+
+/// Metadata should describe the model, not placeholder values.
+#[test]
+#[ignore = "requires downloading facebook/esm2_t6_8M_UR50D weights"]
+fn test_metadata_is_populated() -> Result<()> {
+    let runner = ESM2Runner::load_model(ESM2Models::T6_8M, device(false)?)?;
+    let metadata = runner.metadata();
+
+    // ESM2 t6_8M: 6 layers, width 320, 33-token vocabulary.
+    assert_eq!(metadata.n_layers, 6);
+    assert_eq!(metadata.d_model, 320);
+    assert_eq!(metadata.vocab_size, 33);
+    assert!(
+        metadata.max_positions.is_some_and(|m| m > SEQ.len()),
+        "ESM2 has learned position embeddings, so max_positions should be reported"
+    );
+    Ok(())
+}


### PR DESCRIPTION
> Stacked on #180 (which is stacked on #179). Bases retarget as each merges.

## The contract problem

`PlmRunner` was 19 lines of real code — `embed()` and `model_name()`. Too thin to write anything generic against, and its contract was worse than thin:

> Shape: `(1, L, d_model)` where `L` includes **any** BOS/EOS tokens.

"Any" was doing all the work. A caller comparing two runners' embeddings had no way to know whether their rows lined up, so a mismatch surfaced as **silently misaligned residues** rather than an error. `ESMFold2Runner::fold_protein` had to hand-strip with `.narrow(1, 1, l)` against ESMC specifically — exactly the coupling a trait should have removed.

## The widened trait

| addition | what it does |
|---|---|
| `SpecialTokenLayout { leading, trailing }` | Named counts, not an enum of model names — porting a model means declaring its shape, not editing a `match` elsewhere. Consts `NONE`, `BOS_EOS`. |
| `embed_residues()` | **Provided** over `embed()` + `special_tokens()`. Guarantees `(1, sequence.len(), d_model)`, so rows are comparable across models. |
| `metadata() -> ModelMetadata` | `d_model`, `n_layers`, `vocab_size`, `max_positions` — callers could not size a downstream layer without hardcoding. |
| `device()` | Three runners stored one, three fetched it off the model. |
| `logits()` | Provided, defaulting to an explicit *"does not expose masked-LM logits"* error, since not every runner has that head. |

`embed_residues` **errors if the row count disagrees with the declared layout**, so a runner whose declaration drifts from its tokenizer is reported rather than quietly returning shifted residues.

Implemented across all four runners. All are `BOS_EOS` today — but that's a fact about these checkpoints, not a guarantee, so it lives in each impl. ESM2 and ESMC now retain their config so `metadata()` reports real dimensions; AMPLIFY gained `config()`, ESMC gained `device()`.

ESMFold2's hand-rolled `narrow` is gone — it no longer knows anything about ESMC's tokenizer:

```rust
Some(esmc) => esmc.embed_residues(sequence)?,
```

## Applying the contract found a live bug (ferritin-100.18)

`AmplifyRunner::extract_logits` enumerated **every** row of the `(1, L+2, vocab)` logits tensor and reported the row index as `position`. So pseudo-probabilities had two positions too many, and every label was shifted by one — position 0 was BOS, not the first residue. ESM2 already stripped correctly; AMPLIFY now does too, via its declared layout.

`test_amplify_120m_probabilities`, **red on `main`**, now passes. (Same family as ferritin-100.3's contact-map label bug.)

## Verification

New `tests/test_plm_runner_contract.rs` checks the declarations against the real models rather than trusting them — `embed()` returns `L + specials`, `embed_residues()` returns exactly `L`, widths match `metadata`, `logits` align with `embed()`, and two different runners' residue rows agree. All five pass against ESM2 and AMPLIFY.

```
cargo test -p ferritin-plms --test test_plm_runner_contract -- --include-ignored   # 5 passed
cargo test -p ferritin-plms --test test_plm_amplify -- --include-ignored           # 5 passed (was 4/1)
cargo clippy --workspace --all-targets && cargo fmt --all --check                  # clean
```

The ESM2 and AMPLIFY numerical parity tests against the Python reference still pass.

## Left open

`get_pseudo_probabilities` still filters differently per model (ESM2 drops anything under 0.01, AMPLIFY keeps everything). That's documented behavior rather than a bug, so this PR fixes the position indexing and leaves the filtering alone; `logits()` now gives callers the unfiltered path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
