### PR TITLE
F16/BF16 support, with the numerical cost measured rather than assumed (ferritin-100.9)

### DIFF
--- a/crates/ferritin-plms/src/amplify/amplify.rs
+++ b/crates/ferritin-plms/src/amplify/amplify.rs
@@ -99,7 +99,12 @@ impl AMPLIFY {
         let layer_norm_2 = rms_norm(cfg.hidden_size, cfg.norm_eps, vb.pp("layer_norm_2"))?;
         let decoder = linear(cfg.hidden_size, cfg.vocab_size, vb.pp("decoder"))?;
         let head_dim = cfg.hidden_size / cfg.num_attention_heads;
-        let freqs_cis = precompute_freqs_cis(head_dim, cfg.max_length)?.to_device(vb.device())?;
+        // The rotary table is computed in F32 for precision, then cast to the
+        // model's dtype — without the cast, an F16/BF16 model fails in
+        // apply_rotary_emb with "dtype mismatch in mul" (ferritin-100.9).
+        let freqs_cis = precompute_freqs_cis(head_dim, cfg.max_length)?
+            .to_device(vb.device())?
+            .to_dtype(vb.dtype())?;
         Ok(Self {
             encoder,
             transformer_encoder,

--- a/crates/ferritin-plms/src/amplify/amplify_runner.rs
+++ b/crates/ferritin-plms/src/amplify/amplify_runner.rs
@@ -34,7 +34,19 @@ pub struct AmplifyRunner {
     tokenizer: Tokenizer,
 }
 impl AmplifyRunner {
+    /// Load model from HuggingFace hub at F32.
+    ///
+    /// Use [`load_model_with`][Self::load_model_with] for F16 or BF16.
     pub fn load_model(modeltype: AmplifyModels, device: Device) -> Result<AmplifyRunner> {
+        Self::load_model_with(modeltype, &LoadOptions::new(device))
+    }
+
+    /// Load model with an explicit device and dtype.
+    ///
+    /// Reduced precision halves the memory footprint but changes the numerics;
+    /// see `tests/test_plm_dtype_parity.rs` for the achievable tolerance
+    /// (ferritin-100.9).
+    pub fn load_model_with(modeltype: AmplifyModels, opts: &LoadOptions) -> Result<AmplifyRunner> {
         let source = AmplifyModels::get_model_files(modeltype);
         let config_filename = source.fetch("config.json")?;
         let tokenizer_filename = source.fetch("tokenizer.json")?;
@@ -44,7 +56,7 @@ impl AmplifyRunner {
             .replace("Swiglu", "swiglu");
         let config: AMPLIFYConfig = serde_json::from_str(&config_str)?;
         let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
-        let vb = source.var_builder("model.safetensors", &LoadOptions::new(device))?;
+        let vb = source.var_builder("model.safetensors", opts)?;
         let model = AMPLIFY::load(vb, &config)?;
         Ok(AmplifyRunner { model, tokenizer })
     }

--- a/crates/ferritin-plms/src/esm2/esm2_runner.rs
+++ b/crates/ferritin-plms/src/esm2/esm2_runner.rs
@@ -65,8 +65,22 @@ pub struct ESM2Runner {
     config: ESM2Config,
 }
 impl ESM2Runner {
-    /// Load model from HuggingFace hub, downloading config.json, tokenizer files, and weights.
+    /// Load model from HuggingFace hub at F32, downloading config.json,
+    /// tokenizer files, and weights.
+    ///
+    /// Use [`load_model_with`][Self::load_model_with] to load at F16 or BF16 —
+    /// `T36_3B` and `T48_15B` are not loadable at F32 on most machines
+    /// (~12 GB and ~60 GB respectively).
     pub fn load_model(modeltype: ESM2Models, device: Device) -> Result<ESM2Runner> {
+        Self::load_model_with(modeltype, &LoadOptions::new(device))
+    }
+
+    /// Load model with an explicit device and dtype.
+    ///
+    /// Reduced precision halves the memory footprint but changes the numerics;
+    /// see `tests/test_plm_dtype_parity.rs` for the tolerance each dtype
+    /// actually achieves against the Python reference (ferritin-100.9).
+    pub fn load_model_with(modeltype: ESM2Models, opts: &LoadOptions) -> Result<ESM2Runner> {
         let (source, fallback_config) = ESM2Models::get_model_files(modeltype);
         // Try to load config from HF hub; fall back to hardcoded config if unavailable.
         let config = match source.fetch_optional("config.json") {
@@ -76,7 +90,7 @@ impl ESM2Runner {
             }
             None => fallback_config,
         };
-        let vb = source.var_builder("model.safetensors", &LoadOptions::new(device))?;
+        let vb = source.var_builder("model.safetensors", opts)?;
         let model = ESM2::load(vb, config.clone())?;
         let tokenizer = ESM2::load_tokenizer()?;
         Ok(ESM2Runner {

--- a/crates/ferritin-plms/src/esm3/pretrained.rs
+++ b/crates/ferritin-plms/src/esm3/pretrained.rs
@@ -69,10 +69,18 @@ impl ESM3Runner {
     ///
     /// The `.pth` checkpoint is loaded directly via `candle_core::pickle::PthTensors`.
     pub fn from_pretrained(variant: ESM3Models, device: Device) -> Result<Self> {
+        Self::from_pretrained_with(variant, &LoadOptions::new(device))
+    }
+
+    /// Load with an explicit device and dtype (ferritin-100.9).
+    pub fn from_pretrained_with(variant: ESM3Models, opts: &LoadOptions) -> Result<Self> {
         let (source, filename, config) = variant.model_info();
-        let vb = source.var_builder(filename, &LoadOptions::new(device.clone()))?;
+        let vb = source.var_builder(filename, opts)?;
         let model = ESM3::load(vb, config)?;
-        Ok(Self { model, device })
+        Ok(Self {
+            model,
+            device: opts.device.clone(),
+        })
     }
 
     /// Tokenize `sequence` and return per-residue embeddings `(1, L, d_model)`.
@@ -172,12 +180,17 @@ pub struct StructureEncoderRunner {
 impl StructureEncoderRunner {
     /// Download and load the structure encoder from HuggingFace.
     pub fn from_pretrained(device: Device) -> Result<Self> {
-        let vb = ESM3_REPO.var_builder(
-            "esm3_structure_encoder_v0.pth",
-            &LoadOptions::new(device.clone()),
-        )?;
+        Self::from_pretrained_with(&LoadOptions::new(device))
+    }
+
+    /// Load with an explicit device and dtype (ferritin-100.9).
+    pub fn from_pretrained_with(opts: &LoadOptions) -> Result<Self> {
+        let vb = ESM3_REPO.var_builder("esm3_structure_encoder_v0.pth", opts)?;
         let encoder = StructureTokenEncoder::load(vb, VqVaeConfig::default())?;
-        Ok(Self { encoder, device })
+        Ok(Self {
+            encoder,
+            device: opts.device.clone(),
+        })
     }
 
     /// Encode backbone coordinates to structure tokens.

--- a/crates/ferritin-plms/src/esmc/pretrained.rs
+++ b/crates/ferritin-plms/src/esmc/pretrained.rs
@@ -81,8 +81,18 @@ impl ESMCRunner {
     /// VarBuilder root to `vb.pp("esmc")` when found, otherwise uses the
     /// flat (unwrapped) layout.
     pub fn from_pretrained(model: ESMCModels, device: Device) -> Result<Self> {
+        Self::from_pretrained_with(model, &LoadOptions::new(device))
+    }
+
+    /// Load with an explicit device and dtype.
+    ///
+    /// `ESMC6B` is ~24 GB at F32 but ~12 GB at BF16 — its on-disk precision —
+    /// so reduced precision is the difference between loadable and not on a
+    /// 32 GB machine. See `tests/test_plm_dtype_parity.rs` for the numerical
+    /// cost (ferritin-100.9).
+    pub fn from_pretrained_with(model: ESMCModels, opts: &LoadOptions) -> Result<Self> {
         let (source, config) = model.model_info();
-        let vb = source.var_builder("model.safetensors", &LoadOptions::new(device))?;
+        let vb = source.var_builder("model.safetensors", opts)?;
         // Weights saved from ESMCForMaskedLM nest the backbone under "esmc".
         let vb_root = optional_prefix(vb, "esmc", "embed.weight");
         let esmc = ESMC::load(vb_root, config.clone())?;

--- a/crates/ferritin-plms/src/ligandmpnn/pmpnn_runner.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/pmpnn_runner.rs
@@ -40,15 +40,25 @@ pub struct ProteinMPNNRunner {
 impl ProteinMPNNRunner {
     /// Load a ProteinMPNN model from HuggingFace hub.
     pub fn load_model(modeltype: ProteinMPNNModels, device: Device) -> Result<Self> {
+        Self::load_model_with(modeltype, &LoadOptions::new(device))
+    }
+
+    /// Load with an explicit device and dtype (ferritin-100.9).
+    pub fn load_model_with(modeltype: ProteinMPNNModels, opts: &LoadOptions) -> Result<Self> {
         let (source, filename) = modeltype.hf_info();
         let weights_path = source.fetch(filename)?;
-        Self::from_path(&weights_path, device)
+        Self::from_path_with(&weights_path, opts)
     }
 
     /// Load from a local .pt file (e.g. from ferritin-test-data or a cached download).
     pub fn from_path(path: impl AsRef<Path>, device: Device) -> Result<Self> {
+        Self::from_path_with(path, &LoadOptions::new(device))
+    }
+
+    /// Load from a local file with an explicit device and dtype.
+    pub fn from_path_with(path: impl AsRef<Path>, opts: &LoadOptions) -> Result<Self> {
         let path = path.as_ref();
-        let vb = var_builder_from_path(path, PMPNN_FORMAT, &LoadOptions::new(device))?;
+        let vb = var_builder_from_path(path, PMPNN_FORMAT, opts)?;
         let config = ProteinMPNNConfig::proteinmpnn();
         let model = ProteinMPNN::load(vb, &config)
             .map_err(|e| anyhow!("Failed to load ProteinMPNN weights: {e}"))?;

--- a/crates/ferritin-plms/src/loader.rs
+++ b/crates/ferritin-plms/src/loader.rs
@@ -65,6 +65,24 @@ impl LoadOptions {
         self.dtype = dtype;
         self
     }
+
+    /// Reject dtype/device combinations the backend cannot run.
+    ///
+    /// candle's CPU backend has no BF16 `matmul`, so a BF16 model on CPU fails
+    /// partway through loading or on the first forward pass with a bare
+    /// "unsupported dtype BF16 for op matmul". Catching it here says what to do
+    /// instead (ferritin-100.9).
+    pub fn validate(&self) -> Result<()> {
+        if self.dtype == DType::BF16 && self.device.is_cpu() {
+            bail!(
+                "BF16 is not supported on the CPU backend: candle has no BF16 matmul there, \
+                 so loading or the first forward pass would fail with a bare \
+                 'unsupported dtype BF16 for op matmul'. Use F16 for half precision on CPU, \
+                 or run on Metal/CUDA."
+            );
+        }
+        Ok(())
+    }
 }
 
 // ── Format ────────────────────────────────────────────────────────────────────
@@ -214,6 +232,7 @@ pub fn var_builder_from_path(
     format: Format,
     opts: &LoadOptions,
 ) -> Result<VarBuilder<'static>> {
+    opts.validate()?;
     match format {
         Format::Safetensors => {
             // SAFETY: mmap of a file we just materialised in the HF cache. As
@@ -308,6 +327,30 @@ mod tests {
                 root_key: Some("model_state_dict")
             }
         );
+    }
+
+    /// BF16 on CPU is refused up front with an explanation rather than
+    /// surfacing candle's bare matmul error mid-load (ferritin-100.9).
+    #[test]
+    fn test_load_options_rejects_bf16_on_cpu() {
+        let err = LoadOptions::new(Device::Cpu)
+            .with_dtype(DType::BF16)
+            .validate()
+            .expect_err("BF16 on CPU must be refused");
+        assert!(
+            err.to_string().contains("not supported on the CPU backend"),
+            "error should explain the CPU limitation; got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_load_options_accepts_f16_and_f32_on_cpu() {
+        for dtype in [DType::F32, DType::F16] {
+            LoadOptions::new(Device::Cpu)
+                .with_dtype(dtype)
+                .validate()
+                .unwrap_or_else(|e| panic!("{dtype:?} should be allowed on CPU: {e}"));
+        }
     }
 
     #[test]

--- a/crates/ferritin-plms/tests/test_plm_dtype_parity.rs
+++ b/crates/ferritin-plms/tests/test_plm_dtype_parity.rs
@@ -1,0 +1,185 @@
+//! What reduced precision actually costs, measured rather than assumed
+//! (ferritin-100.9).
+//!
+//! F16/BF16 exist here because the largest advertised variants are unloadable
+//! at F32 — `ESM2Models::T48_15B` is ~60 GB, `ESMCModels::ESMC6B` ~24 GB (and
+//! ~12 GB at its on-disk BF16). Halving the footprint is only useful if the
+//! numerics survive, so these tests compare each model against **its own F32
+//! output** and record the divergence, rather than trusting that half
+//! precision is "close enough".
+//!
+//! # Measured on CPU, candle 0.11, ESM2 t6_8M and AMPLIFY 120M
+//!
+//! | model | dtype | max abs Δlogit | mean abs Δlogit | argmax agreement |
+//! |---|---|---|---|---|
+//! | ESM2 | F16 | 2.44e-1 | 2.25e-2 | **1.000** |
+//! | AMPLIFY | F16 | 2.39e-1 | 6.87e-2 | **0.923** |
+//! | either | BF16 | — | — | unsupported on CPU |
+//!
+//! The headline is the last column, not the first. Both models shift logits by
+//! a similar amount, but that shift changes **no** ESM2 top-1 prediction and
+//! roughly **one AMPLIFY position in thirteen**. So F16 is a safe swap for
+//! ESM2 inference and a judgement call for AMPLIFY — worth knowing before
+//! trading precision for memory.
+//!
+//! BF16 is refused up front on CPU: candle has no BF16 `matmul` there, so it
+//! would otherwise fail partway through loading (ESM2) or on the first forward
+//! pass (AMPLIFY) with a bare "unsupported dtype BF16 for op matmul".
+//!
+//! ```shell
+//! cargo test -p ferritin-plms --test test_plm_dtype_parity -- --include-ignored
+//! ```
+
+use anyhow::Result;
+use candle_core::{D, DType, Device, Tensor};
+use ferritin_plms::loader::LoadOptions;
+use ferritin_plms::{AmplifyModels, AmplifyRunner, ESM2Models, ESM2Runner, device};
+
+const SEQUENCES: &[&str] = &["MQIFVKTLTGK", "GGGGGGGGG", "KEKEKEKEK"];
+
+/// `(max abs diff, mean abs diff)` between two logits tensors.
+fn diff_stats(a: &Tensor, b: &Tensor) -> Result<(f32, f32)> {
+    let a = a.to_dtype(DType::F32)?.flatten_all()?.to_vec1::<f32>()?;
+    let b = b.to_dtype(DType::F32)?.flatten_all()?.to_vec1::<f32>()?;
+    let diffs = a.iter().zip(&b).map(|(x, y)| (x - y).abs());
+    let max = diffs.clone().fold(0.0f32, f32::max);
+    let mean = diffs.sum::<f32>() / a.len() as f32;
+    Ok((max, mean))
+}
+
+/// Fraction of positions whose top-1 predicted token is unchanged.
+///
+/// The measure that actually matters: a logit shift nothing downstream can see
+/// is not a regression.
+fn argmax_agreement(a: &Tensor, b: &Tensor) -> Result<f32> {
+    let am = a
+        .to_dtype(DType::F32)?
+        .argmax(D::Minus1)?
+        .flatten_all()?
+        .to_vec1::<u32>()?;
+    let bm = b
+        .to_dtype(DType::F32)?
+        .argmax(D::Minus1)?
+        .flatten_all()?
+        .to_vec1::<u32>()?;
+    let same = am.iter().zip(&bm).filter(|(x, y)| x == y).count();
+    Ok(same as f32 / am.len() as f32)
+}
+
+// Bounds sit above the measured values with headroom, but tight enough that a
+// real numerical regression trips them.
+const ESM2_F16_MAX_DIFF: f32 = 0.5; // measured 2.44e-1
+const ESM2_F16_MEAN_DIFF: f32 = 0.05; // measured 2.25e-2
+const AMPLIFY_F16_MAX_DIFF: f32 = 0.5; // measured 2.39e-1
+const AMPLIFY_F16_MEAN_DIFF: f32 = 0.15; // measured 6.87e-2
+const AMPLIFY_F16_MIN_AGREEMENT: f32 = 0.85; // measured 0.923
+
+/// ESM2 at F16 shifts logits slightly but changes no top-1 prediction.
+#[test]
+#[ignore = "requires downloading facebook/esm2_t6_8M_UR50D weights"]
+fn test_esm2_f16_matches_f32() -> Result<()> {
+    let dev = device(false)?;
+    let f32_model = ESM2Runner::load_model_with(ESM2Models::T6_8M, &LoadOptions::new(dev.clone()))?;
+    let f16_model = ESM2Runner::load_model_with(
+        ESM2Models::T6_8M,
+        &LoadOptions::new(dev).with_dtype(DType::F16),
+    )?;
+
+    for sequence in SEQUENCES {
+        let a = f32_model.run_forward(sequence)?.logits;
+        let b = f16_model.run_forward(sequence)?.logits;
+
+        let (max, mean) = diff_stats(&a, &b)?;
+        assert!(
+            max < ESM2_F16_MAX_DIFF,
+            "{sequence}: ESM2 F16 max logit diff {max:.3e} exceeds {ESM2_F16_MAX_DIFF:.1e}"
+        );
+        assert!(
+            mean < ESM2_F16_MEAN_DIFF,
+            "{sequence}: ESM2 F16 mean logit diff {mean:.3e} exceeds {ESM2_F16_MEAN_DIFF:.1e}"
+        );
+
+        let agreement = argmax_agreement(&a, &b)?;
+        assert_eq!(
+            agreement, 1.0,
+            "{sequence}: ESM2 F16 changed a top-1 prediction (agreement {agreement:.4}); \
+             it has been exactly 1.0 — investigate before relaxing this"
+        );
+    }
+    Ok(())
+}
+
+/// AMPLIFY at F16 changes roughly one top-1 prediction in thirteen.
+///
+/// Asserted as a floor rather than equality precisely because it is *not* 1.0:
+/// this test exists to keep that documented and to catch it getting worse.
+#[test]
+#[ignore = "requires downloading chandar-lab/AMPLIFY_120M weights"]
+fn test_amplify_f16_matches_f32() -> Result<()> {
+    let dev = device(false)?;
+    let f32_model =
+        AmplifyRunner::load_model_with(AmplifyModels::AMP120M, &LoadOptions::new(dev.clone()))?;
+    let f16_model = AmplifyRunner::load_model_with(
+        AmplifyModels::AMP120M,
+        &LoadOptions::new(dev).with_dtype(DType::F16),
+    )?;
+
+    for sequence in SEQUENCES {
+        let a = f32_model.run_forward(sequence)?.logits;
+        let b = f16_model.run_forward(sequence)?.logits;
+
+        let (max, mean) = diff_stats(&a, &b)?;
+        assert!(
+            max < AMPLIFY_F16_MAX_DIFF,
+            "{sequence}: AMPLIFY F16 max logit diff {max:.3e} exceeds {AMPLIFY_F16_MAX_DIFF:.1e}"
+        );
+        assert!(
+            mean < AMPLIFY_F16_MEAN_DIFF,
+            "{sequence}: AMPLIFY F16 mean logit diff {mean:.3e} exceeds {AMPLIFY_F16_MEAN_DIFF:.1e}"
+        );
+
+        let agreement = argmax_agreement(&a, &b)?;
+        assert!(
+            agreement >= AMPLIFY_F16_MIN_AGREEMENT,
+            "{sequence}: AMPLIFY F16 top-1 agreement {agreement:.4} below \
+             {AMPLIFY_F16_MIN_AGREEMENT:.2}"
+        );
+    }
+    Ok(())
+}
+
+/// AMPLIFY's rotary table was built at F32 regardless of the model dtype, so
+/// an F16 model died in `apply_rotary_emb` with "dtype mismatch in mul, lhs:
+/// F16, rhs: F32". Loading and running at F16 at all is the regression test.
+#[test]
+#[ignore = "requires downloading chandar-lab/AMPLIFY_120M weights"]
+fn test_amplify_f16_rotary_dtype_matches_model() -> Result<()> {
+    let dev = device(false)?;
+    let model = AmplifyRunner::load_model_with(
+        AmplifyModels::AMP120M,
+        &LoadOptions::new(dev).with_dtype(DType::F16),
+    )?;
+    let out = model.run_forward(SEQUENCES[0])?;
+    assert_eq!(out.logits.dtype(), DType::F16);
+    Ok(())
+}
+
+/// BF16 is refused on CPU with an explanation, not candle's bare matmul error.
+///
+/// Needs no weights: the check runs before any download.
+#[test]
+fn test_bf16_refused_on_cpu_with_explanation() {
+    let err = LoadOptions::new(Device::Cpu)
+        .with_dtype(DType::BF16)
+        .validate()
+        .expect_err("BF16 on CPU must be refused up front");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("not supported on the CPU backend"),
+        "error should explain the limitation; got: {msg}"
+    );
+    assert!(
+        msg.contains("F16"),
+        "error should point at the workable alternative; got: {msg}"
+    );
+}


### PR DESCRIPTION
> Stacked on #181 → #180 → #179. Bases retarget as each merges.

## Why

Six hardcoded `const *_DTYPE = DType::F32` meant several **advertised variants could not actually be loaded**:

| variant | F32 footprint |
|---|---|
| `ESM2Models::T48_15B` | ~60 GB |
| `ESM2Models::T36_3B` | ~12 GB |
| `ESMCModels::ESMC6B` | ~24 GB — and `ESMFold2Runner::from_pretrained_with_backbone` requires it |

The ESMFold2 docs already described that backbone as "~12 GB" — its on-disk BF16 size, which the crate then doubled on load.

## Plumbing

`LoadOptions` (from #180) already carried a dtype, so this threads it through: every runner gains a `*_with` constructor taking `&LoadOptions`, and the existing device-only constructors delegate to it at F32.

Default behaviour is unchanged. dtype is **not** auto-selected by device — silently changing numerics based on hardware would make parity failures irreproducible across machines.

## Measuring rather than assuming turned up two real things

**BF16 does not work on candle's CPU backend at all.** There is no BF16 `matmul`, so it fails partway through loading (ESM2) or on the first forward pass (AMPLIFY) with a bare `unsupported dtype BF16 for op matmul`. `LoadOptions::validate` now refuses that combination up front and points at F16 or a GPU device.

**AMPLIFY could not run at F16 for a real reason.** `precompute_freqs_cis` always built the rotary table at F32 and `.to_device()` never cast it, so an F16 model died in `apply_rotary_emb` with `dtype mismatch in mul, lhs: F16, rhs: F32`. The table is now computed at F32 for precision and cast to the model's dtype.

## What F16 actually costs

Measured on CPU against **each model's own F32 output** (t6_8M, AMPLIFY 120M) — isolating the dtype cost from any pre-existing divergence from the Python reference:

| model | dtype | max Δlogit | mean Δlogit | argmax agreement |
|---|---|---|---|---|
| ESM2 | F16 | 2.44e-1 | 2.25e-2 | **1.000** |
| AMPLIFY | F16 | 2.39e-1 | 6.87e-2 | **0.923** |
| either | BF16 | — | — | unsupported on CPU |

**The last column is the headline, not the first.** Both models shift logits by a similar amount, but that shift changes *no* ESM2 top-1 prediction and roughly **one AMPLIFY position in thirteen**. So F16 is a safe swap for ESM2 inference and a judgement call for AMPLIFY — which is exactly the kind of thing you want to know before trading precision for memory, and exactly what assuming "half precision is close enough" would have hidden.

`tests/test_plm_dtype_parity.rs` records this. Bounds sit above the measured values with headroom but tight enough to catch a regression; ESM2's agreement is asserted as **exact equality** since it has been exactly 1.0, while AMPLIFY's is a floor precisely because it is not.

## Verification

```
cargo test -p ferritin-plms --test test_plm_dtype_parity -- --include-ignored   # 4 passed
cargo test -p ferritin-plms --test test_plm_esm2 --test test_plm_amplify \
    --test test_plm_runner_contract -- --include-ignored                       # 13 passed
cargo clippy --workspace --all-targets && cargo fmt --all --check              # clean
```

The ESM2 and AMPLIFY numerical parity tests against the Python reference still pass.

## Not covered

Metal was not measured — I only have CPU here, and the issue notes F16 is where Metal pays off. BF16 may well work on Metal/CUDA; `validate()` only refuses it on CPU, so those paths are open. Worth a follow-up measurement on hardware that has them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
