### PR TITLE
Stop ESM2Config silently substituting a different model's config (ferritin-goh.9)

### DIFF
--- a/crates/ferritin-plms/src/esm2/esm2.rs
+++ b/crates/ferritin-plms/src/esm2/esm2.rs
@@ -46,32 +46,63 @@ use tokenizers::Tokenizer;
 // for embeddings
 const MAX_SEQ_LEN: usize = 10000;
 
-#[derive(Deserialize, Clone)]
+/// ESM-2 architecture configuration, deserialized from a HuggingFace
+/// `config.json`.
+///
+/// # Which fields are required
+///
+/// Fields that change shapes or numerics are **required**: a missing one is a
+/// parse error rather than a silent default, because defaulting them would
+/// produce a model that loads and computes the wrong thing.
+///
+/// Everything else — training hyper-parameters, provenance strings, and
+/// metadata the forward pass never reads — carries `#[serde(default)]`. Real
+/// ESM-family configs omit these freely: `westlake-repl/SaProt_35M_AF2` has no
+/// `is_folding_model`, `esmfold_config` or `vocab_list`, and demanding them
+/// made its config unparseable (ferritin-goh.9).
+#[derive(Deserialize, Clone, Debug)]
 pub struct ESM2Config {
-    pub num_attention_heads: usize,
-    pub attention_probs_dropout_prob: f32,
-    pub classifier_dropout: Option<f32>,
-    pub emb_layer_norm_before: bool,
-    pub esmfold_config: Option<String>,
-    pub hidden_act: String,
-    pub hidden_dropout_prob: f32,
+    // ── Required: shapes ──
     pub hidden_size: usize,
-    pub initializer_range: f32,
-    pub intermediate_size: i32,
-    pub is_folding_model: bool,
-    pub layer_norm_eps: f32,
-    pub mask_token_id: i32,
-    pub max_position_embeddings: i32,
-    pub model_type: String,
     pub num_hidden_layers: i32,
-    pub pad_token_id: i32,
-    pub position_embedding_type: String,
-    pub token_dropout: bool,
-    pub torch_dtype: String,
-    pub transformers_version: String,
-    pub use_cache: bool,
-    pub vocab_list: Option<Vec<String>>,
+    pub num_attention_heads: usize,
+    pub intermediate_size: i32,
     pub vocab_size: i32,
+    pub max_position_embeddings: i32,
+
+    // ── Required: numerics and behaviour ──
+    /// `rotary` vs `absolute` changes the attention math outright.
+    pub position_embedding_type: String,
+    pub hidden_act: String,
+    pub layer_norm_eps: f32,
+    pub emb_layer_norm_before: bool,
+    pub token_dropout: bool,
+    pub mask_token_id: i32,
+    pub pad_token_id: i32,
+
+    // ── Optional: not read by the forward pass ──
+    #[serde(default)]
+    pub attention_probs_dropout_prob: f32,
+    #[serde(default)]
+    pub hidden_dropout_prob: f32,
+    #[serde(default)]
+    pub classifier_dropout: Option<f32>,
+    #[serde(default)]
+    pub initializer_range: f32,
+    #[serde(default)]
+    pub is_folding_model: bool,
+    #[serde(default)]
+    pub esmfold_config: Option<String>,
+    #[serde(default)]
+    pub model_type: String,
+    #[serde(default)]
+    pub torch_dtype: String,
+    #[serde(default)]
+    pub transformers_version: String,
+    #[serde(default)]
+    pub use_cache: bool,
+    #[serde(default)]
+    pub vocab_list: Option<Vec<String>>,
 }
 
 impl ESM2Config {

--- a/crates/ferritin-plms/src/esm2/esm2_runner.rs
+++ b/crates/ferritin-plms/src/esm2/esm2_runner.rs
@@ -82,14 +82,7 @@ impl ESM2Runner {
     /// actually achieves against the Python reference (ferritin-100.9).
     pub fn load_model_with(modeltype: ESM2Models, opts: &LoadOptions) -> Result<ESM2Runner> {
         let (source, fallback_config) = ESM2Models::get_model_files(modeltype);
-        // Try to load config from HF hub; fall back to hardcoded config if unavailable.
-        let config = match source.fetch_optional("config.json") {
-            Some(config_path) => {
-                let config_str = std::fs::read_to_string(config_path)?;
-                serde_json::from_str::<ESM2Config>(&config_str).unwrap_or(fallback_config)
-            }
-            None => fallback_config,
-        };
+        let config = Self::resolve_config(&source, fallback_config)?;
         let vb = source.var_builder("model.safetensors", opts)?;
         let model = ESM2::load(vb, config.clone())?;
         let tokenizer = ESM2::load_tokenizer()?;
@@ -99,6 +92,41 @@ impl ESM2Runner {
             config,
         })
     }
+    /// Load `config.json` from the hub, falling back to the built-in config.
+    ///
+    /// The fallback is **loud**. It used to be
+    /// `serde_json::from_str(..).unwrap_or(fallback_config)`, which discarded
+    /// the parse error without a word: a config the struct could not represent
+    /// silently became a different model's config. For a checkpoint like
+    /// `SaProt_35M_AF2` — 446-token vocabulary against ESM-2's 33 — the
+    /// VarBuilder would probably have errored on the embedding shape, but any
+    /// divergence that happened to be shape-compatible would have loaded
+    /// cleanly and produced wrong numbers (ferritin-goh.9).
+    fn resolve_config(source: &WeightSource, fallback: ESM2Config) -> Result<ESM2Config> {
+        let Some(path) = source.fetch_optional("config.json") else {
+            eprintln!(
+                "warning: {}: could not download config.json; using the built-in \
+                 config for this variant. Verify it matches the checkpoint.",
+                source.repo_id
+            );
+            return Ok(fallback);
+        };
+
+        let config_str = std::fs::read_to_string(path)?;
+        match serde_json::from_str::<ESM2Config>(&config_str) {
+            Ok(config) => Ok(config),
+            Err(e) => {
+                eprintln!(
+                    "warning: {}: config.json did not parse as an ESM2Config ({e}); \
+                     using the built-in config instead. If this checkpoint is not an \
+                     ESM-2 variant, the built-in config is probably wrong for it.",
+                    source.repo_id
+                );
+                Ok(fallback)
+            }
+        }
+    }
+
     /// Encode a sequence to token ids **with** ESM-2's BOS (`<cls>`) and EOS
     /// (`<eos>`) special tokens.
     ///

--- a/crates/ferritin-plms/tests/fixtures/configs/SaProt_35M_AF2.json
+++ b/crates/ferritin-plms/tests/fixtures/configs/SaProt_35M_AF2.json
@@ -1,0 +1,26 @@
+{
+  "architectures": [
+    "EsmForMaskedLM"
+  ],
+  "attention_probs_dropout_prob": 0.0,
+  "classifier_dropout": null,
+  "emb_layer_norm_before": false,
+  "hidden_act": "gelu",
+  "hidden_dropout_prob":0.0,
+  "hidden_size": 480,
+  "initializer_range": 0.02,
+  "intermediate_size": 1920,
+  "layer_norm_eps": 1e-05,
+  "mask_token_id": 4,
+  "max_position_embeddings": 1026,
+  "model_type": "esm",
+  "num_attention_heads": 20,
+  "num_hidden_layers": 12,
+  "pad_token_id": 1,
+  "position_embedding_type": "rotary",
+  "token_dropout": true,
+  "torch_dtype": "float32",
+  "transformers_version": "4.23.0.dev0",
+  "use_cache": true,
+  "vocab_size": 446
+}

--- a/crates/ferritin-plms/tests/fixtures/configs/esm1v_t33_650M_UR90S_1.json
+++ b/crates/ferritin-plms/tests/fixtures/configs/esm1v_t33_650M_UR90S_1.json
@@ -1,0 +1,30 @@
+{
+  "_name_or_path": "/tmp/facebook/esm1v_t33_650M_UR90S_1",
+  "architectures": [
+    "EsmForMaskedLM"
+  ],
+  "attention_probs_dropout_prob": 0.0,
+  "classifier_dropout": null,
+  "emb_layer_norm_before": false,
+  "esmfold_config": null,
+  "hidden_act": "gelu",
+  "hidden_dropout_prob": 0.0,
+  "hidden_size": 1280,
+  "initializer_range": 0.02,
+  "intermediate_size": 5120,
+  "is_folding_model": false,
+  "layer_norm_eps": 1e-05,
+  "mask_token_id": 32,
+  "max_position_embeddings": 1026,
+  "model_type": "esm",
+  "num_attention_heads": 20,
+  "num_hidden_layers": 33,
+  "pad_token_id": 1,
+  "position_embedding_type": "absolute",
+  "token_dropout": true,
+  "torch_dtype": "float32",
+  "transformers_version": "4.25.0.dev0",
+  "use_cache": true,
+  "vocab_list": null,
+  "vocab_size": 33
+}

--- a/crates/ferritin-plms/tests/fixtures/configs/esm2_t6_8M_UR50D.json
+++ b/crates/ferritin-plms/tests/fixtures/configs/esm2_t6_8M_UR50D.json
@@ -1,0 +1,30 @@
+{
+  "_name_or_path": "/tmp/facebook/esm2_t6_8M_UR50D",
+  "architectures": [
+    "EsmForMaskedLM"
+  ],
+  "attention_probs_dropout_prob": 0.0,
+  "classifier_dropout": null,
+  "emb_layer_norm_before": false,
+  "esmfold_config": null,
+  "hidden_act": "gelu",
+  "hidden_dropout_prob": 0.0,
+  "hidden_size": 320,
+  "initializer_range": 0.02,
+  "intermediate_size": 1280,
+  "is_folding_model": false,
+  "layer_norm_eps": 1e-05,
+  "mask_token_id": 32,
+  "max_position_embeddings": 1026,
+  "model_type": "esm",
+  "num_attention_heads": 20,
+  "num_hidden_layers": 6,
+  "pad_token_id": 1,
+  "position_embedding_type": "rotary",
+  "token_dropout": true,
+  "torch_dtype": "float32",
+  "transformers_version": "4.25.0.dev0",
+  "use_cache": true,
+  "vocab_list": null,
+  "vocab_size": 33
+}

--- a/crates/ferritin-plms/tests/test_esm2_config_parsing.rs
+++ b/crates/ferritin-plms/tests/test_esm2_config_parsing.rs
@@ -1,0 +1,138 @@
+//! `ESM2Config` must parse the config.json files real ESM-family models ship
+//! (ferritin-goh.9).
+//!
+//! The struct used to demand ~23 non-Option fields, several of which real
+//! configs omit. That alone would be a papercut; what made it a bug is where
+//! the failure went:
+//!
+//! ```ignore
+//! serde_json::from_str::<ESM2Config>(&config_str).unwrap_or(fallback_config)
+//! ```
+//!
+//! A missing field failed deserialization, `unwrap_or` discarded the error
+//! without a word, and the **hardcoded config for a different model** was used
+//! instead. For `SaProt_35M_AF2` that means a 446-token vocabulary model
+//! loading with a 33-token config. The VarBuilder would likely have caught
+//! that particular case on the embedding shape — but any divergence that
+//! happened to be shape-compatible would have loaded cleanly and produced
+//! wrong numbers.
+//!
+//! These fixtures are the published `config.json` of each model, committed
+//! verbatim under `tests/fixtures/configs/`, so this is checked against what
+//! HuggingFace actually serves rather than a hand-written approximation. Add a
+//! fixture here whenever a new ESM-family model is registered — that is what
+//! stops this recurring.
+
+use ferritin_plms::ESM2Config;
+use std::path::PathBuf;
+
+fn config_json(name: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/configs")
+        .join(format!("{name}.json"));
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("missing config fixture {}: {e}", path.display()))
+}
+
+fn parse(name: &str) -> ESM2Config {
+    serde_json::from_str::<ESM2Config>(&config_json(name))
+        .unwrap_or_else(|e| panic!("{name}'s published config.json must deserialize: {e}"))
+}
+
+/// The baseline: a stock ESM-2 config with every field present.
+#[test]
+fn test_parses_esm2_t6_8m() {
+    let config = parse("esm2_t6_8M_UR50D");
+    assert_eq!(config.hidden_size, 320);
+    assert_eq!(config.num_hidden_layers, 6);
+    assert_eq!(config.num_attention_heads, 20);
+    assert_eq!(config.vocab_size, 33);
+    assert_eq!(config.position_embedding_type, "rotary");
+}
+
+/// ESM-1v shares the schema but uses absolute position embeddings — a field
+/// that must stay required, since defaulting it would silently change the
+/// attention math.
+#[test]
+fn test_parses_esm1v_t33_650m() {
+    let config = parse("esm1v_t33_650M_UR90S_1");
+    assert_eq!(config.hidden_size, 1280);
+    assert_eq!(config.num_hidden_layers, 33);
+    assert_eq!(config.position_embedding_type, "absolute");
+}
+
+/// SaProt omits `is_folding_model`, `esmfold_config` and `vocab_list`
+/// entirely. This is the config that used to fail to parse and get silently
+/// replaced by ESM-2's.
+#[test]
+fn test_parses_saprot_35m_which_omits_fields() {
+    let raw = config_json("SaProt_35M_AF2");
+    for absent in ["is_folding_model", "esmfold_config", "vocab_list"] {
+        assert!(
+            !raw.contains(absent),
+            "fixture should still be the published config, which omits {absent}"
+        );
+    }
+
+    let config = parse("SaProt_35M_AF2");
+    assert_eq!(config.hidden_size, 480);
+    assert_eq!(config.num_hidden_layers, 12);
+
+    // The values that made the silent fallback dangerous: nothing like ESM-2's.
+    assert_eq!(config.vocab_size, 446, "SaProt has a structure-aware vocab");
+    assert_eq!(config.mask_token_id, 4);
+
+    // Omitted fields take their defaults rather than failing the parse.
+    assert!(!config.is_folding_model);
+    assert_eq!(config.esmfold_config, None);
+    assert_eq!(config.vocab_list, None);
+}
+
+/// A config missing a shape-critical field must FAIL rather than default.
+///
+/// This is the other half of the fix: `#[serde(default)]` was applied only to
+/// fields the forward pass never reads. Defaulting `hidden_size` to 0 would
+/// trade a loud parse error for a confusing shape error — or worse, silence.
+#[test]
+fn test_missing_required_field_is_an_error() {
+    let mut value: serde_json::Value =
+        serde_json::from_str(&config_json("esm2_t6_8M_UR50D")).unwrap();
+    value.as_object_mut().unwrap().remove("hidden_size");
+
+    let err = serde_json::from_value::<ESM2Config>(value)
+        .map(|_| ())
+        .expect_err("a config without hidden_size must not deserialize");
+    assert!(
+        err.to_string().contains("hidden_size"),
+        "the error should name the missing field; got: {err}"
+    );
+}
+
+/// Likewise for a field that changes the math rather than the shapes.
+#[test]
+fn test_missing_position_embedding_type_is_an_error() {
+    let mut value: serde_json::Value =
+        serde_json::from_str(&config_json("esm2_t6_8M_UR50D")).unwrap();
+    value
+        .as_object_mut()
+        .unwrap()
+        .remove("position_embedding_type");
+
+    serde_json::from_value::<ESM2Config>(value)
+        .map(|_| ())
+        .expect_err("position_embedding_type must stay required: rotary vs absolute");
+}
+
+/// Unknown fields are ignored, so a newer `transformers` version adding keys
+/// does not break loading.
+#[test]
+fn test_unknown_fields_are_ignored() {
+    let mut value: serde_json::Value =
+        serde_json::from_str(&config_json("esm2_t6_8M_UR50D")).unwrap();
+    value.as_object_mut().unwrap().insert(
+        "some_future_field".to_string(),
+        serde_json::Value::Bool(true),
+    );
+
+    serde_json::from_value::<ESM2Config>(value).expect("unknown fields should be ignored");
+}


### PR DESCRIPTION
## The bug

`ESM2Config` derived `Deserialize` with ~23 non-`Option` fields, several of which real ESM-family configs omit. `westlake-repl/SaProt_35M_AF2` has no `is_folding_model`, no `esmfold_config`, no `vocab_list`.

On its own that's a papercut. What made it a bug is **where the failure went**:

```rust
serde_json::from_str::<ESM2Config>(&config_str).unwrap_or(fallback_config)
```

A missing field failed deserialization, `unwrap_or` discarded the error without a word, and the hardcoded config for a **different model** was used instead. For SaProt that means a 446-token vocabulary model loading with a 33-token config, `mask_token_id` 32 instead of 4.

The VarBuilder would probably have caught *that* case on the embedding shape — but any divergence that happened to be shape-compatible would have loaded cleanly and produced wrong numbers. The download-failure arm did the same thing.

## The split

Fields are now divided by what the forward pass actually reads:

**Required** (missing ⇒ parse error): `hidden_size`, `num_hidden_layers`, `num_attention_heads`, `intermediate_size`, `vocab_size`, `max_position_embeddings`, `position_embedding_type`, `hidden_act`, `layer_norm_eps`, `emb_layer_norm_before`, `token_dropout`, `mask_token_id`, `pad_token_id`.

Defaulting any of these would trade a loud parse error for a model that loads and computes the wrong thing — `position_embedding_type` especially, where rotary vs absolute changes the attention math outright.

**`#[serde(default)]`**: training hyper-parameters, provenance strings, and metadata the forward pass never touches.

Both fallback paths now **warn**, naming the parse error or download failure and saying the built-in config may not match the checkpoint.

## Tests

`tests/test_esm2_config_parsing.rs` parses the published `config.json` of `esm2_t6_8M_UR50D`, `esm1v_t33_650M_UR90S_1` and `SaProt_35M_AF2` — committed verbatim under `tests/fixtures/configs/`, so this checks against what HuggingFace actually serves rather than a hand-written approximation.

It also asserts the other half, which is what keeps the fix from over-correcting:

- removing `hidden_size` must still **fail**
- removing `position_embedding_type` must still **fail**
- unknown fields must still be **ignored**, so a newer `transformers` release doesn't break loading

Adding a fixture per newly registered model is what stops this recurring.

```
cargo test -p ferritin-plms --test test_esm2_config_parsing        # 6 passed
cargo test -p ferritin-plms --test test_plm_esm2 -- --include-ignored  # 3 passed
cargo clippy --workspace --all-targets && cargo fmt --all --check  # clean
```

ESM2 numerical parity against the Python reference still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
