### PR TITLE
ModelCard registry — make a model a data row, not a module (ferritin-goh.1)

### DIFF
--- a/crates/ferritin-plms/src/amplify/amplify_runner.rs
+++ b/crates/ferritin-plms/src/amplify/amplify_runner.rs
@@ -7,6 +7,7 @@ use super::amplify::{AMPLIFY, AmplifyOutput};
 use super::config::AMPLIFYConfig;
 use crate::loader::{LoadOptions, WeightSource};
 use crate::plm_runner::{ModelMetadata, PlmRunner, SpecialTokenLayout};
+use crate::registry::{self, ModelCard};
 use anyhow::{Error as E, Result, anyhow};
 use candle_core::{D, Device, Tensor};
 use candle_nn::ops;
@@ -17,16 +18,26 @@ pub enum AmplifyModels {
     AMP350M,
 }
 impl AmplifyModels {
-    /// Where this variant's weights live.
-    pub fn model_info(&self) -> WeightSource {
+    /// This variant's registry id.
+    pub const fn registry_id(&self) -> &'static str {
         match self {
-            AmplifyModels::AMP120M => {
-                WeightSource::safetensors("chandar-lab/AMPLIFY_120M").at_revision("main")
-            }
-            AmplifyModels::AMP350M => {
-                WeightSource::safetensors("chandar-lab/AMPLIFY_350M").at_revision("main")
-            }
+            AmplifyModels::AMP120M => "amplify-120m",
+            AmplifyModels::AMP350M => "amplify-350m",
         }
+    }
+
+    /// This variant's [`ModelCard`].
+    pub fn card(&self) -> &'static ModelCard {
+        registry::lookup(self.registry_id())
+            .expect("every AmplifyModels variant must have a registry entry")
+    }
+
+    /// Where this variant's weights live.
+    ///
+    /// Delegates to [`REGISTRY`][crate::registry::REGISTRY] rather than
+    /// repeating the repo string (ferritin-goh.1).
+    pub fn model_info(&self) -> WeightSource {
+        self.card().source
     }
 
     /// Renamed to [`model_info`][Self::model_info] (ferritin-100.8).

--- a/crates/ferritin-plms/src/esm2/esm2_runner.rs
+++ b/crates/ferritin-plms/src/esm2/esm2_runner.rs
@@ -4,6 +4,7 @@
 use super::esm2::{ESM2, ESM2Config, ESM2Output};
 use crate::loader::{LoadOptions, WeightSource};
 use crate::plm_runner::{ModelMetadata, PlmRunner, SpecialTokenLayout};
+use crate::registry::{self, ModelCard};
 use crate::types::PseudoProbability;
 use anyhow::{Error as E, Result, anyhow};
 use candle_core::{Device, Tensor};
@@ -44,17 +45,40 @@ pub enum ESM2Models {
     T48_15B,
 }
 impl ESM2Models {
+    /// This variant's registry id.
+    pub const fn registry_id(&self) -> &'static str {
+        match self {
+            Self::T6_8M => "esm2-t6-8m",
+            Self::T12_35M => "esm2-t12-35m",
+            Self::T30_150M => "esm2-t30-150m",
+            Self::T33_650M => "esm2-t33-650m",
+            Self::T36_3B => "esm2-t36-3b",
+            Self::T48_15B => "esm2-t48-15b",
+        }
+    }
+
+    /// This variant's [`ModelCard`].
+    pub fn card(&self) -> &'static ModelCard {
+        registry::lookup(self.registry_id())
+            .expect("every ESM2Models variant must have a registry entry")
+    }
+
     /// Where this variant's weights live, plus its built-in fallback config.
+    ///
+    /// The weight source comes from [`REGISTRY`][crate::registry::REGISTRY]
+    /// rather than being repeated here (ferritin-goh.1). The config stays a
+    /// separate hardcoded fallback because it is only used when the hub's
+    /// config.json is unreachable or unparseable.
     pub fn model_info(&self) -> (WeightSource, ESM2Config) {
-        let (repo, config) = match self {
-            Self::T6_8M => ("facebook/esm2_t6_8M_UR50D", ESM2Config::t6_8m()),
-            Self::T12_35M => ("facebook/esm2_t12_35M_UR50D", ESM2Config::t12_35m()),
-            Self::T30_150M => ("facebook/esm2_t30_150M_UR50D", ESM2Config::t30_150m()),
-            Self::T33_650M => ("facebook/esm2_t33_650M_UR50D", ESM2Config::t33_650m()),
-            Self::T36_3B => ("facebook/esm2_t36_3B_UR50D", ESM2Config::t36_3b()),
-            Self::T48_15B => ("facebook/esm2_t48_15B_UR50D", ESM2Config::t48_15b()),
+        let config = match self {
+            Self::T6_8M => ESM2Config::t6_8m(),
+            Self::T12_35M => ESM2Config::t12_35m(),
+            Self::T30_150M => ESM2Config::t30_150m(),
+            Self::T33_650M => ESM2Config::t33_650m(),
+            Self::T36_3B => ESM2Config::t36_3b(),
+            Self::T48_15B => ESM2Config::t48_15b(),
         };
-        (WeightSource::safetensors(repo).at_revision("main"), config)
+        (self.card().source, config)
     }
 
     /// Renamed to [`model_info`][Self::model_info] (ferritin-100.8).

--- a/crates/ferritin-plms/src/esm3/pretrained.rs
+++ b/crates/ferritin-plms/src/esm3/pretrained.rs
@@ -32,6 +32,7 @@ use crate::esm3::models::vqvae::StructureTokenEncoder;
 use crate::esm3::tokenization::sequence::tokenize_sequence;
 use crate::loader::{LoadOptions, WeightSource};
 use crate::plm_runner::{ModelMetadata, PlmRunner, SpecialTokenLayout};
+use crate::registry::{self, ModelCard};
 use anyhow::{Result, bail};
 use candle_core::{Device, Tensor};
 
@@ -43,13 +44,14 @@ pub enum ESM3Models {
     SmOpen,
 }
 
-/// The `esm3-sm-open-v1` repo, whose `.pth` checkpoints store tensors at the root.
-const ESM3_REPO: WeightSource = WeightSource::pth("EvolutionaryScale/esm3-sm-open-v1", None);
+/// The structure encoder's registry id.
+pub const STRUCTURE_ENCODER_ID: &str = "esm3-structure-encoder-v0";
 
 /// Why [`StructureEncoderRunner::from_pretrained`] refuses to load.
 ///
 /// The main ESM3 model loads correctly (ferritin-100.21), but the VQ-VAE
-/// structure encoder is a different shape from the one ported here.
+/// structure encoder is a different shape from the one ported here. Its
+/// [`ModelCard`] carries the same fact in machine-readable form.
 pub const STRUCTURE_ENCODER_MISMATCH: &str = "\
 ESM3 structure-encoder weights cannot be loaded: the ported VQ-VAE encoder does not match \
 data/weights/esm3_structure_encoder_v0.pth. The checkpoint roots its stack at 'transformer', \
@@ -61,15 +63,30 @@ because resolving the paths without porting the real encoder would emit structur
 look plausible and are wrong (ferritin-100.22). ESM3Runner itself is unaffected and works.";
 
 impl ESM3Models {
-    /// Weight source, `.pth` filename, and config for this variant.
-    pub fn model_info(&self) -> (WeightSource, &'static str, ESM3Config) {
+    /// This variant's registry id.
+    pub const fn registry_id(&self) -> &'static str {
         match self {
-            Self::SmOpen => (
-                ESM3_REPO,
-                "data/weights/esm3_sm_open_v1.pth",
-                ESM3Config::sm_open(),
-            ),
+            Self::SmOpen => "esm3-sm-open-v1",
         }
+    }
+
+    /// This variant's [`ModelCard`].
+    pub fn card(&self) -> &'static ModelCard {
+        registry::lookup(self.registry_id())
+            .expect("every ESM3Models variant must have a registry entry")
+    }
+
+    /// Weight source, `.pth` filename, and config for this variant.
+    ///
+    /// Repo and filename come from [`REGISTRY`][crate::registry::REGISTRY]
+    /// (ferritin-goh.1). Note the path: the checkpoints live under
+    /// `data/weights/`, not at the repo root (ferritin-100.21).
+    pub fn model_info(&self) -> (WeightSource, &'static str, ESM3Config) {
+        let card = self.card();
+        let config = match self {
+            Self::SmOpen => ESM3Config::sm_open(),
+        };
+        (card.source, card.file, config)
     }
 }
 
@@ -215,6 +232,12 @@ impl StructureEncoderRunner {
     /// Loading the structure encoder is **not supported** — this always
     /// returns an error (ferritin-100.22).
     pub fn from_pretrained_with(_opts: &LoadOptions) -> Result<Self> {
+        // The registry records the same refusal, so the two cannot drift:
+        // test_structure_encoder_refusal_matches_registry pins them together.
+        debug_assert!(
+            registry::lookup(STRUCTURE_ENCODER_ID).is_some_and(|c| !c.is_loadable()),
+            "the registry should agree that the structure encoder is unsupported"
+        );
         bail!("{STRUCTURE_ENCODER_MISMATCH}");
     }
 

--- a/crates/ferritin-plms/src/esmc/pretrained.rs
+++ b/crates/ferritin-plms/src/esmc/pretrained.rs
@@ -33,6 +33,7 @@
 use crate::esmc::models::esmc::{ESMC, ESMCConfig, LogitsConfig};
 use crate::loader::{LoadOptions, WeightSource, optional_prefix};
 use crate::plm_runner::{ModelMetadata, PlmRunner, SpecialTokenLayout};
+use crate::registry::{self, ModelCard};
 use anyhow::{Result, bail};
 use candle_core::{Device, Tensor};
 
@@ -59,31 +60,44 @@ pub enum ESMCModels {
 }
 
 impl ESMCModels {
+    /// This variant's registry id.
+    pub const fn registry_id(&self) -> &'static str {
+        match self {
+            Self::ESMC300M => "esmc-300m",
+            Self::ESMC600M => "esmc-600m",
+            Self::ESMC6B => "esmc-6b",
+        }
+    }
+
+    /// This variant's [`ModelCard`].
+    pub fn card(&self) -> &'static ModelCard {
+        registry::lookup(self.registry_id())
+            .expect("every ESMCModels variant must have a registry entry")
+    }
+
     /// Returns `(weight_source, filename, config)` for this variant.
     ///
-    /// These point at the **EvolutionaryScale** originals, not the
-    /// `biohub/ESMC-*` re-exports the loader used to request. Those re-exports
-    /// are TransformerEngine-FUSED — `attn.layernorm_qkv.weight` as one fused
-    /// tensor with separate `layer_norm_weight`/`layer_norm_bias`,
-    /// `ffn.fc1_weight`/`fc2_weight`, an `lm_head` instead of
-    /// `sequence_head`, plus 90 empty `_extra_state` tensors — so nothing this
-    /// port asks for resolved (ferritin-100.23).
+    /// Repo and filename come from [`REGISTRY`][crate::registry::REGISTRY]
+    /// (ferritin-goh.1). Those point at the **EvolutionaryScale** originals,
+    /// not the `biohub/ESMC-*` re-exports this once used: those are
+    /// TransformerEngine-FUSED, so nothing this port asks for resolved
+    /// (ferritin-100.23).
     ///
-    /// `ESMC6B` is not yet supported: see [`ESMC6B_UNSUPPORTED`].
+    /// `ESMC6B` is refused; see [`ESMC6B_UNSUPPORTED`].
     pub fn model_info(&self) -> Result<(WeightSource, &'static str, ESMCConfig)> {
-        match self {
-            Self::ESMC300M => Ok((
-                WeightSource::pth("EvolutionaryScale/esmc-300m-2024-12", None),
-                "data/weights/esmc_300m_2024_12_v0.pth",
-                ESMCConfig::esmc_300m(),
-            )),
-            Self::ESMC600M => Ok((
-                WeightSource::pth("EvolutionaryScale/esmc-600m-2024-12", None),
-                "data/weights/esmc_600m_2024_12_v0.pth",
-                ESMCConfig::esmc_600m(),
-            )),
-            Self::ESMC6B => bail!("{ESMC6B_UNSUPPORTED}"),
+        let card = self.card();
+        if let Some(reason) = card.unsupported {
+            bail!(
+                "{} is not supported: {reason}. {ESMC6B_UNSUPPORTED}",
+                card.id
+            );
         }
+        let config = match self {
+            Self::ESMC300M => ESMCConfig::esmc_300m(),
+            Self::ESMC600M => ESMCConfig::esmc_600m(),
+            Self::ESMC6B => ESMCConfig::esmc_6b(),
+        };
+        Ok((card.source, card.file, config))
     }
 }
 

--- a/crates/ferritin-plms/src/esmfold2/pretrained.rs
+++ b/crates/ferritin-plms/src/esmfold2/pretrained.rs
@@ -31,6 +31,7 @@ use super::model::ESMFold2Model;
 use super::output::ESMFold2Output;
 use crate::esmc::pretrained::ESMCRunner;
 use crate::plm_runner::PlmRunner;
+use crate::registry;
 use anyhow::{Result, bail};
 use candle_core::{DType, Device, Tensor};
 
@@ -77,7 +78,16 @@ impl ESMFold2Models {
     /// the reference implementation (ferritin-100.4).
     pub fn model_info(&self) -> Result<(&'static str, ESMFold2Config)> {
         match self {
-            Self::Fast => Ok(("biohub/ESMFold2-Fast", ESMFold2Config::fast())),
+            Self::Fast => Ok((
+                // Repo comes from REGISTRY rather than being repeated here
+                // (ferritin-goh.1). The card also records that this model
+                // cannot currently be loaded at all (ferritin-100.17).
+                registry::lookup("esmfold2-fast")
+                    .expect("esmfold2-fast must have a registry entry")
+                    .source
+                    .repo_id,
+                ESMFold2Config::fast(),
+            )),
             Self::Full => bail!(
                 "ESMFold2Models::Full is not yet supported: only the Fast config is ported. \
                  The Full variant (MSA conditioning) needs a config verified against the \

--- a/crates/ferritin-plms/src/lib.rs
+++ b/crates/ferritin-plms/src/lib.rs
@@ -41,9 +41,11 @@ pub mod featurize;
 pub mod ligandmpnn;
 pub mod loader;
 pub mod plm_runner;
+pub mod registry;
 pub mod types;
 pub mod utils;
 pub use plm_runner::{ModelMetadata, PlmRunner, SpecialTokenLayout};
+pub use registry::{Family, ModelCard, ParityStatus, REGISTRY, TokenizerSpec};
 
 /// Returns the best available device for computation.
 ///

--- a/crates/ferritin-plms/src/ligandmpnn/pmpnn_runner.rs
+++ b/crates/ferritin-plms/src/ligandmpnn/pmpnn_runner.rs
@@ -5,6 +5,7 @@ use super::configs::ProteinMPNNConfig;
 use super::model::ProteinMPNN;
 use super::proteinfeatures::ProteinFeatures;
 use crate::loader::{Format, LoadOptions, WeightSource, var_builder_from_path};
+use crate::registry::{self, ModelCard};
 use crate::types::PseudoProbability;
 use anyhow::{Result, anyhow};
 use candle_core::{Device, Tensor};
@@ -21,15 +22,25 @@ pub enum ProteinMPNNModels {
 }
 
 impl ProteinMPNNModels {
-    /// Weight source and file for this variant.
-    pub fn model_info(&self) -> (WeightSource, &'static str) {
+    /// This variant's registry id.
+    pub const fn registry_id(&self) -> &'static str {
         match self {
-            Self::V48_020 => (
-                WeightSource::pth("zcpbx/ligandmpnn-weights", Some("model_state_dict"))
-                    .at_revision("main"),
-                "model_params/proteinmpnn_v_48_020.pt",
-            ),
+            Self::V48_020 => "proteinmpnn-v48-020",
         }
+    }
+
+    /// This variant's [`ModelCard`].
+    pub fn card(&self) -> &'static ModelCard {
+        registry::lookup(self.registry_id())
+            .expect("every ProteinMPNNModels variant must have a registry entry")
+    }
+
+    /// Weight source and file for this variant.
+    ///
+    /// Delegates to [`REGISTRY`][crate::registry::REGISTRY] (ferritin-goh.1).
+    pub fn model_info(&self) -> (WeightSource, &'static str) {
+        let card = self.card();
+        (card.source, card.file)
     }
 
     /// Renamed to [`model_info`][Self::model_info] (ferritin-100.8).

--- a/crates/ferritin-plms/src/registry.rs
+++ b/crates/ferritin-plms/src/registry.rs
@@ -1,0 +1,634 @@
+//! One table describing every supported model.
+//!
+//! Before this, the same facts were spread across six enums that each encoded a
+//! different subset in a different shape: `AmplifyModels` returned a
+//! [`WeightSource`], `ESM2Models` a source plus a config, `ESMCModels` a source
+//! plus a filename plus a config wrapped in `Result`, and so on. Which
+//! tokenizer a model needs lived in its runner; how many special tokens it
+//! wraps lived in its `PlmRunner` impl; whether it had ever been checked
+//! against a Python reference lived only in the test suite.
+//!
+//! [`REGISTRY`] is where that belongs. A model is a data row.
+//!
+//! # Why a const table
+//!
+//! The variation between models is data — strings, dimensions, token counts —
+//! so it stays data. The moment it becomes `dyn`, the compiler stops checking
+//! that every model is fully specified, which is exactly the property worth
+//! having: adding a row that omits a field will not compile.
+//!
+//! [`Family`] is a closed enum for the same reason. Adding a backbone should be
+//! a deliberate, reviewed act rather than something that falls out of a string.
+//!
+//! ```
+//! # use ferritin_plms::registry::{REGISTRY, lookup};
+//! let card = lookup("esm2-t6-8m").expect("registered");
+//! assert_eq!(card.metadata.d_model, 320);
+//! assert_eq!(card.source.repo_id, "facebook/esm2_t6_8M_UR50D");
+//! ```
+
+use crate::loader::WeightSource;
+use crate::plm_runner::{ModelMetadata, SpecialTokenLayout};
+
+// ── Family ────────────────────────────────────────────────────────────────────
+
+/// Architecture family a model belongs to.
+///
+/// Closed on purpose: a new family means a new loader, which is a reviewed
+/// change rather than a new string. Families are added when a loader for them
+/// lands, so every variant here has at least one row in [`REGISTRY`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Family {
+    /// ESM-2 and its schema-compatible relatives (ESM-1v, SaProt).
+    Esm2,
+    /// AMPLIFY.
+    Amplify,
+    /// ESM Cambrian.
+    Esmc,
+    /// ESM3, the multi-track model.
+    Esm3,
+    /// ESMFold2 — structure prediction, not an embedding model.
+    Esmfold2,
+    /// ProteinMPNN / LigandMPNN — inverse folding, not an embedding model.
+    Mpnn,
+}
+
+// ── TokenizerSpec ─────────────────────────────────────────────────────────────
+
+/// Where a model's tokenizer comes from.
+///
+/// Not incidental detail: the four ported families genuinely differ here, and
+/// that knowledge used to be buried in six separate runners.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenizerSpec {
+    /// A `tokenizer.json` downloaded from the model's own HF repo.
+    HfJson,
+    /// A `tokenizer.json` compiled into the binary with `include_bytes!`,
+    /// named by its path under `src/`.
+    Embedded(&'static str),
+    /// A hand-written vocabulary table in Rust, named by its module path.
+    BuiltinVocab(&'static str),
+    /// No tokenizer: the model consumes structure, not sequence.
+    None,
+}
+
+// ── ParityStatus ──────────────────────────────────────────────────────────────
+
+/// Whether this model's numerics have been checked against a Python reference.
+///
+/// `Unverified` is the honest default and covers most rows. It is not a
+/// statement that a model is wrong — only that nothing proves it right, which
+/// is worth being able to read off the registry rather than inferring from
+/// which fixtures happen to exist.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParityStatus {
+    /// A committed fixture pins this model's output against the reference
+    /// implementation. Names the fixture stem under `tests/fixtures/`.
+    Verified {
+        /// Fixture stem, without the `.safetensors` extension.
+        fixture: &'static str,
+    },
+    /// No parity fixture exists, so nothing checks this model's numerics.
+    Unverified,
+}
+
+// ── ModelCard ─────────────────────────────────────────────────────────────────
+
+/// Everything needed to identify, fetch, and load one model.
+#[derive(Debug, Clone, Copy)]
+pub struct ModelCard {
+    /// Stable kebab-case identifier, unique across the registry.
+    pub id: &'static str,
+    /// Architecture family.
+    pub family: Family,
+    /// Which repo and revision the weights live in, and their on-disk format.
+    pub source: WeightSource,
+    /// Path of the weight file within the repo.
+    pub file: &'static str,
+    /// Where the tokenizer comes from.
+    pub tokenizer: TokenizerSpec,
+    /// How many special tokens the tokenizer wraps a sequence in.
+    pub specials: SpecialTokenLayout,
+    /// Architecture dimensions.
+    ///
+    /// For the non-embedding families these are the nearest analogue rather
+    /// than a literal reading: `d_model` is the model's hidden width and
+    /// `vocab_size` its output alphabet.
+    pub metadata: ModelMetadata,
+    /// Rough in-memory footprint at F32, from the published parameter count.
+    ///
+    /// Approximate on purpose — it exists to tier CI and to warn before a
+    /// machine starts swapping, not to be exact. Load at F16 to roughly halve
+    /// it; see `LoadOptions::with_dtype`.
+    pub approx_bytes_f32: u64,
+    /// Whether anything checks this model's numerics.
+    pub parity: ParityStatus,
+    /// Set when the model cannot currently be loaded, saying why.
+    ///
+    /// Three ported models are in this state, each for a recorded reason. A
+    /// row that carries this is present because the model is part of the
+    /// public API, not because it works.
+    pub unsupported: Option<&'static str>,
+}
+
+impl ModelCard {
+    /// Whether this model can actually be loaded today.
+    pub const fn is_loadable(&self) -> bool {
+        self.unsupported.is_none()
+    }
+
+    /// Whether this model consumes sequence and can implement
+    /// [`PlmRunner`][crate::plm_runner::PlmRunner].
+    ///
+    /// A property of the card, not of its [`Family`]: ESM3 contains both a
+    /// sequence model and a VQ-VAE structure encoder that takes backbone
+    /// coordinates, so the family alone does not settle it.
+    pub const fn is_embedding_model(&self) -> bool {
+        !matches!(self.tokenizer, TokenizerSpec::None)
+    }
+}
+
+const GB: u64 = 1024 * 1024 * 1024;
+const MB: u64 = 1024 * 1024;
+
+/// Every model the public API exposes.
+///
+/// Rows carrying [`unsupported`][ModelCard::unsupported] are still listed: they
+/// are reachable from the public API, and a registry that hid them would
+/// misrepresent what a caller can name.
+pub const REGISTRY: &[ModelCard] = &[
+    // ── ESM-2 ────────────────────────────────────────────────────────────────
+    ModelCard {
+        id: "esm2-t6-8m",
+        family: Family::Esm2,
+        source: WeightSource::safetensors("facebook/esm2_t6_8M_UR50D").at_revision("main"),
+        file: "model.safetensors",
+        tokenizer: TokenizerSpec::Embedded("esm2/tokenizer.json"),
+        specials: SpecialTokenLayout::BOS_EOS,
+        metadata: ModelMetadata {
+            d_model: 320,
+            n_layers: 6,
+            vocab_size: 33,
+            max_positions: Some(1026),
+        },
+        approx_bytes_f32: 32 * MB,
+        parity: ParityStatus::Verified {
+            fixture: "esm2_parity",
+        },
+        unsupported: None,
+    },
+    ModelCard {
+        id: "esm2-t12-35m",
+        family: Family::Esm2,
+        source: WeightSource::safetensors("facebook/esm2_t12_35M_UR50D").at_revision("main"),
+        file: "model.safetensors",
+        tokenizer: TokenizerSpec::Embedded("esm2/tokenizer.json"),
+        specials: SpecialTokenLayout::BOS_EOS,
+        metadata: ModelMetadata {
+            d_model: 480,
+            n_layers: 12,
+            vocab_size: 33,
+            max_positions: Some(1026),
+        },
+        approx_bytes_f32: 140 * MB,
+        parity: ParityStatus::Unverified,
+        unsupported: None,
+    },
+    ModelCard {
+        id: "esm2-t30-150m",
+        family: Family::Esm2,
+        source: WeightSource::safetensors("facebook/esm2_t30_150M_UR50D").at_revision("main"),
+        file: "model.safetensors",
+        tokenizer: TokenizerSpec::Embedded("esm2/tokenizer.json"),
+        specials: SpecialTokenLayout::BOS_EOS,
+        metadata: ModelMetadata {
+            d_model: 640,
+            n_layers: 30,
+            vocab_size: 33,
+            max_positions: Some(1026),
+        },
+        approx_bytes_f32: 600 * MB,
+        parity: ParityStatus::Unverified,
+        unsupported: None,
+    },
+    ModelCard {
+        id: "esm2-t33-650m",
+        family: Family::Esm2,
+        source: WeightSource::safetensors("facebook/esm2_t33_650M_UR50D").at_revision("main"),
+        file: "model.safetensors",
+        tokenizer: TokenizerSpec::Embedded("esm2/tokenizer.json"),
+        specials: SpecialTokenLayout::BOS_EOS,
+        metadata: ModelMetadata {
+            d_model: 1280,
+            n_layers: 33,
+            vocab_size: 33,
+            max_positions: Some(1026),
+        },
+        approx_bytes_f32: 2 * GB + 600 * MB,
+        parity: ParityStatus::Unverified,
+        unsupported: None,
+    },
+    ModelCard {
+        id: "esm2-t36-3b",
+        family: Family::Esm2,
+        source: WeightSource::safetensors("facebook/esm2_t36_3B_UR50D").at_revision("main"),
+        file: "model.safetensors",
+        tokenizer: TokenizerSpec::Embedded("esm2/tokenizer.json"),
+        specials: SpecialTokenLayout::BOS_EOS,
+        metadata: ModelMetadata {
+            d_model: 2560,
+            n_layers: 36,
+            vocab_size: 33,
+            max_positions: Some(1026),
+        },
+        approx_bytes_f32: 12 * GB,
+        parity: ParityStatus::Unverified,
+        unsupported: None,
+    },
+    ModelCard {
+        id: "esm2-t48-15b",
+        family: Family::Esm2,
+        source: WeightSource::safetensors("facebook/esm2_t48_15B_UR50D").at_revision("main"),
+        file: "model.safetensors",
+        tokenizer: TokenizerSpec::Embedded("esm2/tokenizer.json"),
+        specials: SpecialTokenLayout::BOS_EOS,
+        metadata: ModelMetadata {
+            d_model: 5120,
+            n_layers: 48,
+            vocab_size: 33,
+            max_positions: Some(1026),
+        },
+        approx_bytes_f32: 60 * GB,
+        parity: ParityStatus::Unverified,
+        unsupported: None,
+    },
+    // ── AMPLIFY ──────────────────────────────────────────────────────────────
+    ModelCard {
+        id: "amplify-120m",
+        family: Family::Amplify,
+        source: WeightSource::safetensors("chandar-lab/AMPLIFY_120M").at_revision("main"),
+        file: "model.safetensors",
+        // The runner downloads the repo's tokenizer.json; an embedded copy also
+        // exists for AMPLIFY::load_tokenizer.
+        tokenizer: TokenizerSpec::HfJson,
+        specials: SpecialTokenLayout::BOS_EOS,
+        metadata: ModelMetadata {
+            d_model: 640,
+            n_layers: 24,
+            vocab_size: 27,
+            max_positions: Some(2048),
+        },
+        approx_bytes_f32: 480 * MB,
+        parity: ParityStatus::Verified {
+            fixture: "amplify_parity",
+        },
+        unsupported: None,
+    },
+    ModelCard {
+        id: "amplify-350m",
+        family: Family::Amplify,
+        source: WeightSource::safetensors("chandar-lab/AMPLIFY_350M").at_revision("main"),
+        file: "model.safetensors",
+        tokenizer: TokenizerSpec::HfJson,
+        specials: SpecialTokenLayout::BOS_EOS,
+        metadata: ModelMetadata {
+            d_model: 960,
+            n_layers: 32,
+            vocab_size: 27,
+            max_positions: Some(2048),
+        },
+        approx_bytes_f32: GB + 400 * MB,
+        parity: ParityStatus::Unverified,
+        unsupported: None,
+    },
+    // ── ESM Cambrian ─────────────────────────────────────────────────────────
+    ModelCard {
+        id: "esmc-300m",
+        family: Family::Esmc,
+        source: WeightSource::pth("EvolutionaryScale/esmc-300m-2024-12", None),
+        file: "data/weights/esmc_300m_2024_12_v0.pth",
+        tokenizer: TokenizerSpec::BuiltinVocab("esmc::tokenizer::EsmSequenceTokenizer"),
+        specials: SpecialTokenLayout::BOS_EOS,
+        metadata: ModelMetadata {
+            d_model: 960,
+            n_layers: 30,
+            vocab_size: 64,
+            // Rotary positions: no hard architectural cap.
+            max_positions: None,
+        },
+        approx_bytes_f32: GB + 200 * MB,
+        parity: ParityStatus::Unverified,
+        unsupported: None,
+    },
+    ModelCard {
+        id: "esmc-600m",
+        family: Family::Esmc,
+        source: WeightSource::pth("EvolutionaryScale/esmc-600m-2024-12", None),
+        file: "data/weights/esmc_600m_2024_12_v0.pth",
+        tokenizer: TokenizerSpec::BuiltinVocab("esmc::tokenizer::EsmSequenceTokenizer"),
+        specials: SpecialTokenLayout::BOS_EOS,
+        metadata: ModelMetadata {
+            d_model: 1152,
+            n_layers: 36,
+            vocab_size: 64,
+            max_positions: None,
+        },
+        approx_bytes_f32: 2 * GB + 400 * MB,
+        parity: ParityStatus::Unverified,
+        unsupported: None,
+    },
+    ModelCard {
+        id: "esmc-6b",
+        family: Family::Esmc,
+        source: WeightSource::safetensors("EvolutionaryScale/esmc-6b-2024-12"),
+        // Sharded across six files; see `unsupported`.
+        file: "model-00001-of-00006.safetensors",
+        tokenizer: TokenizerSpec::BuiltinVocab("esmc::tokenizer::EsmSequenceTokenizer"),
+        specials: SpecialTokenLayout::BOS_EOS,
+        metadata: ModelMetadata {
+            d_model: 2560,
+            n_layers: 80,
+            vocab_size: 64,
+            max_positions: None,
+        },
+        approx_bytes_f32: 24 * GB,
+        parity: ParityStatus::Unverified,
+        unsupported: Some(
+            "weights are sharded across six safetensors files, which the loader cannot yet \
+             follow, and the head is named lm_head at the top level rather than sequence_head \
+             (ferritin-100.24)",
+        ),
+    },
+    // ── ESM3 ─────────────────────────────────────────────────────────────────
+    ModelCard {
+        id: "esm3-sm-open-v1",
+        family: Family::Esm3,
+        source: WeightSource::pth("EvolutionaryScale/esm3-sm-open-v1", None),
+        file: "data/weights/esm3_sm_open_v1.pth",
+        tokenizer: TokenizerSpec::BuiltinVocab("esm3::tokenization::sequence"),
+        specials: SpecialTokenLayout::BOS_EOS,
+        metadata: ModelMetadata {
+            d_model: 1536,
+            n_layers: 48,
+            vocab_size: 64,
+            max_positions: None,
+        },
+        approx_bytes_f32: 5 * GB + 600 * MB,
+        parity: ParityStatus::Unverified,
+        unsupported: None,
+    },
+    ModelCard {
+        id: "esm3-structure-encoder-v0",
+        family: Family::Esm3,
+        source: WeightSource::pth("EvolutionaryScale/esm3-sm-open-v1", None),
+        file: "data/weights/esm3_structure_encoder_v0.pth",
+        // Consumes backbone coordinates and emits structure tokens.
+        tokenizer: TokenizerSpec::None,
+        specials: SpecialTokenLayout::NONE,
+        metadata: ModelMetadata {
+            d_model: 1024,
+            n_layers: 2,
+            // Codebook size: the structure-token alphabet it emits.
+            vocab_size: 4096,
+            max_positions: None,
+        },
+        approx_bytes_f32: 30 * MB,
+        parity: ParityStatus::Unverified,
+        unsupported: Some(
+            "the ported VQ-VAE encoder is a different shape from the released checkpoint: its \
+             blocks have no multi-head attn, it roots at 'transformer' not 'encoder', and it \
+             carries a relative positional embedding this port does not model (ferritin-100.22)",
+        ),
+    },
+    // ── ESMFold2 ─────────────────────────────────────────────────────────────
+    ModelCard {
+        id: "esmfold2-fast",
+        family: Family::Esmfold2,
+        source: WeightSource::safetensors("biohub/ESMFold2-Fast"),
+        file: "model.safetensors",
+        // Consumes ESMC-6B hidden states, not tokens of its own.
+        tokenizer: TokenizerSpec::None,
+        specials: SpecialTokenLayout::NONE,
+        metadata: ModelMetadata {
+            // d_single, the single-representation width.
+            d_model: 384,
+            n_layers: 24,
+            // Structure output, no token vocabulary.
+            vocab_size: 0,
+            max_positions: None,
+        },
+        approx_bytes_f32: 755 * MB,
+        parity: ParityStatus::Unverified,
+        unsupported: Some(
+            "the ported architecture does not match the released checkpoint: none of its 1032 \
+             tensors resolve to a model parameter (ferritin-100.17)",
+        ),
+    },
+    // ── ProteinMPNN ──────────────────────────────────────────────────────────
+    ModelCard {
+        id: "proteinmpnn-v48-020",
+        family: Family::Mpnn,
+        source: WeightSource::pth("zcpbx/ligandmpnn-weights", Some("model_state_dict"))
+            .at_revision("main"),
+        file: "model_params/proteinmpnn_v_48_020.pt",
+        // Consumes structure; residues are encoded by the featurizer.
+        tokenizer: TokenizerSpec::None,
+        specials: SpecialTokenLayout::NONE,
+        metadata: ModelMetadata {
+            d_model: 128,
+            // 3 encoder + 3 decoder.
+            n_layers: 6,
+            // 20 amino acids plus X.
+            vocab_size: 21,
+            max_positions: None,
+        },
+        approx_bytes_f32: 7 * MB,
+        parity: ParityStatus::Unverified,
+        unsupported: None,
+    },
+];
+
+// ── Lookups ───────────────────────────────────────────────────────────────────
+
+/// Find a model by its registry id.
+pub fn lookup(id: &str) -> Option<&'static ModelCard> {
+    REGISTRY.iter().find(|c| c.id == id)
+}
+
+/// Every card in a family.
+pub fn by_family(family: Family) -> impl Iterator<Item = &'static ModelCard> {
+    REGISTRY.iter().filter(move |c| c.family == family)
+}
+
+/// Every card that can actually be loaded today.
+pub fn loadable() -> impl Iterator<Item = &'static ModelCard> {
+    REGISTRY.iter().filter(|c| c.is_loadable())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_ids_are_unique() {
+        let mut seen = HashSet::new();
+        for card in REGISTRY {
+            assert!(seen.insert(card.id), "duplicate registry id: {}", card.id);
+        }
+    }
+
+    /// Ids are the registry's public handle, so they stay kebab-case and free
+    /// of the underscores and capitals the upstream repo names use.
+    #[test]
+    fn test_ids_are_kebab_case() {
+        for card in REGISTRY {
+            assert!(
+                card.id
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                "id {:?} should be lowercase kebab-case",
+                card.id
+            );
+        }
+    }
+
+    /// Every repo id must be well formed, or the failure only shows up as a
+    /// confusing 404 after a network round-trip.
+    #[test]
+    fn test_every_source_repo_is_well_formed() {
+        for card in REGISTRY {
+            assert!(
+                card.source.repo_id.split('/').count() == 2
+                    && !card.source.repo_id.starts_with('/')
+                    && !card.source.repo_id.ends_with('/'),
+                "{}: malformed repo id {:?}",
+                card.id,
+                card.source.repo_id
+            );
+            assert!(!card.file.is_empty(), "{}: empty weight filename", card.id);
+        }
+    }
+
+    #[test]
+    fn test_metadata_dimensions_are_plausible() {
+        for card in REGISTRY {
+            assert!(card.metadata.d_model > 0, "{}: zero d_model", card.id);
+            assert!(card.metadata.n_layers > 0, "{}: zero n_layers", card.id);
+            assert!(
+                card.approx_bytes_f32 > 0,
+                "{}: zero approx_bytes_f32",
+                card.id
+            );
+        }
+    }
+
+    /// Embedding models tokenize and therefore have a vocabulary; the
+    /// structure models deliberately have neither.
+    #[test]
+    fn test_embedding_models_have_a_tokenizer_and_vocab() {
+        for card in REGISTRY {
+            if card.is_embedding_model() {
+                assert_ne!(
+                    card.tokenizer,
+                    TokenizerSpec::None,
+                    "{}: an embedding model needs a tokenizer",
+                    card.id
+                );
+                assert!(
+                    card.metadata.vocab_size > 0,
+                    "{}: an embedding model needs a vocabulary",
+                    card.id
+                );
+            } else {
+                assert_eq!(
+                    card.metadata.max_positions, None,
+                    "{}: a structure model has no token positions to cap",
+                    card.id
+                );
+            }
+        }
+    }
+
+    /// Every family variant must have at least one row. Family is closed so
+    /// that adding a backbone is deliberate; a variant with no models means
+    /// the enum has drifted ahead of the loaders.
+    #[test]
+    fn test_every_family_has_at_least_one_model() {
+        for family in [
+            Family::Esm2,
+            Family::Amplify,
+            Family::Esmc,
+            Family::Esm3,
+            Family::Esmfold2,
+            Family::Mpnn,
+        ] {
+            assert!(
+                by_family(family).next().is_some(),
+                "{family:?} has no models; drop the variant or add its loader"
+            );
+        }
+    }
+
+    /// The three unsupported models are the ones with recorded reasons. This
+    /// pins the set so that a model silently becoming unloadable — or quietly
+    /// staying that way after a fix — shows up here.
+    #[test]
+    fn test_unsupported_models_are_the_known_set() {
+        let mut unsupported: Vec<&str> = REGISTRY
+            .iter()
+            .filter(|c| !c.is_loadable())
+            .map(|c| c.id)
+            .collect();
+        unsupported.sort_unstable();
+        assert_eq!(
+            unsupported,
+            ["esm3-structure-encoder-v0", "esmc-6b", "esmfold2-fast"]
+        );
+
+        for card in REGISTRY.iter().filter(|c| !c.is_loadable()) {
+            let reason = card.unsupported.unwrap();
+            assert!(
+                reason.contains("ferritin-"),
+                "{}: an unsupported reason should cite its tracking issue; got: {reason}",
+                card.id
+            );
+        }
+    }
+
+    /// Parity claims must name a fixture that the test suite actually has.
+    /// Only ESM2-8M and AMPLIFY-120M are verified today.
+    #[test]
+    fn test_verified_models_name_a_real_fixture() {
+        let mut verified: Vec<(&str, &str)> = REGISTRY
+            .iter()
+            .filter_map(|c| match c.parity {
+                ParityStatus::Verified { fixture } => Some((c.id, fixture)),
+                ParityStatus::Unverified => None,
+            })
+            .collect();
+        verified.sort_unstable();
+        assert_eq!(
+            verified,
+            [
+                ("amplify-120m", "amplify_parity"),
+                ("esm2-t6-8m", "esm2_parity"),
+            ],
+            "the set of parity-verified models changed; that is a deliberate act"
+        );
+    }
+
+    #[test]
+    fn test_lookup_finds_and_misses() {
+        assert_eq!(lookup("esm2-t6-8m").map(|c| c.id), Some("esm2-t6-8m"));
+        assert!(lookup("no-such-model").is_none());
+    }
+
+    #[test]
+    fn test_loadable_excludes_unsupported() {
+        assert!(loadable().all(|c| c.unsupported.is_none()));
+        assert!(!loadable().any(|c| c.id == "esmfold2-fast"));
+    }
+}

--- a/crates/ferritin-plms/tests/test_registry_conformance.rs
+++ b/crates/ferritin-plms/tests/test_registry_conformance.rs
@@ -1,0 +1,176 @@
+//! The registry must describe the models as they actually load (ferritin-goh.1).
+//!
+//! [`REGISTRY`] is only worth having if its rows are true. A declared `d_model`
+//! that disagrees with the loaded weights is worse than no declaration at all,
+//! because callers will size downstream layers from it.
+//!
+//! The unit tests in `registry.rs` check internal consistency — unique ids,
+//! well-formed repos, plausible dimensions. These check the rows against real
+//! checkpoints, so they download weights and are `#[ignore]`d:
+//!
+//! ```shell
+//! cargo test -p ferritin-plms --test test_registry_conformance -- --include-ignored
+//! ```
+//!
+//! Models whose cards carry `unsupported` are skipped rather than asserted on:
+//! their dimensions cannot be checked against weights that will not load, and
+//! pretending otherwise would make this suite red for reasons it does not own.
+
+use anyhow::Result;
+use ferritin_plms::plm_runner::PlmRunner;
+use ferritin_plms::registry::{Family, REGISTRY, lookup};
+use ferritin_plms::{
+    AmplifyModels, AmplifyRunner, ESM2Models, ESM2Runner, ESMCModels, ESMCRunner, device,
+};
+
+/// Every enum variant resolves to a registry row, and the row's source is what
+/// the enum hands the loader.
+///
+/// This is the delegation the issue asked for: the enums are thin lookups, so
+/// a repo string exists in exactly one place.
+#[test]
+fn test_enums_delegate_to_registry() {
+    for (variant, id, repo) in [
+        (
+            ESM2Models::T6_8M.registry_id(),
+            "esm2-t6-8m",
+            "facebook/esm2_t6_8M_UR50D",
+        ),
+        (
+            ESM2Models::T33_650M.registry_id(),
+            "esm2-t33-650m",
+            "facebook/esm2_t33_650M_UR50D",
+        ),
+    ] {
+        assert_eq!(variant, id);
+        assert_eq!(lookup(id).unwrap().source.repo_id, repo);
+    }
+
+    // The enum's own accessor must return the registry's source, not a copy.
+    let (source, _config) = ESM2Models::T6_8M.model_info();
+    assert_eq!(source.repo_id, lookup("esm2-t6-8m").unwrap().source.repo_id);
+
+    let source = AmplifyModels::AMP120M.model_info();
+    assert_eq!(
+        source.repo_id,
+        lookup("amplify-120m").unwrap().source.repo_id
+    );
+}
+
+/// Loading ESM2-8M must produce exactly the dimensions its card declares.
+#[test]
+#[ignore = "requires downloading facebook/esm2_t6_8M_UR50D weights"]
+fn test_esm2_loaded_dims_match_card() -> Result<()> {
+    let card = lookup("esm2-t6-8m").expect("registered");
+    let runner = ESM2Runner::from_pretrained(ESM2Models::T6_8M, device(false)?)?;
+    assert_card_matches(card.id, &runner)
+}
+
+#[test]
+#[ignore = "requires downloading chandar-lab/AMPLIFY_120M weights"]
+fn test_amplify_loaded_dims_match_card() -> Result<()> {
+    let card = lookup("amplify-120m").expect("registered");
+    let runner = AmplifyRunner::from_pretrained(AmplifyModels::AMP120M, device(false)?)?;
+    assert_card_matches(card.id, &runner)
+}
+
+#[test]
+#[ignore = "requires downloading EvolutionaryScale/esmc-300m-2024-12 weights"]
+fn test_esmc_loaded_dims_match_card() -> Result<()> {
+    let card = lookup("esmc-300m").expect("registered");
+    let runner = ESMCRunner::from_pretrained(ESMCModels::ESMC300M, device(false)?)?;
+    assert_card_matches(card.id, &runner)
+}
+
+/// Compare a loaded runner's self-reported metadata and token layout against
+/// its registry row.
+fn assert_card_matches(id: &str, runner: &dyn PlmRunner) -> Result<()> {
+    let card = lookup(id).expect("registered");
+    let loaded = runner.metadata();
+
+    assert_eq!(
+        loaded.d_model, card.metadata.d_model,
+        "{id}: card says d_model {} but the loaded model reports {}",
+        card.metadata.d_model, loaded.d_model
+    );
+    assert_eq!(
+        loaded.n_layers, card.metadata.n_layers,
+        "{id}: card says n_layers {} but the loaded model reports {}",
+        card.metadata.n_layers, loaded.n_layers
+    );
+    assert_eq!(
+        loaded.vocab_size, card.metadata.vocab_size,
+        "{id}: card says vocab_size {} but the loaded model reports {}",
+        card.metadata.vocab_size, loaded.vocab_size
+    );
+    assert_eq!(
+        loaded.max_positions, card.metadata.max_positions,
+        "{id}: card and loaded model disagree on max_positions"
+    );
+    assert_eq!(
+        runner.special_tokens(),
+        card.specials,
+        "{id}: card and runner disagree on the special-token layout"
+    );
+
+    // The declared width must also be the width actually returned.
+    let embedded = runner.embed_residues("MQIFVKTLTGK")?;
+    assert_eq!(
+        embedded.dim(2)?,
+        card.metadata.d_model,
+        "{id}: embeddings are not d_model wide"
+    );
+    Ok(())
+}
+
+/// Every loadable embedding model has a card that can be checked this way.
+///
+/// Guards against a new row being added without conformance coverage: if this
+/// list grows, a matching `#[ignore]`d test above should grow with it.
+#[test]
+fn test_loadable_embedding_models_are_covered() {
+    let mut covered: Vec<&str> = REGISTRY
+        .iter()
+        .filter(|c| c.is_loadable() && c.is_embedding_model())
+        .map(|c| c.id)
+        .collect();
+    covered.sort_unstable();
+
+    assert_eq!(
+        covered,
+        [
+            "amplify-120m",
+            "amplify-350m",
+            "esm2-t12-35m",
+            "esm2-t30-150m",
+            "esm2-t33-650m",
+            "esm2-t36-3b",
+            "esm2-t48-15b",
+            "esm2-t6-8m",
+            "esm3-sm-open-v1",
+            "esmc-300m",
+            "esmc-600m",
+        ],
+        "the set of loadable embedding models changed; add or remove a \
+         conformance test to match"
+    );
+}
+
+/// The two structure families stay outside PlmRunner, so no conformance test
+/// above applies to them. Recorded rather than implied.
+#[test]
+fn test_structure_models_are_not_embedding_models() {
+    for id in [
+        "esmfold2-fast",
+        "proteinmpnn-v48-020",
+        "esm3-structure-encoder-v0",
+    ] {
+        let card = lookup(id).expect("registered");
+        assert!(
+            !card.is_embedding_model(),
+            "{id} should not be treated as an embedding model"
+        );
+    }
+    assert_eq!(lookup("esmfold2-fast").unwrap().family, Family::Esmfold2);
+    assert_eq!(lookup("proteinmpnn-v48-020").unwrap().family, Family::Mpnn);
+}


### PR DESCRIPTION
The P0 for the `ferritin-goh` epic, and now unblocked — it explicitly depended on `WeightSource` (#180) and `SpecialTokenLayout` (#181), which is where those types get their public home.

## The problem

The same facts were spread across six enums, each encoding a different subset in a different shape: `AmplifyModels` returned a `WeightSource`, `ESM2Models` a source plus a config, `ESMCModels` a source plus a filename plus a config wrapped in `Result`. Which tokenizer a model needs lived in its runner. How many special tokens it wraps lived in its `PlmRunner` impl. Whether it had ever been checked against a Python reference lived **only in the test suite**.

`registry.rs` is one const table, fourteen rows, each carrying id, family, `WeightSource`, weight filename, `TokenizerSpec`, `SpecialTokenLayout`, `ModelMetadata`, approximate F32 footprint, `ParityStatus`, and — where applicable — why the model can't currently be loaded.

A const table rather than a trait-object plugin system, per the issue's design: the variation is data, and the moment it becomes `dyn` the compiler stops checking that every model is fully specified. **Adding a row that omits a field does not compile.**

All six enums are now thin lookups — each gains `registry_id()` and `card()`, and `model_info()` reads repo and filename off the card. A repo string exists in exactly one place.

## Two deliberate deviations from the issue's sketch

**`Family` omits `T5Encoder` and `Bert`.** Those loaders don't exist yet, and a variant with no rows can't be tested — `test_every_family_has_at_least_one_model` enforces that. `Esmfold2` is *added*, which the issue's list missed despite `ESMFold2Models` being public API.

**`TokenizerSpec` gains `BuiltinVocab` and `None`.** ESMC and ESM3 use hand-written vocab tables, not a `tokenizer.json`; the structure models consume coordinates and have no tokenizer at all. `SpaceSeparatedResidues` is left out until the ProtBert loader that needs it lands.

Also: `is_embedding_model` is a property of the **card**, not the family. ESM3 contains both a sequence model and a VQ-VAE structure encoder, so the family alone doesn't settle it. That surfaced while adding a row for the structure encoder — public API via `StructureEncoderRunner`, and absent from the issue's model list.

## Tests, in two layers

**Internal consistency (10 unit tests):** unique kebab-case ids, well-formed repos, plausible dimensions, every family populated, and pinned sets for the unsupported and parity-verified rows so either changing is a deliberate act.

**Conformance against reality:** `tests/test_registry_conformance.rs` loads ESM2-8M, AMPLIFY-120M and ESMC-300M and compares `d_model`, `n_layers`, `vocab_size`, `max_positions` and the special-token layout against their cards — plus the width actually returned by `embed_residues`. **All three match.**

That layer is the point rather than a formality: a declared `d_model` that disagrees with the weights is *worse* than no declaration, because callers size downstream layers from it.

```
cargo test -p ferritin-plms --test test_registry_conformance -- --include-ignored   # 6 passed
cargo clippy --workspace --all-targets -- -D warnings                               # clean
cargo test --workspace                                                              # pass
```

## Follow-on value

`ParityStatus` and `approx_bytes_f32` are what ferritin-100.13 (support matrix) and the epic's CI tiering were waiting on — both are now readable off one table instead of inferred from which fixtures happen to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
