### PR TITLE
Publish a model support matrix in the crate docs (ferritin-100.13)

### DIFF
--- a/crates/ferritin-plms/src/amplify/amplify_runner.rs
+++ b/crates/ferritin-plms/src/amplify/amplify_runner.rs
@@ -124,7 +124,7 @@ impl AmplifyRunner {
     /// shifted every label by one — position 0 was BOS, not the first residue
     /// (ferritin-100.18).
     ///
-    /// Unlike [`ESM2Runner::get_pseudo_probabilities`], every amino acid is
+    /// Unlike [`crate::ESM2Runner::get_pseudo_probabilities`], every amino acid is
     /// returned rather than only those above a probability threshold.
     pub fn get_pseudo_probabilities(&self, prot_sequence: &str) -> Result<Vec<PseudoProbability>> {
         let model_output: AmplifyOutput = self.run_forward(prot_sequence)?;

--- a/crates/ferritin-plms/src/lib.rs
+++ b/crates/ferritin-plms/src/lib.rs
@@ -5,6 +5,38 @@
 //! cargo run --example amplify
 //! cargo run --example amplify --features metal
 //! ```
+//!
+//! # Model support matrix
+//!
+//! Generated from [`registry::REGISTRY`]; regenerate with
+//! `cargo test -p ferritin-plms --lib print_support_matrix -- --ignored --nocapture`.
+//! `test_lib_rs_support_matrix_is_current` fails if this copy drifts.
+//!
+//! The column to read first is **Parity**. "It compiles" and even "it loads"
+//! are not what you need before trusting a number — you need to know whether
+//! anyone has compared this port's output against the reference
+//! implementation. Two models have. The rest are unverified: not known to be
+//! wrong, but nothing proves them right.
+//!
+//! <!-- BEGIN SUPPORT MATRIX -->
+//! | Model | Family | Weights | Parity | Status |
+//! |---|---|---|---|---|
+//! | `esm2-t6-8m` | Esm2 | `facebook/esm2_t6_8M_UR50D` (safetensors) | verified (`esm2_parity`) | supported |
+//! | `esm2-t12-35m` | Esm2 | `facebook/esm2_t12_35M_UR50D` (safetensors) | **not checked** | supported |
+//! | `esm2-t30-150m` | Esm2 | `facebook/esm2_t30_150M_UR50D` (safetensors) | **not checked** | supported |
+//! | `esm2-t33-650m` | Esm2 | `facebook/esm2_t33_650M_UR50D` (safetensors) | **not checked** | supported |
+//! | `esm2-t36-3b` | Esm2 | `facebook/esm2_t36_3B_UR50D` (safetensors) | **not checked** | supported |
+//! | `esm2-t48-15b` | Esm2 | `facebook/esm2_t48_15B_UR50D` (safetensors) | **not checked** | supported |
+//! | `amplify-120m` | Amplify | `chandar-lab/AMPLIFY_120M` (safetensors) | verified (`amplify_parity`) | supported |
+//! | `amplify-350m` | Amplify | `chandar-lab/AMPLIFY_350M` (safetensors) | **not checked** | supported |
+//! | `esmc-300m` | Esmc | `EvolutionaryScale/esmc-300m-2024-12` (pth) | **not checked** | supported |
+//! | `esmc-600m` | Esmc | `EvolutionaryScale/esmc-600m-2024-12` (pth) | **not checked** | supported |
+//! | `esmc-6b` | Esmc | `EvolutionaryScale/esmc-6b-2024-12` (safetensors) | **not checked** | **unsupported** — weights are sharded across six safetensors files (ferritin-100.24) |
+//! | `esm3-sm-open-v1` | Esm3 | `EvolutionaryScale/esm3-sm-open-v1` (pth) | **not checked** | supported |
+//! | `esm3-structure-encoder-v0` | Esm3 | `EvolutionaryScale/esm3-sm-open-v1` (pth) | **not checked** | **unsupported** — the ported VQ-VAE encoder is a different shape from the released checkpoint (ferritin-100.22) |
+//! | `esmfold2-fast` | Esmfold2 | `biohub/ESMFold2-Fast` (safetensors) | **not checked** | **unsupported** — the ported architecture does not match the released checkpoint (ferritin-100.17) |
+//! | `proteinmpnn-v48-020` | Mpnn | `zcpbx/ligandmpnn-weights` (pth) | **not checked** | supported |
+//! <!-- END SUPPORT MATRIX -->
 
 // The crate deliberately uses the `foo/mod.rs` + inner `mod foo` layout for
 // each model family, so module_inception is expected throughout.

--- a/crates/ferritin-plms/src/registry.rs
+++ b/crates/ferritin-plms/src/registry.rs
@@ -146,6 +146,18 @@ impl ModelCard {
     pub const fn is_embedding_model(&self) -> bool {
         !matches!(self.tokenizer, TokenizerSpec::None)
     }
+
+    /// Lowercase family name, for matching against string-keyed tables.
+    pub const fn family_str(&self) -> &'static str {
+        match self.family {
+            Family::Esm2 => "esm2",
+            Family::Amplify => "amplify",
+            Family::Esmc => "esmc",
+            Family::Esm3 => "esm3",
+            Family::Esmfold2 => "esmfold2",
+            Family::Mpnn => "proteinmpnn",
+        }
+    }
 }
 
 const GB: u64 = 1024 * 1024 * 1024;
@@ -448,6 +460,60 @@ pub const REGISTRY: &[ModelCard] = &[
     },
 ];
 
+// ── Support matrix ────────────────────────────────────────────────────────────
+
+/// Render [`REGISTRY`] as a markdown support matrix.
+///
+/// The column that matters is **Parity**. "Does it compile" and even "does it
+/// load" are not what a user needs to know before trusting a number — what
+/// they need is whether anyone has ever compared this port's output against
+/// the reference implementation. Today two models have, and the table says so
+/// rather than leaving it to be inferred from which fixtures happen to exist
+/// (ferritin-100.13).
+///
+/// The copy embedded in the crate docs is checked against this function by
+/// `test_lib_rs_support_matrix_is_current`, so the two cannot drift.
+pub fn support_matrix_markdown() -> String {
+    let mut out = String::new();
+    out.push_str("| Model | Family | Weights | Parity | Status |\n");
+    out.push_str("|---|---|---|---|---|\n");
+
+    for card in REGISTRY {
+        let format = match card.source.format {
+            crate::loader::Format::Safetensors => "safetensors",
+            crate::loader::Format::Pth { .. } => "pth",
+        };
+        let parity = match card.parity {
+            ParityStatus::Verified { fixture } => {
+                format!("verified (`{fixture}`)")
+            }
+            ParityStatus::Unverified => "**not checked**".to_string(),
+        };
+        let status = match card.unsupported {
+            None => "supported".to_string(),
+            Some(reason) => {
+                // Keep the table readable; the full reason lives on the card.
+                let short = reason.split(" (ferritin-").next().unwrap_or(reason);
+                let issue = reason
+                    .rsplit_once("(ferritin-")
+                    .map(|(_, tail)| tail.trim_end_matches(')'))
+                    .unwrap_or("");
+                let first = short.split(&[',', ':'][..]).next().unwrap_or(short);
+                if issue.is_empty() {
+                    format!("**unsupported** — {first}")
+                } else {
+                    format!("**unsupported** — {first} (ferritin-{issue})")
+                }
+            }
+        };
+        out.push_str(&format!(
+            "| `{}` | {:?} | `{}` ({format}) | {parity} | {status} |\n",
+            card.id, card.family, card.source.repo_id,
+        ));
+    }
+    out
+}
+
 // ── Lookups ───────────────────────────────────────────────────────────────────
 
 /// Find a model by its registry id.
@@ -630,5 +696,80 @@ mod tests {
     fn test_loadable_excludes_unsupported() {
         assert!(loadable().all(|c| c.unsupported.is_none()));
         assert!(!loadable().any(|c| c.id == "esmfold2-fast"));
+    }
+}
+
+#[cfg(test)]
+mod matrix {
+    use super::*;
+
+    /// Regeneration helper: prints the matrix for pasting into `lib.rs`.
+    ///
+    /// ```shell
+    /// cargo test -p ferritin-plms --lib print_support_matrix -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "prints the matrix for copying into lib.rs"]
+    fn print_support_matrix() {
+        println!("{}", support_matrix_markdown());
+    }
+
+    /// The copy in the crate docs must match what the registry renders.
+    ///
+    /// A stale matrix is worse than none: it would tell a user a model is
+    /// parity-verified, or supported, after that stopped being true.
+    #[test]
+    fn test_lib_rs_support_matrix_is_current() {
+        const LIB_RS: &str = include_str!("lib.rs");
+        const BEGIN: &str = "//! <!-- BEGIN SUPPORT MATRIX -->";
+        const END: &str = "//! <!-- END SUPPORT MATRIX -->";
+
+        let start = LIB_RS
+            .find(BEGIN)
+            .expect("lib.rs should carry a BEGIN SUPPORT MATRIX marker")
+            + BEGIN.len();
+        let end = LIB_RS
+            .find(END)
+            .expect("lib.rs should carry an END SUPPORT MATRIX marker");
+
+        let embedded: String = LIB_RS[start..end]
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| {
+                format!(
+                    "{}\n",
+                    l.trim_start().trim_start_matches("//!").trim_start()
+                )
+            })
+            .collect();
+
+        let rendered: String = support_matrix_markdown()
+            .lines()
+            .map(|l| format!("{l}\n"))
+            .collect();
+
+        assert_eq!(
+            embedded, rendered,
+            "the support matrix in lib.rs is stale. Regenerate it with:\n  \
+             cargo test -p ferritin-plms --lib print_support_matrix -- --ignored --nocapture\n\
+             then replace the block between the SUPPORT MATRIX markers."
+        );
+    }
+
+    /// Every model in the matrix carries an explicit parity verdict.
+    #[test]
+    fn test_matrix_states_parity_for_every_model() {
+        let matrix = support_matrix_markdown();
+        for card in REGISTRY {
+            let row = matrix
+                .lines()
+                .find(|l| l.contains(&format!("`{}`", card.id)))
+                .unwrap_or_else(|| panic!("{} missing from the matrix", card.id));
+            assert!(
+                row.contains("verified") || row.contains("not checked"),
+                "{}: the matrix must state a parity verdict; got: {row}",
+                card.id
+            );
+        }
     }
 }

--- a/crates/ferritin-plms/tests/support/model_harness.rs
+++ b/crates/ferritin-plms/tests/support/model_harness.rs
@@ -21,8 +21,18 @@ pub enum PortStatus {
     Partial,
 }
 
+/// Test-coverage annotation for one model.
+///
+/// This is deliberately NOT a second model list. `registry::REGISTRY` is the
+/// canonical inventory — which models exist, where their weights live, and
+/// whether their numerics have been checked (ferritin-goh.1). This table only
+/// records what automated coverage each one has, keyed to a registry id by
+/// [`ModelPortCase::registry_id`]; `test_port_cases_reference_real_models`
+/// keeps the two from drifting apart (ferritin-100.13).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ModelPortCase {
+    /// The `ModelCard::id` this case annotates.
+    pub registry_id: &'static str,
     pub family: &'static str,
     pub variant: &'static str,
     pub source_artifact: &'static str,
@@ -37,6 +47,7 @@ pub struct ModelPortCase {
 pub const MODEL_PORT_CASES: &[ModelPortCase] = &[
     ModelPortCase {
         family: "amplify",
+        registry_id: "amplify-120m",
         variant: "AMP120M",
         source_artifact: "huggingface safetensors",
         rust_backend: "candle",
@@ -48,6 +59,7 @@ pub const MODEL_PORT_CASES: &[ModelPortCase] = &[
     },
     ModelPortCase {
         family: "amplify",
+        registry_id: "amplify-350m",
         variant: "AMP350M",
         source_artifact: "huggingface safetensors",
         rust_backend: "candle",
@@ -59,6 +71,7 @@ pub const MODEL_PORT_CASES: &[ModelPortCase] = &[
     },
     ModelPortCase {
         family: "esm2",
+        registry_id: "esm2-t6-8m",
         variant: "T6_8M",
         source_artifact: "huggingface safetensors",
         rust_backend: "candle",
@@ -70,6 +83,7 @@ pub const MODEL_PORT_CASES: &[ModelPortCase] = &[
     },
     ModelPortCase {
         family: "esm2",
+        registry_id: "esm2-t30-150m",
         variant: "T30_150M",
         source_artifact: "huggingface safetensors",
         rust_backend: "candle",
@@ -81,6 +95,7 @@ pub const MODEL_PORT_CASES: &[ModelPortCase] = &[
     },
     ModelPortCase {
         family: "proteinmpnn",
+        registry_id: "proteinmpnn-v48-020",
         variant: "v48_020",
         source_artifact: "embedded pytorch checkpoint",
         rust_backend: "candle",
@@ -92,6 +107,7 @@ pub const MODEL_PORT_CASES: &[ModelPortCase] = &[
     },
     ModelPortCase {
         family: "esmc",
+        registry_id: "esmc-300m",
         variant: "ESMC-300M",
         source_artifact: "huggingface safetensors (biohub/ESMC-300M)",
         rust_backend: "candle",

--- a/crates/ferritin-plms/tests/test_model_port_harness.rs
+++ b/crates/ferritin-plms/tests/test_model_port_harness.rs
@@ -65,3 +65,47 @@ fn test_proteinmpnn_checkpoint_contract() -> Result<()> {
     validate_proteinmpnn_checkpoint()?;
     Ok(())
 }
+
+/// Every port case must name a real registry model.
+///
+/// This is what keeps `MODEL_PORT_CASES` an annotation rather than a rival
+/// inventory. Before ferritin-goh.1 there were two model lists that could
+/// disagree; now the registry is canonical and this table only records what
+/// coverage each entry has (ferritin-100.13).
+#[test]
+fn test_port_cases_reference_real_models() {
+    use ferritin_plms::registry::lookup;
+
+    for case in MODEL_PORT_CASES {
+        let card = lookup(case.registry_id).unwrap_or_else(|| {
+            panic!(
+                "port case {}:{} names {:?}, which is not in REGISTRY",
+                case.family, case.variant, case.registry_id
+            )
+        });
+        assert_eq!(
+            card.family_str(),
+            case.family,
+            "{}: port case and registry disagree on family",
+            case.registry_id
+        );
+    }
+}
+
+/// A port case must not claim coverage for a model the registry says cannot
+/// be loaded — that would advertise validation that cannot be running.
+#[test]
+fn test_no_coverage_claimed_for_unsupported_models() {
+    use ferritin_plms::registry::lookup;
+
+    for case in MODEL_PORT_CASES {
+        let card = lookup(case.registry_id).expect("checked above");
+        if !card.is_loadable() {
+            assert!(
+                !(case.has_remote_smoke || case.has_pytorch_checkpoint_test),
+                "{}: registry says unsupported, so it cannot have live coverage",
+                case.registry_id
+            );
+        }
+    }
+}


### PR DESCRIPTION
A user landing on `ferritin-plms` had no way to tell that ESM2 is well-trodden while most ports have **never had their outputs compared against anything**. The data existed; it was just invisible.

The crate docs now carry a generated matrix — one row per model, with repo, format, and a **Parity** column:

| Model | Family | Weights | Parity | Status |
|---|---|---|---|---|
| `esm2-t6-8m` | Esm2 | `facebook/esm2_t6_8M_UR50D` (safetensors) | verified (`esm2_parity`) | supported |
| `amplify-120m` | Amplify | `chandar-lab/AMPLIFY_120M` (safetensors) | verified (`amplify_parity`) | supported |
| `esmc-6b` | Esmc | `EvolutionaryScale/esmc-6b-2024-12` (safetensors) | **not checked** | **unsupported** — sharded across six files (ferritin-100.24) |
| … | | | | |

That column is the point. "It compiles" and even "it loads" aren't what you need before trusting a number — you need to know whether anyone has checked this port against the reference. **Two models have.** The rest say *not checked*: not known to be wrong, but nothing proves them right.

`registry::support_matrix_markdown()` renders it; `test_lib_rs_support_matrix_is_current` fails if the embedded copy drifts and prints the regeneration command. I verified that test **actually fails** by editing a parity verdict in `lib.rs` and watching it catch the change — a drift test that can't fail is decoration.

## Departure from the issue

It asked to complete `MODEL_PORT_CASES` and render *that*. Since #192 landed, doing so would mean maintaining a **second model list** alongside `REGISTRY` — exactly what the registry exists to prevent. And the evidence is right there: `MODEL_PORT_CASES` was already missing ESM3, ESMFold2, ESMC-600M and ESMC-6B, precisely because a hand-maintained duplicate drifts.

So the matrix renders from `REGISTRY`, and `MODEL_PORT_CASES` becomes what it's actually good at — a **coverage annotation**. Each case gains a `registry_id`, and two tests keep it honest:

- every case must name a real registry model and agree on its family
- no case may claim live coverage for a model the registry says can't be loaded

The issue's proposed `parity_verified` bool is subsumed by `ParityStatus`, which also names the fixture.

## Also

Fixes one rustdoc warning I introduced with the AMPLIFY position fix in #181. The crate has 17 more, all pre-existing and of one class (`[0,1]` read as an intra-doc link) — filed as **ferritin-100.26** rather than folded into an unrelated change. Worth doing soon now that the crate docs are something users are meant to read.

```
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test --workspace                                  # pass
cargo doc -p ferritin-plms --no-deps                    # 17 warnings, all pre-existing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
