### PR TITLE
Make the nightly parity signal honest; fix ESM3 pretrained loading (ferritin-100.20, ferritin-100.21)

### DIFF
--- a/crates/ferritin-plms/src/esm3/layers/blocks.rs
+++ b/crates/ferritin-plms/src/esm3/layers/blocks.rs
@@ -57,8 +57,10 @@ impl UnifiedTransformerBlock {
         let attn = MultiHeadAttention::load(vb.pp("attn"), &esmc_cfg)?;
 
         let geom_attn = if layer_idx < config.n_layers_geom {
+            // Checkpoints name this block "geom_attn", not "geometric"
+            // (ferritin-100.21).
             Some(GeometricReasoningOriginalImpl::load(
-                vb.pp("geometric"),
+                vb.pp("geom_attn"),
                 &esmc_cfg,
             )?)
         } else {

--- a/crates/ferritin-plms/src/esm3/models/vqvae.rs
+++ b/crates/ferritin-plms/src/esm3/models/vqvae.rs
@@ -60,7 +60,10 @@ impl VqVaeConfig {
             scale_residue: false,
             mask_and_zero_frameless: true,
             qk_layernorm: true,
-            bias: false,
+            // esm3_structure_encoder_v0.pth stores geom_attn with bias terms
+            // (s_norm.bias, proj.bias, out_proj.bias), unlike the main model
+            // (ferritin-100.21).
+            bias: true,
             // Vocab/embedding sizes unused by TransformerStack
             d_sequence_vocab: 0,
             d_structure_vocab: self.n_codes,

--- a/crates/ferritin-plms/src/esm3/pretrained.rs
+++ b/crates/ferritin-plms/src/esm3/pretrained.rs
@@ -8,13 +8,18 @@
 //! The `.pth` file is a plain PyTorch state dict saved via `torch.save(model.state_dict(), ...)`.
 //! No wrapping key is used; `PthTensors::new(path, None)` loads it directly.
 //!
+//! Note the repo path: the checkpoints live under `data/weights/`, not at the
+//! repo root. Requesting the bare filename returns
+//! "Entry not found: esm3_sm_open_v1.pth" (ferritin-100.21).
+//!
 //! | Model attribute (Python) | VarBuilder prefix |
 //! |--------------------------|-------------------|
 //! | `encoder.*`              | `encoder.*`       |
 //! | `transformer.*`          | `transformer.*`   |
 //! | `output_heads.*`         | `output_heads.*`  |
 //!
-//! The structure encoder uses a separate checkpoint (`esm3_structure_encoder_v0.pth`):
+//! The structure encoder uses a separate checkpoint
+//! (`data/weights/esm3_structure_encoder_v0.pth`):
 //!
 //! | Python attribute        | VarBuilder prefix  |
 //! |-------------------------|--------------------|
@@ -23,11 +28,11 @@
 //! | `codebook.embeddings`   | `codebook.*`       |
 
 use crate::esm3::models::esm3::{ESM3, ESM3Config};
-use crate::esm3::models::vqvae::{StructureTokenEncoder, VqVaeConfig};
+use crate::esm3::models::vqvae::StructureTokenEncoder;
 use crate::esm3::tokenization::sequence::tokenize_sequence;
 use crate::loader::{LoadOptions, WeightSource};
 use crate::plm_runner::{ModelMetadata, PlmRunner, SpecialTokenLayout};
-use anyhow::Result;
+use anyhow::{Result, bail};
 use candle_core::{Device, Tensor};
 
 // ── ESM3Models enum ───────────────────────────────────────────────────────────
@@ -41,11 +46,29 @@ pub enum ESM3Models {
 /// The `esm3-sm-open-v1` repo, whose `.pth` checkpoints store tensors at the root.
 const ESM3_REPO: WeightSource = WeightSource::pth("EvolutionaryScale/esm3-sm-open-v1", None);
 
+/// Why [`StructureEncoderRunner::from_pretrained`] refuses to load.
+///
+/// The main ESM3 model loads correctly (ferritin-100.21), but the VQ-VAE
+/// structure encoder is a different shape from the one ported here.
+pub const STRUCTURE_ENCODER_MISMATCH: &str = "\
+ESM3 structure-encoder weights cannot be loaded: the ported VQ-VAE encoder does not match \
+data/weights/esm3_structure_encoder_v0.pth. The checkpoint roots its stack at 'transformer', \
+not 'encoder'; its two blocks contain only geom_attn and ffn, with no multi-head 'attn' \
+sub-module and no per-stack final 'norm.weight'; it carries a \
+relative_positional_embedding.embedding.weight that this port does not model; and its \
+pre_vq_proj has a bias that the port loads without. Loading is refused rather than patched, \
+because resolving the paths without porting the real encoder would emit structure tokens that \
+look plausible and are wrong (ferritin-100.22). ESM3Runner itself is unaffected and works.";
+
 impl ESM3Models {
     /// Weight source, `.pth` filename, and config for this variant.
     pub fn model_info(&self) -> (WeightSource, &'static str, ESM3Config) {
         match self {
-            Self::SmOpen => (ESM3_REPO, "esm3_sm_open_v1.pth", ESM3Config::sm_open()),
+            Self::SmOpen => (
+                ESM3_REPO,
+                "data/weights/esm3_sm_open_v1.pth",
+                ESM3Config::sm_open(),
+            ),
         }
     }
 }
@@ -170,7 +193,8 @@ impl PlmRunner for ESM3Runner {
 
 /// Wraps the ESM3 structure token encoder for converting backbone coordinates to tokens.
 ///
-/// Uses a separate checkpoint (`esm3_structure_encoder_v0.pth`) from the main model.
+/// Uses a separate checkpoint (`data/weights/esm3_structure_encoder_v0.pth`)
+/// from the main model.
 pub struct StructureEncoderRunner {
     encoder: StructureTokenEncoder,
     #[allow(dead_code)]
@@ -178,19 +202,20 @@ pub struct StructureEncoderRunner {
 }
 
 impl StructureEncoderRunner {
-    /// Download and load the structure encoder from HuggingFace.
+    /// Loading the structure encoder is **not supported** — this always
+    /// returns an error (ferritin-100.22).
+    ///
+    /// The ported VQ-VAE encoder does not match
+    /// `data/weights/esm3_structure_encoder_v0.pth`. See
+    /// [`STRUCTURE_ENCODER_MISMATCH`].
     pub fn from_pretrained(device: Device) -> Result<Self> {
         Self::from_pretrained_with(&LoadOptions::new(device))
     }
 
-    /// Load with an explicit device and dtype (ferritin-100.9).
-    pub fn from_pretrained_with(opts: &LoadOptions) -> Result<Self> {
-        let vb = ESM3_REPO.var_builder("esm3_structure_encoder_v0.pth", opts)?;
-        let encoder = StructureTokenEncoder::load(vb, VqVaeConfig::default())?;
-        Ok(Self {
-            encoder,
-            device: opts.device.clone(),
-        })
+    /// Loading the structure encoder is **not supported** — this always
+    /// returns an error (ferritin-100.22).
+    pub fn from_pretrained_with(_opts: &LoadOptions) -> Result<Self> {
+        bail!("{STRUCTURE_ENCODER_MISMATCH}");
     }
 
     /// Encode backbone coordinates to structure tokens.

--- a/crates/ferritin-plms/src/esmc/layers/geom_attention.rs
+++ b/crates/ferritin-plms/src/esmc/layers/geom_attention.rs
@@ -43,29 +43,70 @@ impl GeometricReasoningOriginalImpl {
     //         rotation_scale_per_head: Tensor::zeros((v_heads,), device)?,
     //     })
     // }
+    /// Load geometric attention from a `VarBuilder` rooted at `geom_attn`.
+    ///
+    /// Weight layout, verified against both `esm3_sm_open_v1.pth` and
+    /// `esm3_structure_encoder_v0.pth` (ferritin-100.21):
+    ///
+    /// ```text
+    /// s_norm.weight[/.bias]      — (d_model,)
+    /// proj.weight[/.bias]        — (15 * v_heads, d_model)
+    /// out_proj.weight[/.bias]    — (d_model, 3 * v_heads)
+    /// distance_scale_per_head    — (v_heads,)
+    /// rotation_scale_per_head    — (v_heads,)
+    /// ```
+    ///
+    /// The main ESM3 model stores these **without** bias terms while the VQ-VAE
+    /// structure encoder stores them **with** bias, so `config.bias` selects.
     pub fn load(vb: VarBuilder, config: &ESMCConfig) -> Result<Self> {
         let ESMCConfig {
             d_model,
             v_head_transformer,
             mask_and_zero_frameless,
+            bias,
             ..
         } = config;
 
         let num_vector_messages = 1usize;
 
-        // todo: this is a hidden param. Needs to be fixed
-        let v_heads = v_head_transformer.unwrap_or(128);
+        // Previously defaulted to 128, which silently mis-sized every geometric
+        // projection for the main ESM3 model (v_heads = 256). The checkpoint's
+        // per-head scale tensors give the true value, so a missing config is an
+        // error rather than a guess.
+        let v_heads = v_head_transformer.ok_or_else(|| {
+            candle_core::Error::Msg(
+                "geometric attention needs v_head_transformer to be set; it determines the \
+                 projection sizes and cannot be guessed"
+                    .to_string(),
+            )
+        })?;
 
         let dim_proj = 4 * v_heads * 3 + v_heads * 3 * num_vector_messages;
         let channels_out = v_heads * 3 * num_vector_messages;
 
-        let ln_conf = LayerNormConfig::from(1e-5);
-        let s_norm = nn::layer_norm(*d_model, ln_conf, vb.pp("layer_norm"))?;
+        let s_norm = if *bias {
+            nn::layer_norm(*d_model, LayerNormConfig::from(1e-5), vb.pp("s_norm"))?
+        } else {
+            LayerNorm::new_no_bias(vb.pp("s_norm").get((*d_model,), "weight")?, 1e-5)
+        };
 
-        let proj = nn::linear(*d_model, dim_proj, vb.pp("linear1"))?;
-        let out_proj = nn::linear(channels_out, *d_model, vb.pp("outproj"))?;
-        let distance_scale_per_head = Tensor::zeros((v_heads,), vb.dtype(), vb.device())?;
-        let rotation_scale_per_head = Tensor::zeros((v_heads,), vb.dtype(), vb.device())?;
+        let (proj, out_proj) = if *bias {
+            (
+                nn::linear(*d_model, dim_proj, vb.pp("proj"))?,
+                nn::linear(channels_out, *d_model, vb.pp("out_proj"))?,
+            )
+        } else {
+            (
+                nn::linear_no_bias(*d_model, dim_proj, vb.pp("proj"))?,
+                nn::linear_no_bias(channels_out, *d_model, vb.pp("out_proj"))?,
+            )
+        };
+
+        // These are learned per-head scales. They used to be zero-initialised
+        // rather than loaded, which made geometric attention silently wrong
+        // while the model still loaded cleanly (ferritin-100.21).
+        let distance_scale_per_head = vb.get((v_heads,), "distance_scale_per_head")?;
+        let rotation_scale_per_head = vb.get((v_heads,), "rotation_scale_per_head")?;
 
         Ok(Self {
             c_s: *d_model,

--- a/crates/ferritin-plms/tests/fixtures/.gitignore
+++ b/crates/ferritin-plms/tests/fixtures/.gitignore
@@ -1,7 +1,14 @@
-# Parity fixtures are large by default and stay out of git — EXCEPT the small,
-# committed reference tensors for the parity suite (a few KB each), which the
-# non-ignored parity tests load. Large model-specific fixtures (ESMC-6B, ESM3,
-# etc.) remain generated-on-demand and gitignored.
+# Parity fixtures can be large, so they are gitignored by default and
+# un-ignored individually as they are committed.
+#
+# "Not committed" is NOT the same as "generated on demand" — nothing in CI
+# generates them, so an un-committed fixture means that port has no numerical
+# parity coverage at all. That gap is declared explicitly in PARITY_COVERAGE
+# (tests/support/parity.rs) and enforced by test_parity_coverage_is_accurate,
+# rather than left implicit here (ferritin-100.20).
+#
+# To add coverage: generate the fixture, un-ignore it below, and flip its
+# PARITY_COVERAGE entry to Committed.
 *.safetensors
 !esm2_parity.safetensors
 !amplify_parity.safetensors

--- a/crates/ferritin-plms/tests/support/parity.rs
+++ b/crates/ferritin-plms/tests/support/parity.rs
@@ -44,6 +44,82 @@ use candle_core::{Device, Tensor};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+// ── Declared parity coverage ─────────────────────────────────────────────────
+
+/// Whether a port's parity fixture is committed to the repo.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CoverageStatus {
+    /// The fixture is in `tests/fixtures/` and its parity test really runs.
+    Committed,
+    /// No fixture exists, so this port has **no numerical parity coverage**.
+    /// Its parity test skips rather than failing the nightly forever
+    /// (ferritin-100.20).
+    NotGenerated {
+        /// Why it has not been generated — what a fixer would need.
+        reason: &'static str,
+    },
+}
+
+/// One port's parity-fixture status.
+#[derive(Debug, Clone, Copy)]
+pub struct ParityCoverage {
+    /// Fixture stem, without `.safetensors`.
+    pub fixture: &'static str,
+    /// The `<X>` in `scripts/generate_<X>_fixtures.py`.
+    pub generator: &'static str,
+    pub status: CoverageStatus,
+}
+
+/// Which ports actually have numerical parity coverage, and which do not.
+///
+/// This table exists so that "no parity coverage" is a recorded, reviewed fact
+/// rather than something that quietly grows. `test_parity_coverage_is_accurate`
+/// asserts it against what is really on disk, so adding a fixture without
+/// declaring it — or adding a port with no fixture at all — fails CI instead of
+/// passing vacuously.
+///
+/// Before ferritin-100.20 the three `NotGenerated` entries failed the nightly
+/// every single night, because `tests/fixtures/.gitignore` describes them as
+/// "generated-on-demand" but nothing in CI generates them.
+pub const PARITY_COVERAGE: &[ParityCoverage] = &[
+    ParityCoverage {
+        fixture: "esm2_parity",
+        generator: "esm2",
+        status: CoverageStatus::Committed,
+    },
+    ParityCoverage {
+        fixture: "amplify_parity",
+        generator: "amplify",
+        status: CoverageStatus::Committed,
+    },
+    ParityCoverage {
+        fixture: "esmc_parity",
+        generator: "esmc",
+        status: CoverageStatus::NotGenerated {
+            reason: "needs the `esm` SDK and an ESMC-300M download to generate",
+        },
+    },
+    ParityCoverage {
+        fixture: "esm3_parity",
+        generator: "esm3",
+        status: CoverageStatus::NotGenerated {
+            reason: "needs the `esm` SDK and gated EvolutionaryScale weights (HF_TOKEN)",
+        },
+    },
+    ParityCoverage {
+        fixture: "1BC8_log_probs",
+        generator: "proteinmpnn",
+        status: CoverageStatus::NotGenerated {
+            reason: "needs the dauparas/ProteinMPNN Python package checked out and installed",
+        },
+    },
+];
+
+/// Look up a fixture's declared coverage, if it is declared at all.
+pub fn declared_coverage(fixture: &str) -> Option<&'static ParityCoverage> {
+    PARITY_COVERAGE.iter().find(|c| c.fixture == fixture)
+}
+
 /// A loaded parity fixture: the safetensors key→tensor map plus the fixture
 /// name, used for good error messages.
 #[derive(Debug)]
@@ -100,6 +176,48 @@ impl ParityFixture {
                 keys.join(", ")
             )
         })
+    }
+
+    /// Load a fixture, or return `None` if it is declared as not generated.
+    ///
+    /// This is what keeps the nightly signal honest. A fixture that
+    /// [`PARITY_COVERAGE`] marks `NotGenerated` is a known gap: the test skips
+    /// and says so, rather than failing every night for a reason no run can fix.
+    ///
+    /// A fixture declared [`Committed`][CoverageStatus::Committed] but missing
+    /// from disk is a **regression** — someone deleted a checked-in fixture —
+    /// and still errors. So does an undeclared fixture: add it to the table.
+    pub fn load_or_skip(name: &str, device: &Device) -> Result<Option<Self>> {
+        let coverage = declared_coverage(name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "parity fixture '{name}' is not listed in PARITY_COVERAGE; add it there \
+                 so its coverage status is explicit (ferritin-100.20)"
+            )
+        })?;
+
+        match coverage.status {
+            CoverageStatus::Committed => {
+                Self::load_with_generator(name, coverage.generator, device).map(Some)
+            }
+            CoverageStatus::NotGenerated { reason } => {
+                if fixture_path(name).exists() {
+                    bail!(
+                        "parity fixture '{name}' exists on disk but PARITY_COVERAGE still \
+                         declares it NotGenerated — flip it to Committed so its test runs \
+                         (ferritin-100.20)"
+                    );
+                }
+                eprintln!(
+                    "SKIPPING {name} parity: no fixture committed, so this port has NO \
+                     numerical parity coverage. Reason: {reason}. Generate with \
+                     `python scripts/generate_{}_fixtures.py --output \
+                     crates/ferritin-plms/tests/fixtures/` and flip its PARITY_COVERAGE \
+                     entry to Committed (ferritin-100.20).",
+                    coverage.generator
+                );
+                Ok(None)
+            }
+        }
     }
 
     /// The fixture stem, for diagnostics.

--- a/crates/ferritin-plms/tests/test_parity_harness.rs
+++ b/crates/ferritin-plms/tests/test_parity_harness.rs
@@ -124,3 +124,80 @@ fn fixture_load_missing_names_generator_script() {
             .ends_with("tests/fixtures/nonexistent_parity.safetensors")
     );
 }
+
+// ── Declared parity coverage (ferritin-100.20) ───────────────────────────────
+
+/// The declared coverage table must match what is actually on disk.
+///
+/// This is what keeps the skip-when-absent behaviour from turning the nightly
+/// into a vacuous green. Committing a fixture without flipping its entry to
+/// `Committed` — or deleting a committed one — fails here.
+#[test]
+fn test_parity_coverage_is_accurate() {
+    use support::parity::{CoverageStatus, PARITY_COVERAGE, fixture_path};
+
+    for entry in PARITY_COVERAGE {
+        let exists = fixture_path(entry.fixture).exists();
+        match entry.status {
+            CoverageStatus::Committed => assert!(
+                exists,
+                "'{}' is declared Committed but is missing from tests/fixtures/. \
+                 Restore it, or change its PARITY_COVERAGE status.",
+                entry.fixture
+            ),
+            CoverageStatus::NotGenerated { .. } => assert!(
+                !exists,
+                "'{}' exists on disk but is declared NotGenerated. Flip its \
+                 PARITY_COVERAGE entry to Committed so its parity test runs.",
+                entry.fixture
+            ),
+        }
+    }
+}
+
+/// Every fixture in `tests/fixtures/` must be declared, so a fixture cannot be
+/// added without its coverage status being stated.
+#[test]
+fn test_no_undeclared_fixtures_on_disk() {
+    use support::parity::declared_coverage;
+
+    let dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    for entry in std::fs::read_dir(&dir)
+        .expect("tests/fixtures should exist")
+        .flatten()
+    {
+        let path = entry.path();
+        if path.extension().is_none_or(|e| e != "safetensors") {
+            continue;
+        }
+        let stem = path.file_stem().unwrap().to_string_lossy().to_string();
+        assert!(
+            declared_coverage(&stem).is_some(),
+            "fixture '{stem}' is on disk but absent from PARITY_COVERAGE; declare it there"
+        );
+    }
+}
+
+/// Records which ports currently have NO numerical parity coverage.
+///
+/// Deliberately an assertion on the exact set rather than a `println!`: the gap
+/// is a reviewed fact, so closing one (or opening a new one) has to be a
+/// conscious edit here. Shrinking this list is the goal.
+#[test]
+fn test_uncovered_ports_are_the_known_set() {
+    use support::parity::{CoverageStatus, PARITY_COVERAGE};
+
+    let mut uncovered: Vec<&str> = PARITY_COVERAGE
+        .iter()
+        .filter(|c| matches!(c.status, CoverageStatus::NotGenerated { .. }))
+        .map(|c| c.fixture)
+        .collect();
+    uncovered.sort_unstable();
+
+    assert_eq!(
+        uncovered,
+        ["1BC8_log_probs", "esm3_parity", "esmc_parity"],
+        "the set of ports without parity coverage changed; update this test and \
+         ferritin-100.20 deliberately rather than letting it drift"
+    );
+}

--- a/crates/ferritin-plms/tests/test_plm_esm3.rs
+++ b/crates/ferritin-plms/tests/test_plm_esm3.rs
@@ -262,7 +262,11 @@ fn test_esm3_parity_vs_python_reference() -> Result<()> {
     use support::parity::{ParityFixture, SpecialTokens, align_rows, assert_embeddings_close};
 
     let device = Device::Cpu;
-    let fixture = ParityFixture::load("esm3_parity", &device)?;
+    // Skips (loudly) while no esm3_parity fixture is committed — see
+    // PARITY_COVERAGE and ferritin-100.20.
+    let Some(fixture) = ParityFixture::load_or_skip("esm3_parity", &device)? else {
+        return Ok(());
+    };
     let ref_embeddings = fixture.tensor("embeddings")?;
 
     let runner = ESM3Runner::from_pretrained(ESM3Models::SmOpen, device)?;
@@ -272,4 +276,30 @@ fn test_esm3_parity_vs_python_reference() -> Result<()> {
     assert_embeddings_close(&rust_embeddings, ref_embeddings, ESM3_EMBED_COSINE_FLOOR)?;
     println!("ESM3 sm-open embedding parity OK (cosine floor {ESM3_EMBED_COSINE_FLOOR})");
     Ok(())
+}
+
+/// The structure encoder refuses to load, with the mismatch named.
+///
+/// Nothing exercised `StructureEncoderRunner` before ferritin-100.21, which is
+/// how its loading defects went unnoticed. Fixing the main model's checkpoint
+/// path revealed that the ported VQ-VAE encoder is a different shape from the
+/// released one, so it refuses rather than half-loading (ferritin-100.22).
+///
+/// Needs no weights: the refusal precedes any download.
+#[test]
+fn test_esm3_structure_encoder_refuses_with_reason() {
+    use ferritin_plms::esm3::pretrained::StructureEncoderRunner;
+
+    let err = StructureEncoderRunner::from_pretrained(Device::Cpu)
+        .map(|_| ())
+        .expect_err("the structure encoder must refuse while the port is mismatched");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("does not match"),
+        "error should name the mismatch; got: {msg}"
+    );
+    assert!(
+        msg.contains("ESM3Runner itself is unaffected"),
+        "error should say the main model still works; got: {msg}"
+    );
 }

--- a/crates/ferritin-plms/tests/test_plm_esmc.rs
+++ b/crates/ferritin-plms/tests/test_plm_esmc.rs
@@ -219,7 +219,11 @@ fn test_esmc_parity_vs_python_reference() -> Result<()> {
     use support::parity::{ParityFixture, SpecialTokens, align_rows, assert_embeddings_close};
 
     let device = Device::Cpu;
-    let fixture = ParityFixture::load("esmc_parity", &device)?;
+    // Skips (loudly) while no esmc_parity fixture is committed — see
+    // PARITY_COVERAGE and ferritin-100.20.
+    let Some(fixture) = ParityFixture::load_or_skip("esmc_parity", &device)? else {
+        return Ok(());
+    };
     let ref_embeddings = fixture.tensor("embeddings")?;
 
     let runner = ESMCRunner::from_pretrained(ESMCModels::ESMC300M, device)?;

--- a/crates/ferritin-plms/tests/test_plm_ligandmpnn.rs
+++ b/crates/ferritin-plms/tests/test_plm_ligandmpnn.rs
@@ -94,8 +94,13 @@ mod tests {
 
         // Python-reference log-probs, shape (L, 21). ProteinMPNN has no special
         // tokens, so the reference rows align 1:1 with residues.
-        let fixture = ParityFixture::load_with_generator("1BC8_log_probs", "proteinmpnn", &device)
-            .expect("failed to load ProteinMPNN parity fixture");
+        // Skips (loudly) while no 1BC8_log_probs fixture is committed — see
+        // PARITY_COVERAGE and ferritin-100.20.
+        let Some(fixture) = ParityFixture::load_or_skip("1BC8_log_probs", &device)
+            .expect("ProteinMPNN parity fixture lookup failed")
+        else {
+            return;
+        };
         let ref_log_probs = fixture.tensor("log_probs").expect("missing 'log_probs'");
         let (_, vocab_size) = ref_log_probs.dims2().expect("expected 2D tensor");
         assert_eq!(vocab_size, 21, "ProteinMPNN vocab is 21 amino acids");


### PR DESCRIPTION
Two commits. The second exists because the first made the nightly's real failures visible.

## 1. The nightly was permanently red for an unfixable reason (100.20)

Nightly Parity runs `--include-ignored`, so three parity tests execute that load fixtures which **do not exist in the repo and are gitignored**: `esmc_parity`, `esm3_parity`, `1BC8_log_probs`.

ferritin-100.2 committed only `esm2_parity` (5.6 KB) and `amplify_parity` (3.0 KB). `tests/fixtures/.gitignore` called the rest "generated-on-demand" — but nothing in CI generates them, so on-demand meant **never**.

**Skipping when absent is not sufficient on its own.** A permanently-red nightly and a green-but-vacuous one are the same failure of the same signal, in opposite directions. So the gap is declared and enforced:

- **`PARITY_COVERAGE`** declares each port's fixture `Committed` or `NotGenerated { reason }`, where the reason states what a fixer would actually need.
- **`load_or_skip`** returns `None` for a declared gap and prints what is uncovered. It still **errors** for a fixture declared `Committed` but missing (someone deleted a checked-in fixture), and for any fixture not listed at all.
- **`test_parity_coverage_is_accurate`** asserts the table against what is really on disk.
- **`test_no_undeclared_fixtures_on_disk`** stops a fixture appearing without a declared status.
- **`test_uncovered_ports_are_the_known_set`** pins the uncovered set as an exact assertion, not a `println!`, so closing a gap or opening one is a conscious edit. Shrinking that list is the goal.

I did **not** generate the three fixtures: that needs the `esm` SDK, the dauparas/ProteinMPNN package, and gated weights — a ~2 GB Python stack this environment lacks and whose installation is its own decision.

## 2. With that noise gone, ESM3 turned out to have never loaded (100.21)

Three defects, each hidden behind the previous:

1. **Wrong repo path.** The runner asked for `esm3_sm_open_v1.pth`; the file lives at `data/weights/esm3_sm_open_v1.pth`. It failed with `Entry not found` — legible only because of the error context added in #180.
2. **Renamed tensors.** Loading then failed at `transformer.blocks.0.geometric.layer_norm.weight`. The checkpoint's 539 keys say `geom_attn`, with `s_norm` / `proj` / `out_proj` — not `layer_norm` / `linear1` / `outproj`. Everything *else* matches the port well, so unlike ESMFold2 this really was the rename 100.16 was assumed to be.
3. **Two learned scales were zeroed, not loaded.** `distance_scale_per_head` and `rotation_scale_per_head` were built with `Tensor::zeros` while the checkpoint carries both. After the rename the model would have loaded *cleanly* and computed geometric attention with zeroed scales — precisely the silent wrongness #179 refused to create.

Also removed a guess: `v_head_transformer.unwrap_or(128)`, while the main model's per-head scale tensors are `(256,)` — every geometric projection was mis-sized. A missing value is now an error. Bias is config-driven (main model has none, VQ-VAE encoder does), so `VqVaeConfig`'s `bias: false` was wrong and is now `true`.

**Verified against the real 5 GB checkpoint: all 9 `test_plm_esm3` tests pass under `--include-ignored`**, including the two smoke tests that had been failing.

### And that revealed one more (100.22, filed)

The VQ-VAE **structure encoder** is a different shape from the port: its blocks have no multi-head `attn` at all, it roots at `transformer` not `encoder`, and it carries a relative positional embedding the port doesn't model. `StructureEncoderRunner::from_pretrained` now refuses with that diagnosis rather than half-loading, per the #179 precedent. Nothing had ever exercised it — which is how this hid. There's now a test for the refusal, and the full 34-tensor inventory is in 100.22.

## Verification

```
cargo test -p ferritin-plms -- --include-ignored   # green, incl. the real ESM3 checkpoint
cargo clippy --workspace --all-targets             # clean
cargo fmt --all --check                            # clean
```

## One thing I could not push

A matching explanatory comment for `.github/workflows/nightly-parity.yaml` is **not** included — pushing workflow changes needs a token scope this session doesn't have. The substance lives in `PARITY_COVERAGE` and the `.gitignore` regardless; happy to add it if you grant `workflow` scope or paste it in yourself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
