### PR TITLE
Surface the cause when AMPLIFY test loads fail (ferritin-100.25)

### DIFF
--- a/crates/ferritin-plms/tests/test_plm_amplify.rs
+++ b/crates/ferritin-plms/tests/test_plm_amplify.rs
@@ -17,23 +17,33 @@ const PARITY_SEQUENCES: &[(&str, &str)] = &[
     ("alt_charged", "KEKEKEK"),
 ];
 
+/// Load AMPLIFY 120M, surfacing the underlying error on failure.
+///
+/// These loads fail intermittently in the full concurrent `--include-ignored`
+/// run while passing reliably in isolation (ferritin-100.25). A bare
+/// `.expect("Failed to load ...")` discarded the cause, which is why that
+/// issue could not name one — so the source error is included here.
 fn load_amplify_120m() -> AmplifyRunner {
-    AmplifyRunner::from_pretrained(AmplifyModels::AMP120M, device(false).unwrap())
-        .expect("Failed to load AMPLIFY 120M model")
+    match AmplifyRunner::from_pretrained(AmplifyModels::AMP120M, device(false).unwrap()) {
+        Ok(runner) => runner,
+        Err(e) => panic!("Failed to load AMPLIFY 120M model: {e:#}"),
+    }
 }
 
 #[test]
 #[ignore = "requires downloading model files"]
 fn test_load_amplify_120m() {
-    run_remote_amplify_prediction_smoke(AmplifyModels::AMP120M)
-        .expect("Failed to load AMPLIFY 120M model");
+    if let Err(e) = run_remote_amplify_prediction_smoke(AmplifyModels::AMP120M) {
+        panic!("Failed to load AMPLIFY 120M model: {e:#}");
+    }
 }
 
 #[test]
 #[ignore = "requires downloading model files"]
 fn test_amplify_120m_prediction() {
-    run_remote_amplify_prediction_smoke(AmplifyModels::AMP120M)
-        .expect("Failed to get prediction from AMPLIFY 120M");
+    if let Err(e) = run_remote_amplify_prediction_smoke(AmplifyModels::AMP120M) {
+        panic!("Failed to get prediction from AMPLIFY 120M: {e:#}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
**This is a diagnostic step, not a fix.**

AMPLIFY tests fail intermittently at the model-load step in the full concurrent `--include-ignored` run, while passing 3/3 in isolation. Two different tests have failed this way (`test_amplify_120m_prediction`, `test_amplify_120m_contact_map`), both at the `.expect` around loading rather than at any assertion about model output.

The cause is **still unknown** — and the reason it's unknown is these call sites:

```rust
.expect("Failed to load AMPLIFY 120M model")
```

That discards the source error into a panic message that says nothing about what went wrong. HF rate limiting, cache contention between concurrent writers, and memory pressure from several 500 MB models resident at once are all plausible, and none can be distinguished without the actual error.

So the three load sites now panic with `{e:#}`, printing the full `anyhow` chain. The next reproduction will name its cause instead of repeating "Failed to load".

Worth doing now rather than bundling with a fix: #183 was about making the nightly signal trustworthy, and an intermittently-red nightly is indistinguishable at a glance from a real regression — which costs exactly the signal that work restored.

Tracked in ferritin-100.25, which deliberately leaves the cause open rather than guessing it.

```
cargo clippy -p ferritin-plms --all-targets -- -D warnings   # clean
cargo test -p ferritin-plms --test test_plm_amplify -- --include-ignored   # 5 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
