### PR TITLE
Bump workspace to 0.4.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5425,7 +5425,7 @@ checksum = "b97b65636e5b9ef369943878ac74335ba1c55c1cb6adbf1e2c293c624248d693"
 
 [[package]]
 name = "ferritin"
-version = "0.3.6-dev"
+version = "0.4.0-dev"
 dependencies = [
  "ferritin-bevy",
  "ferritin-core",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "ferritin-bevy"
-version = "0.3.6-dev"
+version = "0.4.0-dev"
 dependencies = [
  "anyhow",
  "bevy",
@@ -5448,7 +5448,7 @@ dependencies = [
 
 [[package]]
 name = "ferritin-cellscape"
-version = "0.3.6-dev"
+version = "0.4.0-dev"
 dependencies = [
  "ferritin-core",
  "ferritin-test-data",
@@ -5458,7 +5458,7 @@ dependencies = [
 
 [[package]]
 name = "ferritin-core"
-version = "0.3.6-dev"
+version = "0.4.0-dev"
 dependencies = [
  "anyhow",
  "compact_str 0.10.0",
@@ -5469,7 +5469,7 @@ dependencies = [
 
 [[package]]
 name = "ferritin-examples"
-version = "0.3.6-dev"
+version = "0.4.0-dev"
 dependencies = [
  "anyhow",
  "bevy",
@@ -5493,7 +5493,7 @@ dependencies = [
 
 [[package]]
 name = "ferritin-molviewspec"
-version = "0.3.6-dev"
+version = "0.4.0-dev"
 dependencies = [
  "chrono",
  "serde",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "ferritin-plms"
-version = "0.3.6-dev"
+version = "0.4.0-dev"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "ferritin-test-data"
-version = "0.3.6-dev"
+version = "0.4.0-dev"
 dependencies = [
  "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.6-dev"
+version = "0.4.0-dev"
 authors = ["Zach Charlop-Powers<zach.charlop.powers@gmail.com>"]
 description = "Protein Manipulation and visualization tools"
 license = "MIT OR Apache-2.0"

--- a/crates/ferritin-plms/src/amplify/amplify_runner.rs
+++ b/crates/ferritin-plms/src/amplify/amplify_runner.rs
@@ -30,7 +30,7 @@ impl AmplifyModels {
     }
 
     /// Renamed to [`model_info`][Self::model_info] (ferritin-100.8).
-    #[deprecated(since = "0.3.6", note = "renamed to `model_info`, which takes &self")]
+    #[deprecated(since = "0.4.0", note = "renamed to `model_info`, which takes &self")]
     pub fn get_model_files(model: Self) -> WeightSource {
         model.model_info()
     }
@@ -49,13 +49,13 @@ impl AmplifyRunner {
     }
 
     /// Renamed to [`from_pretrained`][Self::from_pretrained] (ferritin-100.8).
-    #[deprecated(since = "0.3.6", note = "renamed to `from_pretrained`")]
+    #[deprecated(since = "0.4.0", note = "renamed to `from_pretrained`")]
     pub fn load_model(modeltype: AmplifyModels, device: Device) -> Result<AmplifyRunner> {
         Self::from_pretrained(modeltype, device)
     }
 
     /// Renamed to [`from_pretrained_with`][Self::from_pretrained_with] (ferritin-100.8).
-    #[deprecated(since = "0.3.6", note = "renamed to `from_pretrained_with`")]
+    #[deprecated(since = "0.4.0", note = "renamed to `from_pretrained_with`")]
     pub fn load_model_with(modeltype: AmplifyModels, opts: &LoadOptions) -> Result<AmplifyRunner> {
         Self::from_pretrained_with(modeltype, opts)
     }

--- a/crates/ferritin-plms/src/esm2/esm2_runner.rs
+++ b/crates/ferritin-plms/src/esm2/esm2_runner.rs
@@ -58,7 +58,7 @@ impl ESM2Models {
     }
 
     /// Renamed to [`model_info`][Self::model_info] (ferritin-100.8).
-    #[deprecated(since = "0.3.6", note = "renamed to `model_info`, which takes &self")]
+    #[deprecated(since = "0.4.0", note = "renamed to `model_info`, which takes &self")]
     pub fn get_model_files(model: Self) -> (WeightSource, ESM2Config) {
         model.model_info()
     }
@@ -83,13 +83,13 @@ impl ESM2Runner {
     }
 
     /// Renamed to [`from_pretrained`][Self::from_pretrained] (ferritin-100.8).
-    #[deprecated(since = "0.3.6", note = "renamed to `from_pretrained`")]
+    #[deprecated(since = "0.4.0", note = "renamed to `from_pretrained`")]
     pub fn load_model(modeltype: ESM2Models, device: Device) -> Result<ESM2Runner> {
         Self::from_pretrained(modeltype, device)
     }
 
     /// Renamed to [`from_pretrained_with`][Self::from_pretrained_with] (ferritin-100.8).
-    #[deprecated(since = "0.3.6", note = "renamed to `from_pretrained_with`")]
+    #[deprecated(since = "0.4.0", note = "renamed to `from_pretrained_with`")]
     pub fn load_model_with(modeltype: ESM2Models, opts: &LoadOptions) -> Result<ESM2Runner> {
         Self::from_pretrained_with(modeltype, opts)
     }

--- a/crates/ferritin-plms/src/ligandmpnn/pmpnn_runner.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/pmpnn_runner.rs
@@ -33,7 +33,7 @@ impl ProteinMPNNModels {
     }
 
     /// Renamed to [`model_info`][Self::model_info] (ferritin-100.8).
-    #[deprecated(since = "0.3.6", note = "renamed to `model_info`")]
+    #[deprecated(since = "0.4.0", note = "renamed to `model_info`")]
     pub fn hf_info(&self) -> (WeightSource, &'static str) {
         self.model_info()
     }
@@ -50,13 +50,13 @@ impl ProteinMPNNRunner {
     }
 
     /// Renamed to [`from_pretrained`][Self::from_pretrained] (ferritin-100.8).
-    #[deprecated(since = "0.3.6", note = "renamed to `from_pretrained`")]
+    #[deprecated(since = "0.4.0", note = "renamed to `from_pretrained`")]
     pub fn load_model(modeltype: ProteinMPNNModels, device: Device) -> Result<Self> {
         Self::from_pretrained(modeltype, device)
     }
 
     /// Renamed to [`from_pretrained_with`][Self::from_pretrained_with] (ferritin-100.8).
-    #[deprecated(since = "0.3.6", note = "renamed to `from_pretrained_with`")]
+    #[deprecated(since = "0.4.0", note = "renamed to `from_pretrained_with`")]
     pub fn load_model_with(modeltype: ProteinMPNNModels, opts: &LoadOptions) -> Result<Self> {
         Self::from_pretrained_with(modeltype, opts)
     }


### PR DESCRIPTION
**Minor, not patch.** This cycle (#179–#187) changed the public API in ways no deprecation shim covers, so under 0.x semver the minor is where it belongs.

## Breaking, no shim possible

| change | issue |
|---|---|
| `PlmRunner` gained three **required** methods (`special_tokens`, `metadata`, `device`) — breaks any external implementor | 100.7 |
| `ESMCModels::model_info`: `(WeightSource, ESMCConfig)` → `Result<(WeightSource, &str, ESMCConfig)>` — the checkpoints are `.pth` under `data/weights/`, and `ESMC6B` now refuses | 100.23 |
| `ESM3Models::model_info` likewise gained a filename | 100.21 |
| `ESMFold2Runner::from_pretrained` and `StructureEncoderRunner::from_pretrained` now always error rather than loading a mismatched checkpoint | 100.16, 100.22 |
| `AmplifyRunner::get_pseudo_probabilities` returns one entry per **residue**, not per token — callers indexing by position see different data, because the old numbering was off by one | 100.18 |

That last one is the one worth flagging to downstream: it's a silent behavioural change for anyone who worked around the old off-by-one.

## Breaking, with `#[deprecated]` shims for one release

- `{Amplify,ESM2,ProteinMPNN}Runner::load_model{,_with}` → `from_pretrained{,_with}`
- `{Amplify,ESM2}Models::get_model_files` → `model_info(&self)`
- `ProteinMPNNModels::hf_info` → `model_info`

This also retargets those shims' `since` from `0.3.6` to `0.4.0` — `0.3.6` was never released, so nothing could have been deprecated in it.

## Scope

All 8 active workspace crates, via `version.workspace = true`, plus `Cargo.lock`. `ferritin-pymol` and `ferritin-wasm-examples` are commented out of `members` and unaffected; they'd inherit the workspace version if re-enabled.

```
cargo build --workspace                                 # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo fmt --all --check                                 # clean
cargo test --workspace                                  # pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
