### PR TITLE
Unify runner constructor and model-enum accessor naming (ferritin-100.8)

### DIFF
--- a/crates/ferritin-examples/examples/amplify/main.rs
+++ b/crates/ferritin-examples/examples/amplify/main.rs
@@ -28,7 +28,7 @@ fn main() -> Result<()> {
         "350M" => AmplifyModels::AMP350M,
         &_ => panic!("Only 2 options"),
     };
-    let amprunner = AmplifyRunner::load_model(amp_model, device)?;
+    let amprunner = AmplifyRunner::from_pretrained(amp_model, device)?;
     let prot_sequence = args.protein_string.unwrap_or_else(|| {
         println!("No --protein-string provided, using default demo sequence.");
         DEFAULT_SEQUENCE.to_string()

--- a/crates/ferritin-examples/examples/esm2/main.rs
+++ b/crates/ferritin-examples/examples/esm2/main.rs
@@ -34,7 +34,7 @@ fn main() -> Result<()> {
         "15B" => ESM2Models::T48_15B,
         _ => return Err(E::msg("Invalid model ID")),
     };
-    let modelrunner = ESM2Runner::load_model(model_enum, device(args.cpu)?)?;
+    let modelrunner = ESM2Runner::from_pretrained(model_enum, device(args.cpu)?)?;
     println!("Encoding.......");
     let prot_string = args.protein_string.unwrap_or_else(|| {
         println!("No --protein-string provided, using default demo sequence.");

--- a/crates/ferritin-plms/src/amplify/amplify_runner.rs
+++ b/crates/ferritin-plms/src/amplify/amplify_runner.rs
@@ -17,8 +17,9 @@ pub enum AmplifyModels {
     AMP350M,
 }
 impl AmplifyModels {
-    pub fn get_model_files(model: Self) -> WeightSource {
-        match model {
+    /// Where this variant's weights live.
+    pub fn model_info(&self) -> WeightSource {
+        match self {
             AmplifyModels::AMP120M => {
                 WeightSource::safetensors("chandar-lab/AMPLIFY_120M").at_revision("main")
             }
@@ -26,6 +27,12 @@ impl AmplifyModels {
                 WeightSource::safetensors("chandar-lab/AMPLIFY_350M").at_revision("main")
             }
         }
+    }
+
+    /// Renamed to [`model_info`][Self::model_info] (ferritin-100.8).
+    #[deprecated(since = "0.3.6", note = "renamed to `model_info`, which takes &self")]
+    pub fn get_model_files(model: Self) -> WeightSource {
+        model.model_info()
     }
 }
 
@@ -36,9 +43,21 @@ pub struct AmplifyRunner {
 impl AmplifyRunner {
     /// Load model from HuggingFace hub at F32.
     ///
-    /// Use [`load_model_with`][Self::load_model_with] for F16 or BF16.
+    /// Use [`from_pretrained_with`][Self::from_pretrained_with] for F16 or BF16.
+    pub fn from_pretrained(modeltype: AmplifyModels, device: Device) -> Result<AmplifyRunner> {
+        Self::from_pretrained_with(modeltype, &LoadOptions::new(device))
+    }
+
+    /// Renamed to [`from_pretrained`][Self::from_pretrained] (ferritin-100.8).
+    #[deprecated(since = "0.3.6", note = "renamed to `from_pretrained`")]
     pub fn load_model(modeltype: AmplifyModels, device: Device) -> Result<AmplifyRunner> {
-        Self::load_model_with(modeltype, &LoadOptions::new(device))
+        Self::from_pretrained(modeltype, device)
+    }
+
+    /// Renamed to [`from_pretrained_with`][Self::from_pretrained_with] (ferritin-100.8).
+    #[deprecated(since = "0.3.6", note = "renamed to `from_pretrained_with`")]
+    pub fn load_model_with(modeltype: AmplifyModels, opts: &LoadOptions) -> Result<AmplifyRunner> {
+        Self::from_pretrained_with(modeltype, opts)
     }
 
     /// Load model with an explicit device and dtype.
@@ -46,8 +65,11 @@ impl AmplifyRunner {
     /// Reduced precision halves the memory footprint but changes the numerics;
     /// see `tests/test_plm_dtype_parity.rs` for the achievable tolerance
     /// (ferritin-100.9).
-    pub fn load_model_with(modeltype: AmplifyModels, opts: &LoadOptions) -> Result<AmplifyRunner> {
-        let source = AmplifyModels::get_model_files(modeltype);
+    pub fn from_pretrained_with(
+        modeltype: AmplifyModels,
+        opts: &LoadOptions,
+    ) -> Result<AmplifyRunner> {
+        let source = modeltype.model_info();
         let config_filename = source.fetch("config.json")?;
         let tokenizer_filename = source.fetch("tokenizer.json")?;
         let config_str = std::fs::read_to_string(config_filename)?;

--- a/crates/ferritin-plms/src/esm2/esm2_runner.rs
+++ b/crates/ferritin-plms/src/esm2/esm2_runner.rs
@@ -44,8 +44,9 @@ pub enum ESM2Models {
     T48_15B,
 }
 impl ESM2Models {
-    pub fn get_model_files(model: Self) -> (WeightSource, ESM2Config) {
-        let (repo, config) = match model {
+    /// Where this variant's weights live, plus its built-in fallback config.
+    pub fn model_info(&self) -> (WeightSource, ESM2Config) {
+        let (repo, config) = match self {
             Self::T6_8M => ("facebook/esm2_t6_8M_UR50D", ESM2Config::t6_8m()),
             Self::T12_35M => ("facebook/esm2_t12_35M_UR50D", ESM2Config::t12_35m()),
             Self::T30_150M => ("facebook/esm2_t30_150M_UR50D", ESM2Config::t30_150m()),
@@ -54,6 +55,12 @@ impl ESM2Models {
             Self::T48_15B => ("facebook/esm2_t48_15B_UR50D", ESM2Config::t48_15b()),
         };
         (WeightSource::safetensors(repo).at_revision("main"), config)
+    }
+
+    /// Renamed to [`model_info`][Self::model_info] (ferritin-100.8).
+    #[deprecated(since = "0.3.6", note = "renamed to `model_info`, which takes &self")]
+    pub fn get_model_files(model: Self) -> (WeightSource, ESM2Config) {
+        model.model_info()
     }
 }
 
@@ -68,11 +75,23 @@ impl ESM2Runner {
     /// Load model from HuggingFace hub at F32, downloading config.json,
     /// tokenizer files, and weights.
     ///
-    /// Use [`load_model_with`][Self::load_model_with] to load at F16 or BF16 —
-    /// `T36_3B` and `T48_15B` are not loadable at F32 on most machines
-    /// (~12 GB and ~60 GB respectively).
+    /// Use [`from_pretrained_with`][Self::from_pretrained_with] to load at F16
+    /// or BF16 — `T36_3B` and `T48_15B` are not loadable at F32 on most
+    /// machines (~12 GB and ~60 GB respectively).
+    pub fn from_pretrained(modeltype: ESM2Models, device: Device) -> Result<ESM2Runner> {
+        Self::from_pretrained_with(modeltype, &LoadOptions::new(device))
+    }
+
+    /// Renamed to [`from_pretrained`][Self::from_pretrained] (ferritin-100.8).
+    #[deprecated(since = "0.3.6", note = "renamed to `from_pretrained`")]
     pub fn load_model(modeltype: ESM2Models, device: Device) -> Result<ESM2Runner> {
-        Self::load_model_with(modeltype, &LoadOptions::new(device))
+        Self::from_pretrained(modeltype, device)
+    }
+
+    /// Renamed to [`from_pretrained_with`][Self::from_pretrained_with] (ferritin-100.8).
+    #[deprecated(since = "0.3.6", note = "renamed to `from_pretrained_with`")]
+    pub fn load_model_with(modeltype: ESM2Models, opts: &LoadOptions) -> Result<ESM2Runner> {
+        Self::from_pretrained_with(modeltype, opts)
     }
 
     /// Load model with an explicit device and dtype.
@@ -80,8 +99,8 @@ impl ESM2Runner {
     /// Reduced precision halves the memory footprint but changes the numerics;
     /// see `tests/test_plm_dtype_parity.rs` for the tolerance each dtype
     /// actually achieves against the Python reference (ferritin-100.9).
-    pub fn load_model_with(modeltype: ESM2Models, opts: &LoadOptions) -> Result<ESM2Runner> {
-        let (source, fallback_config) = ESM2Models::get_model_files(modeltype);
+    pub fn from_pretrained_with(modeltype: ESM2Models, opts: &LoadOptions) -> Result<ESM2Runner> {
+        let (source, fallback_config) = modeltype.model_info();
         let config = Self::resolve_config(&source, fallback_config)?;
         let vb = source.var_builder("model.safetensors", opts)?;
         let model = ESM2::load(vb, config.clone())?;

--- a/crates/ferritin-plms/src/ligandmpnn/configs.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/configs.rs
@@ -61,14 +61,14 @@ impl MPNNExecConfig {
     }
     /// Load the weights for `model_type`.
     ///
-    /// Delegates to [`ProteinMPNNRunner::load_model`], which downloads from
+    /// Delegates to [`ProteinMPNNRunner::from_pretrained`], which downloads from
     /// `zcpbx/ligandmpnn-weights`. This previously extracted an embedded test
     /// fixture (`TestFile::ligmpnn_pmpnn_01`) to a temp file, which made the
     /// 37 MB `ferritin-test-data` crate a runtime dependency of every
     /// downstream consumer (ferritin-100.10).
     pub fn load_model(&self, model_type: ModelTypes) -> Result<ProteinMPNN, Error> {
         match model_type {
-            ModelTypes::ProteinMPNN => Ok(ProteinMPNNRunner::load_model(
+            ModelTypes::ProteinMPNN => Ok(ProteinMPNNRunner::from_pretrained(
                 ProteinMPNNModels::V48_020,
                 self.device.clone(),
             )?

--- a/crates/ferritin-plms/src/ligandmpnn/pmpnn_runner.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/pmpnn_runner.rs
@@ -22,7 +22,7 @@ pub enum ProteinMPNNModels {
 
 impl ProteinMPNNModels {
     /// Weight source and file for this variant.
-    pub fn hf_info(&self) -> (WeightSource, &'static str) {
+    pub fn model_info(&self) -> (WeightSource, &'static str) {
         match self {
             Self::V48_020 => (
                 WeightSource::pth("zcpbx/ligandmpnn-weights", Some("model_state_dict"))
@@ -30,6 +30,12 @@ impl ProteinMPNNModels {
                 "model_params/proteinmpnn_v_48_020.pt",
             ),
         }
+    }
+
+    /// Renamed to [`model_info`][Self::model_info] (ferritin-100.8).
+    #[deprecated(since = "0.3.6", note = "renamed to `model_info`")]
+    pub fn hf_info(&self) -> (WeightSource, &'static str) {
+        self.model_info()
     }
 }
 
@@ -39,13 +45,25 @@ pub struct ProteinMPNNRunner {
 
 impl ProteinMPNNRunner {
     /// Load a ProteinMPNN model from HuggingFace hub.
+    pub fn from_pretrained(modeltype: ProteinMPNNModels, device: Device) -> Result<Self> {
+        Self::from_pretrained_with(modeltype, &LoadOptions::new(device))
+    }
+
+    /// Renamed to [`from_pretrained`][Self::from_pretrained] (ferritin-100.8).
+    #[deprecated(since = "0.3.6", note = "renamed to `from_pretrained`")]
     pub fn load_model(modeltype: ProteinMPNNModels, device: Device) -> Result<Self> {
-        Self::load_model_with(modeltype, &LoadOptions::new(device))
+        Self::from_pretrained(modeltype, device)
+    }
+
+    /// Renamed to [`from_pretrained_with`][Self::from_pretrained_with] (ferritin-100.8).
+    #[deprecated(since = "0.3.6", note = "renamed to `from_pretrained_with`")]
+    pub fn load_model_with(modeltype: ProteinMPNNModels, opts: &LoadOptions) -> Result<Self> {
+        Self::from_pretrained_with(modeltype, opts)
     }
 
     /// Load with an explicit device and dtype (ferritin-100.9).
-    pub fn load_model_with(modeltype: ProteinMPNNModels, opts: &LoadOptions) -> Result<Self> {
-        let (source, filename) = modeltype.hf_info();
+    pub fn from_pretrained_with(modeltype: ProteinMPNNModels, opts: &LoadOptions) -> Result<Self> {
+        let (source, filename) = modeltype.model_info();
         let weights_path = source.fetch(filename)?;
         Self::from_path_with(&weights_path, opts)
     }

--- a/crates/ferritin-plms/tests/support/model_harness.rs
+++ b/crates/ferritin-plms/tests/support/model_harness.rs
@@ -146,7 +146,7 @@ pub fn validate_proteinmpnn_checkpoint() -> Result<(), Error> {
 }
 
 pub fn run_remote_esm2_smoke(model: ESM2Models) -> Result<()> {
-    let esm2 = ESM2Runner::load_model(model, device(false)?)?;
+    let esm2 = ESM2Runner::from_pretrained(model, device(false)?)?;
     let output = esm2.run_forward(TEST_SEQUENCE)?;
     let output_sequence = esm2.decode_logits(output)?;
     let hamming = hamming_ratio(TEST_SEQUENCE, &output_sequence);
@@ -159,7 +159,7 @@ pub fn run_remote_esm2_smoke(model: ESM2Models) -> Result<()> {
 }
 
 pub fn run_remote_amplify_prediction_smoke(model: AmplifyModels) -> Result<()> {
-    let amplify = AmplifyRunner::load_model(model, device(false)?)?;
+    let amplify = AmplifyRunner::from_pretrained(model, device(false)?)?;
     let prediction = amplify
         .get_best_prediction(TEST_SEQUENCE)
         .map_err(|err| anyhow!("AMPLIFY prediction failed: {err}"))?;

--- a/crates/ferritin-plms/tests/test_esm2_config_parsing.rs
+++ b/crates/ferritin-plms/tests/test_esm2_config_parsing.rs
@@ -136,3 +136,20 @@ fn test_unknown_fields_are_ignored() {
 
     serde_json::from_value::<ESM2Config>(value).expect("unknown fields should be ignored");
 }
+
+/// The deprecated `get_model_files` shim still returns what `model_info` does,
+/// so a downstream caller on the old name keeps working for one release
+/// (ferritin-100.8).
+#[test]
+#[allow(deprecated)]
+fn test_deprecated_get_model_files_shim_matches_model_info() {
+    use ferritin_plms::ESM2Models;
+
+    let (new_source, new_config) = ESM2Models::T6_8M.model_info();
+    let (old_source, old_config) = ESM2Models::get_model_files(ESM2Models::T6_8M);
+
+    assert_eq!(old_source.repo_id, new_source.repo_id);
+    assert_eq!(old_source.revision, new_source.revision);
+    assert_eq!(old_config.hidden_size, new_config.hidden_size);
+    assert_eq!(old_config.vocab_size, new_config.vocab_size);
+}

--- a/crates/ferritin-plms/tests/test_plm_amplify.rs
+++ b/crates/ferritin-plms/tests/test_plm_amplify.rs
@@ -18,7 +18,7 @@ const PARITY_SEQUENCES: &[(&str, &str)] = &[
 ];
 
 fn load_amplify_120m() -> AmplifyRunner {
-    AmplifyRunner::load_model(AmplifyModels::AMP120M, device(false).unwrap())
+    AmplifyRunner::from_pretrained(AmplifyModels::AMP120M, device(false).unwrap())
         .expect("Failed to load AMPLIFY 120M model")
 }
 

--- a/crates/ferritin-plms/tests/test_plm_dtype_parity.rs
+++ b/crates/ferritin-plms/tests/test_plm_dtype_parity.rs
@@ -79,8 +79,9 @@ const AMPLIFY_F16_MIN_AGREEMENT: f32 = 0.85; // measured 0.923
 #[ignore = "requires downloading facebook/esm2_t6_8M_UR50D weights"]
 fn test_esm2_f16_matches_f32() -> Result<()> {
     let dev = device(false)?;
-    let f32_model = ESM2Runner::load_model_with(ESM2Models::T6_8M, &LoadOptions::new(dev.clone()))?;
-    let f16_model = ESM2Runner::load_model_with(
+    let f32_model =
+        ESM2Runner::from_pretrained_with(ESM2Models::T6_8M, &LoadOptions::new(dev.clone()))?;
+    let f16_model = ESM2Runner::from_pretrained_with(
         ESM2Models::T6_8M,
         &LoadOptions::new(dev).with_dtype(DType::F16),
     )?;
@@ -117,9 +118,11 @@ fn test_esm2_f16_matches_f32() -> Result<()> {
 #[ignore = "requires downloading chandar-lab/AMPLIFY_120M weights"]
 fn test_amplify_f16_matches_f32() -> Result<()> {
     let dev = device(false)?;
-    let f32_model =
-        AmplifyRunner::load_model_with(AmplifyModels::AMP120M, &LoadOptions::new(dev.clone()))?;
-    let f16_model = AmplifyRunner::load_model_with(
+    let f32_model = AmplifyRunner::from_pretrained_with(
+        AmplifyModels::AMP120M,
+        &LoadOptions::new(dev.clone()),
+    )?;
+    let f16_model = AmplifyRunner::from_pretrained_with(
         AmplifyModels::AMP120M,
         &LoadOptions::new(dev).with_dtype(DType::F16),
     )?;
@@ -155,7 +158,7 @@ fn test_amplify_f16_matches_f32() -> Result<()> {
 #[ignore = "requires downloading chandar-lab/AMPLIFY_120M weights"]
 fn test_amplify_f16_rotary_dtype_matches_model() -> Result<()> {
     let dev = device(false)?;
-    let model = AmplifyRunner::load_model_with(
+    let model = AmplifyRunner::from_pretrained_with(
         AmplifyModels::AMP120M,
         &LoadOptions::new(dev).with_dtype(DType::F16),
     )?;

--- a/crates/ferritin-plms/tests/test_plm_esm2.rs
+++ b/crates/ferritin-plms/tests/test_plm_esm2.rs
@@ -62,7 +62,7 @@ fn test_esm2_parity_vs_python_reference() -> Result<()> {
     }
 
     let dev = device(false)?;
-    let esm2 = ESM2Runner::load_model(ESM2Models::T6_8M, dev.clone())?;
+    let esm2 = ESM2Runner::from_pretrained(ESM2Models::T6_8M, dev.clone())?;
 
     // The ESM2 reference (generate_esm2_fixtures.py) strips BOS/EOS and stores
     // only the L interior residue rows, so align the Rust output to match.

--- a/crates/ferritin-plms/tests/test_plm_runner_contract.rs
+++ b/crates/ferritin-plms/tests/test_plm_runner_contract.rs
@@ -58,7 +58,7 @@ fn assert_contract_holds(runner: &dyn PlmRunner) -> Result<()> {
 #[test]
 #[ignore = "requires downloading facebook/esm2_t6_8M_UR50D weights"]
 fn test_esm2_special_token_contract() -> Result<()> {
-    let runner = ESM2Runner::load_model(ESM2Models::T6_8M, device(false)?)?;
+    let runner = ESM2Runner::from_pretrained(ESM2Models::T6_8M, device(false)?)?;
     assert_eq!(runner.special_tokens(), SpecialTokenLayout::BOS_EOS);
     assert_contract_holds(&runner)
 }
@@ -66,7 +66,7 @@ fn test_esm2_special_token_contract() -> Result<()> {
 #[test]
 #[ignore = "requires downloading chandar-lab/AMPLIFY_120M weights"]
 fn test_amplify_special_token_contract() -> Result<()> {
-    let runner = AmplifyRunner::load_model(AmplifyModels::AMP120M, device(false)?)?;
+    let runner = AmplifyRunner::from_pretrained(AmplifyModels::AMP120M, device(false)?)?;
     assert_eq!(runner.special_tokens(), SpecialTokenLayout::BOS_EOS);
     assert_contract_holds(&runner)
 }
@@ -77,8 +77,8 @@ fn test_amplify_special_token_contract() -> Result<()> {
 #[test]
 #[ignore = "requires downloading both ESM2 and AMPLIFY weights"]
 fn test_embed_residues_aligns_across_models() -> Result<()> {
-    let esm2 = ESM2Runner::load_model(ESM2Models::T6_8M, device(false)?)?;
-    let amplify = AmplifyRunner::load_model(AmplifyModels::AMP120M, device(false)?)?;
+    let esm2 = ESM2Runner::from_pretrained(ESM2Models::T6_8M, device(false)?)?;
+    let amplify = AmplifyRunner::from_pretrained(AmplifyModels::AMP120M, device(false)?)?;
 
     let a = esm2.embed_residues(SEQ)?;
     let b = amplify.embed_residues(SEQ)?;
@@ -97,7 +97,7 @@ fn test_embed_residues_aligns_across_models() -> Result<()> {
 #[test]
 #[ignore = "requires downloading facebook/esm2_t6_8M_UR50D weights"]
 fn test_logits_shape_matches_metadata() -> Result<()> {
-    let runner = ESM2Runner::load_model(ESM2Models::T6_8M, device(false)?)?;
+    let runner = ESM2Runner::from_pretrained(ESM2Models::T6_8M, device(false)?)?;
     let logits = runner.logits(SEQ)?;
     let metadata = runner.metadata();
 
@@ -118,7 +118,7 @@ fn test_logits_shape_matches_metadata() -> Result<()> {
 #[test]
 #[ignore = "requires downloading facebook/esm2_t6_8M_UR50D weights"]
 fn test_metadata_is_populated() -> Result<()> {
-    let runner = ESM2Runner::load_model(ESM2Models::T6_8M, device(false)?)?;
+    let runner = ESM2Runner::from_pretrained(ESM2Models::T6_8M, device(false)?)?;
     let metadata = runner.metadata();
 
     // ESM2 t6_8M: 6 layers, width 320, 33-token vocabulary.


### PR DESCRIPTION
Three naming conventions were in play across six runners — and **this session's work made it worse**. The `*_with` constructors added in #182 each inherited whichever name their runner already used, and ESMC's `model_info` gained a filename and a `Result` in #185 while ESM2's kept neither. Cleaning that up is finishing my own work.

## The rename

| before | after |
|---|---|
| `AmplifyRunner::load_model{,_with}` | `from_pretrained{,_with}` |
| `ESM2Runner::load_model{,_with}` | `from_pretrained{,_with}` |
| `ProteinMPNNRunner::load_model{,_with}` | `from_pretrained{,_with}` |
| `AmplifyModels::get_model_files(Self)` | `model_info(&self)` |
| `ESM2Models::get_model_files(Self)` | `model_info(&self)` |
| `ProteinMPNNModels::hf_info(&self)` | `model_info(&self)` |

ESMC, ESM3 and ESMFold2 already used `from_pretrained` / `model_info`.

The `get_` prefix is non-idiomatic Rust, and taking `Self` **by value** in an associated function forced callers into `ESM2Models::get_model_files(model)` rather than `model.model_info()`.

## Not breaking downstream silently

This is a breaking public API change, so the old names stay as `#[deprecated]` shims delegating to the new ones for one release.

Every in-tree caller moved: `tests/support/model_harness.rs`, five test files, the `amplify` and `esm2` examples, and `MPNNExecConfig::load_model`. That's verified rather than asserted — CI runs `cargo clippy --workspace --all-targets -- -D warnings`, so a single remaining deprecated call fails the build.

A test asserts the deprecated `ESM2Models::get_model_files` shim still returns what `model_info` does, so the grace period is real rather than assumed.

`MPNNExecConfig::load_model` keeps its name — it's a different thing, taking `&self` and a `ModelTypes` rather than being a runner constructor.

## Verification

```
cargo clippy --workspace --all-targets -- -D warnings   # clean (proves no stale callers)
cargo fmt --all --check                                 # clean
cargo test --workspace                                  # pass
cargo build -p ferritin-examples --examples             # pass
cargo test -p ferritin-plms --test test_plm_esm2 --test test_plm_ligandmpnn -- --include-ignored
```

ESM2 numerical parity against the Python reference still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
