### PR TITLE
Point ESMC at the EvolutionaryScale originals, not the fused biohub re-exports (ferritin-100.23)

### DIFF
--- a/crates/ferritin-plms/src/esmc/pretrained.rs
+++ b/crates/ferritin-plms/src/esmc/pretrained.rs
@@ -33,8 +33,20 @@
 use crate::esmc::models::esmc::{ESMC, ESMCConfig, LogitsConfig};
 use crate::loader::{LoadOptions, WeightSource, optional_prefix};
 use crate::plm_runner::{ModelMetadata, PlmRunner, SpecialTokenLayout};
-use anyhow::Result;
+use anyhow::{Result, bail};
 use candle_core::{Device, Tensor};
+
+/// Why [`ESMCModels::ESMC6B`] cannot be loaded yet.
+///
+/// Its checkpoint uses the same unfused layout as 300M/600M, so this is
+/// plumbing rather than an architecture mismatch — but two pieces are missing.
+pub const ESMC6B_UNSUPPORTED: &str = "\
+ESMCModels::ESMC6B is not yet supported. EvolutionaryScale/esmc-6b-2024-12 splits its 808 \
+tensors across six safetensors shards (model-0000{1..6}-of-00006.safetensors with a \
+model.safetensors.index.json), and WeightSource::var_builder loads a single file; it also \
+names its output head 'lm_head' at the top level rather than 'sequence_head' under the 'esmc' \
+prefix this port descends into. Refusing until both are handled, rather than loading part of \
+the model (ferritin-100.24). ESMC300M and ESMC600M work.";
 
 /// Available ESMC model variants hosted on HuggingFace.
 pub enum ESMCModels {
@@ -47,21 +59,30 @@ pub enum ESMCModels {
 }
 
 impl ESMCModels {
-    /// Returns `(weight_source, config)` for this variant.
-    pub fn model_info(&self) -> (WeightSource, ESMCConfig) {
+    /// Returns `(weight_source, filename, config)` for this variant.
+    ///
+    /// These point at the **EvolutionaryScale** originals, not the
+    /// `biohub/ESMC-*` re-exports the loader used to request. Those re-exports
+    /// are TransformerEngine-FUSED — `attn.layernorm_qkv.weight` as one fused
+    /// tensor with separate `layer_norm_weight`/`layer_norm_bias`,
+    /// `ffn.fc1_weight`/`fc2_weight`, an `lm_head` instead of
+    /// `sequence_head`, plus 90 empty `_extra_state` tensors — so nothing this
+    /// port asks for resolved (ferritin-100.23).
+    ///
+    /// `ESMC6B` is not yet supported: see [`ESMC6B_UNSUPPORTED`].
+    pub fn model_info(&self) -> Result<(WeightSource, &'static str, ESMCConfig)> {
         match self {
-            Self::ESMC300M => (
-                WeightSource::safetensors("biohub/ESMC-300M"),
+            Self::ESMC300M => Ok((
+                WeightSource::pth("EvolutionaryScale/esmc-300m-2024-12", None),
+                "data/weights/esmc_300m_2024_12_v0.pth",
                 ESMCConfig::esmc_300m(),
-            ),
-            Self::ESMC600M => (
-                WeightSource::safetensors("biohub/ESMC-600M"),
+            )),
+            Self::ESMC600M => Ok((
+                WeightSource::pth("EvolutionaryScale/esmc-600m-2024-12", None),
+                "data/weights/esmc_600m_2024_12_v0.pth",
                 ESMCConfig::esmc_600m(),
-            ),
-            Self::ESMC6B => (
-                WeightSource::safetensors("biohub/ESMC-6B"),
-                ESMCConfig::esmc_6b(),
-            ),
+            )),
+            Self::ESMC6B => bail!("{ESMC6B_UNSUPPORTED}"),
         }
     }
 }
@@ -91,8 +112,8 @@ impl ESMCRunner {
     /// 32 GB machine. See `tests/test_plm_dtype_parity.rs` for the numerical
     /// cost (ferritin-100.9).
     pub fn from_pretrained_with(model: ESMCModels, opts: &LoadOptions) -> Result<Self> {
-        let (source, config) = model.model_info();
-        let vb = source.var_builder("model.safetensors", opts)?;
+        let (source, filename, config) = model.model_info()?;
+        let vb = source.var_builder(filename, opts)?;
         // Weights saved from ESMCForMaskedLM nest the backbone under "esmc".
         let vb_root = optional_prefix(vb, "esmc", "embed.weight");
         let esmc = ESMC::load(vb_root, config.clone())?;

--- a/crates/ferritin-plms/tests/test_plm_esmc.rs
+++ b/crates/ferritin-plms/tests/test_plm_esmc.rs
@@ -182,8 +182,8 @@ fn test_esmc_300m_logits_shape() -> Result<()> {
     use ferritin_plms::loader::{LoadOptions, optional_prefix};
 
     let device = Device::Cpu;
-    let (source, config) = Variants::ESMC300M.model_info();
-    let vb = source.var_builder("model.safetensors", &LoadOptions::new(device.clone()))?;
+    let (source, filename, config) = Variants::ESMC300M.model_info()?;
+    let vb = source.var_builder(filename, &LoadOptions::new(device.clone()))?;
     let vb_root = optional_prefix(vb, "esmc", "embed.weight");
     let model = ESMC::load(vb_root, config)?;
 
@@ -233,4 +233,51 @@ fn test_esmc_parity_vs_python_reference() -> Result<()> {
     assert_embeddings_close(&rust_embeddings, ref_embeddings, ESMC_EMBED_COSINE_FLOOR)?;
     println!("ESMC-300M embedding parity OK (cosine floor {ESMC_EMBED_COSINE_FLOOR})");
     Ok(())
+}
+
+/// 300M and 600M point at the EvolutionaryScale originals, not the fused
+/// `biohub/ESMC-*` re-exports whose layout nothing in this port could resolve
+/// (ferritin-100.23).
+#[test]
+fn test_esmc_model_info_targets_evolutionaryscale() {
+    use ferritin_plms::esmc::pretrained::ESMCModels;
+
+    for (variant, repo, file) in [
+        (
+            ESMCModels::ESMC300M,
+            "EvolutionaryScale/esmc-300m-2024-12",
+            "data/weights/esmc_300m_2024_12_v0.pth",
+        ),
+        (
+            ESMCModels::ESMC600M,
+            "EvolutionaryScale/esmc-600m-2024-12",
+            "data/weights/esmc_600m_2024_12_v0.pth",
+        ),
+    ] {
+        let (source, filename, _config) =
+            variant.model_info().expect("variant should be supported");
+        assert_eq!(source.repo_id, repo);
+        assert_eq!(filename, file);
+    }
+}
+
+/// ESMC6B refuses with the specific reason rather than failing partway through
+/// a six-shard download (ferritin-100.24).
+#[test]
+fn test_esmc_6b_refuses_with_reason() {
+    use ferritin_plms::esmc::pretrained::ESMCModels;
+
+    let err = ESMCModels::ESMC6B
+        .model_info()
+        .map(|_| ())
+        .expect_err("ESMC6B is not supported yet");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("shards"),
+        "error should name the sharding problem; got: {msg}"
+    );
+    assert!(
+        msg.contains("ESMC300M and ESMC600M work"),
+        "error should say which variants do work; got: {msg}"
+    );
 }


### PR DESCRIPTION
This was the **last red leg** of the nightly.

## The bug

`test_esmc_300m_logits_shape` and `test_esmc_300m_embed_gfp` failed with:

```
cannot find tensor esmc.transformer.blocks.0.attn.layernorm_qkv.0.weight
```

`ESMCModels::model_info` pointed at `biohub/ESMC-{300M,600M,6B}`, but the port was written against the **EvolutionaryScale originals**. The biohub repos are TransformerEngine-**fused** re-exports:

| port expects | biohub re-export has |
|---|---|
| `attn.layernorm_qkv.{0,1}.weight/.bias` | one fused `attn.layernorm_qkv.weight` `[2880, 960]` + separate `layer_norm_weight`/`layer_norm_bias` |
| `ffn.{0,1,3}.weight/.bias` | `ffn.fc1_weight` / `ffn.fc2_weight` |
| `sequence_head.{0,2,3}` | `lm_head.{0,2,3}` |
| — | 90 empty `*._extra_state` tensors (TransformerEngine artifacts) |

**Nothing** this port asks for resolved.

`EvolutionaryScale/esmc-300m-2024-12`'s `data/weights/esmc_300m_2024_12_v0.pth` (308 tensors) matches it **exactly** — right down to the flat `embed.weight` and `sequence_head.{0,2,3}`. The module's own doc comment already described that layout; only the repo id disagreed.

So: a wrong-repo bug of the same class as #183's wrong path, **not** an architecture mismatch. `model_info` now returns `(WeightSource, filename, config)` and is fallible, since these are `.pth` files under `data/weights/` rather than a root `model.safetensors`.

## ESMC6B refuses for now

Its layout is the same unfused one, but two pieces are missing:

1. `EvolutionaryScale/esmc-6b-2024-12` splits **808 tensors across six shards** with a `model.safetensors.index.json`, while `WeightSource::var_builder` loads a single file.
2. It names its head `lm_head` at the **top level**, outside the `esmc.` prefix this port descends into — whereas 300M/600M use `sequence_head`. A per-checkpoint difference, not a global rename.

Refusing beats loading part of a model. The plumbing is **ferritin-100.24**, and the refusal names both causes plus which variants do work.

The `optional_prefix("esmc", …)` probe from #180 stays: the 300M/600M checkpoints are flat so it correctly doesn't descend, and it already covers the prefixed 6B export for when that lands.

## Verification

```
cargo test -p ferritin-plms --test test_plm_esmc -- --include-ignored   # 7 passed (was 5/2)
cargo clippy --workspace --all-targets && cargo fmt --all --check       # clean
```

With this, a full local `cargo test -p ferritin-plms -- --include-ignored` has no remaining model-loading failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
