### PR TITLE
Support sharded safetensors so ESMC-6B can load (ferritin-100.24)

### DIFF
--- a/crates/ferritin-plms/src/esmc/models/esmc.rs
+++ b/crates/ferritin-plms/src/esmc/models/esmc.rs
@@ -182,7 +182,20 @@ pub struct ESMC {
 }
 
 impl ESMC {
+    /// Load with the output head at the conventional `sequence_head` path.
     pub fn load(vb: VarBuilder, config: ESMCConfig) -> Result<Self> {
+        let head = vb.pp("sequence_head");
+        Self::load_with_head(vb, head, config)
+    }
+
+    /// Load with the output head supplied separately.
+    ///
+    /// ESMC-300M and 600M are flat checkpoints whose head sits at
+    /// `sequence_head`, alongside the backbone. ESMC-6B nests its backbone
+    /// under an `esmc.` prefix but leaves its head at the top level, named
+    /// `lm_head` — so the head's root is not reachable by descending from the
+    /// backbone's, and the caller has to say where it is (ferritin-100.24).
+    pub fn load_with_head(vb: VarBuilder, head: VarBuilder, config: ESMCConfig) -> Result<Self> {
         let ESMCConfig {
             d_model,
             tokenizer,
@@ -196,7 +209,7 @@ impl ESMC {
         Ok(Self {
             embed: nn::embedding(embedding_dim, d_model, vb.pp("embed"))?,
             transformer: TransformerStack::load(vb.pp("transformer"), &config)?,
-            sequence_head: RegressionHead::load(vb.pp("sequence_head"), &config)?,
+            sequence_head: RegressionHead::load(head, &config)?,
             tokenizer: tokenizer_collection.sequence,
             device,
         })

--- a/crates/ferritin-plms/src/esmc/pretrained.rs
+++ b/crates/ferritin-plms/src/esmc/pretrained.rs
@@ -37,18 +37,6 @@ use crate::registry::{self, ModelCard};
 use anyhow::{Result, bail};
 use candle_core::{Device, Tensor};
 
-/// Why [`ESMCModels::ESMC6B`] cannot be loaded yet.
-///
-/// Its checkpoint uses the same unfused layout as 300M/600M, so this is
-/// plumbing rather than an architecture mismatch — but two pieces are missing.
-pub const ESMC6B_UNSUPPORTED: &str = "\
-ESMCModels::ESMC6B is not yet supported. EvolutionaryScale/esmc-6b-2024-12 splits its 808 \
-tensors across six safetensors shards (model-0000{1..6}-of-00006.safetensors with a \
-model.safetensors.index.json), and WeightSource::var_builder loads a single file; it also \
-names its output head 'lm_head' at the top level rather than 'sequence_head' under the 'esmc' \
-prefix this port descends into. Refusing until both are handled, rather than loading part of \
-the model (ferritin-100.24). ESMC300M and ESMC600M work.";
-
 /// Available ESMC model variants hosted on HuggingFace.
 pub enum ESMCModels {
     /// ESMC 300M — 30 layers, d_model=960 (~1.3 GB weights)
@@ -83,14 +71,12 @@ impl ESMCModels {
     /// TransformerEngine-FUSED, so nothing this port asks for resolved
     /// (ferritin-100.23).
     ///
-    /// `ESMC6B` is refused; see [`ESMC6B_UNSUPPORTED`].
+    /// `ESMC6B` loads through its shard index and keeps its head at
+    /// `lm_head` rather than `sequence_head` (ferritin-100.24).
     pub fn model_info(&self) -> Result<(WeightSource, &'static str, ESMCConfig)> {
         let card = self.card();
         if let Some(reason) = card.unsupported {
-            bail!(
-                "{} is not supported: {reason}. {ESMC6B_UNSUPPORTED}",
-                card.id
-            );
+            bail!("{} is not supported: {reason}", card.id);
         }
         let config = match self {
             Self::ESMC300M => ESMCConfig::esmc_300m(),
@@ -129,8 +115,17 @@ impl ESMCRunner {
         let (source, filename, config) = model.model_info()?;
         let vb = source.var_builder(filename, opts)?;
         // Weights saved from ESMCForMaskedLM nest the backbone under "esmc".
+        // ESMC-6B nests its backbone under "esmc." but keeps its head at the
+        // top level as "lm_head"; 300M/600M are flat with "sequence_head".
+        // So the head is resolved from the ORIGINAL root, not the descended
+        // one (ferritin-100.24).
+        let head = if vb.contains_tensor("lm_head.0.weight") {
+            vb.pp("lm_head")
+        } else {
+            vb.pp("sequence_head")
+        };
         let vb_root = optional_prefix(vb, "esmc", "embed.weight");
-        let esmc = ESMC::load(vb_root, config.clone())?;
+        let esmc = ESMC::load_with_head(vb_root, head, config.clone())?;
         Ok(Self {
             model: esmc,
             config,

--- a/crates/ferritin-plms/src/lib.rs
+++ b/crates/ferritin-plms/src/lib.rs
@@ -31,7 +31,7 @@
 //! | `amplify-350m` | Amplify | `chandar-lab/AMPLIFY_350M` (safetensors) | **not checked** | supported |
 //! | `esmc-300m` | Esmc | `EvolutionaryScale/esmc-300m-2024-12` (pth) | **not checked** | supported |
 //! | `esmc-600m` | Esmc | `EvolutionaryScale/esmc-600m-2024-12` (pth) | **not checked** | supported |
-//! | `esmc-6b` | Esmc | `EvolutionaryScale/esmc-6b-2024-12` (safetensors) | **not checked** | **unsupported** — weights are sharded across six safetensors files (ferritin-100.24) |
+//! | `esmc-6b` | Esmc | `EvolutionaryScale/esmc-6b-2024-12` (safetensors) | **not checked** | supported |
 //! | `esm3-sm-open-v1` | Esm3 | `EvolutionaryScale/esm3-sm-open-v1` (pth) | **not checked** | supported |
 //! | `esm3-structure-encoder-v0` | Esm3 | `EvolutionaryScale/esm3-sm-open-v1` (pth) | **not checked** | **unsupported** — the ported VQ-VAE encoder is a different shape from the released checkpoint (ferritin-100.22) |
 //! | `esmfold2-fast` | Esmfold2 | `biohub/ESMFold2-Fast` (safetensors) | **not checked** | **unsupported** — the ported architecture does not match the released checkpoint (ferritin-100.17) |

--- a/crates/ferritin-plms/src/loader.rs
+++ b/crates/ferritin-plms/src/loader.rs
@@ -245,9 +245,95 @@ impl WeightSource {
     ///
     /// This is the only place in the crate that performs the safetensors mmap,
     /// and the only place the dtype is applied.
+    /// Suffix marking a HuggingFace shard index rather than a weight file.
+    const SHARD_INDEX_SUFFIX: &'static str = ".index.json";
+
     pub fn var_builder(&self, filename: &str, opts: &LoadOptions) -> Result<VarBuilder<'static>> {
+        if filename.ends_with(Self::SHARD_INDEX_SUFFIX) {
+            return self.var_builder_sharded(filename, opts);
+        }
         let path = self.fetch(filename)?;
         self.var_builder_from_path(&path, opts)
+    }
+
+    /// Build a [`VarBuilder`] over a checkpoint split across several
+    /// safetensors shards.
+    ///
+    /// Large checkpoints ship as `model-0000N-of-0000M.safetensors` plus a
+    /// `model.safetensors.index.json` whose `weight_map` says which shard holds
+    /// each tensor. candle's `from_mmaped_safetensors` already takes a slice of
+    /// paths, so all this does is read the index, fetch every shard it names,
+    /// and hand candle the lot (ferritin-100.24).
+    ///
+    /// Shard order does not matter — candle indexes by tensor name — but the
+    /// shards are deduplicated and sorted so the mmap set is deterministic.
+    pub fn var_builder_sharded(
+        &self,
+        index_filename: &str,
+        opts: &LoadOptions,
+    ) -> Result<VarBuilder<'static>> {
+        opts.validate()?;
+        if !matches!(self.format, Format::Safetensors) {
+            bail!(
+                "{}: sharded loading is only defined for safetensors, but {index_filename} \
+                 was requested for a {:?} source",
+                self.repo_id,
+                self.format
+            );
+        }
+
+        let index_path = self.fetch(index_filename)?;
+        let shards = Self::shard_names(&index_path)?;
+
+        let paths = shards
+            .iter()
+            .map(|shard| self.fetch(shard))
+            .collect::<Result<Vec<_>>>()?;
+
+        // SAFETY: as in var_builder_from_path — mmap of files we just
+        // materialised in the HF cache.
+        let vb = unsafe {
+            VarBuilder::from_mmaped_safetensors(&paths, opts.dtype, &opts.device).with_context(
+                || {
+                    format!(
+                        "failed to mmap {} shards from {}",
+                        paths.len(),
+                        self.repo_id
+                    )
+                },
+            )?
+        };
+        Ok(vb)
+    }
+
+    /// Read a shard index and return the shard filenames it references, sorted
+    /// and deduplicated.
+    fn shard_names(index_path: &Path) -> Result<Vec<String>> {
+        #[derive(serde::Deserialize)]
+        struct ShardIndex {
+            weight_map: std::collections::BTreeMap<String, String>,
+        }
+
+        let raw = std::fs::read_to_string(index_path)
+            .with_context(|| format!("failed to read shard index {}", index_path.display()))?;
+        let index: ShardIndex = serde_json::from_str(&raw).with_context(|| {
+            format!(
+                "shard index {} is not a HuggingFace weight_map",
+                index_path.display()
+            )
+        })?;
+
+        if index.weight_map.is_empty() {
+            bail!(
+                "shard index {} has an empty weight_map",
+                index_path.display()
+            );
+        }
+
+        let mut shards: Vec<String> = index.weight_map.into_values().collect();
+        shards.sort_unstable();
+        shards.dedup();
+        Ok(shards)
     }
 
     /// Build a [`VarBuilder`] over an already-downloaded (or local) file.
@@ -384,6 +470,134 @@ mod tests {
         assert!(
             CACHE_LOCK_RETRY_PAUSE < CACHE_LOCK_RETRY_BUDGET,
             "pause must be shorter than the budget or only one retry happens"
+        );
+    }
+
+    /// A shard index resolves to its unique shard files, sorted and deduped.
+    ///
+    /// The 6-shard ESMC-6B index maps 808 tensors onto 6 files, so the
+    /// many-tensors-to-one-shard collapse is the case that matters.
+    #[test]
+    fn test_shard_names_dedupes_and_sorts() {
+        let dir = std::env::temp_dir().join("ferritin-shard-index-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("model.safetensors.index.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "metadata": {"total_size": 123},
+                "weight_map": {
+                    "b.weight": "model-00002-of-00002.safetensors",
+                    "a.weight": "model-00001-of-00002.safetensors",
+                    "a.bias":   "model-00001-of-00002.safetensors"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let shards = WeightSource::shard_names(&path).unwrap();
+        assert_eq!(
+            shards,
+            [
+                "model-00001-of-00002.safetensors",
+                "model-00002-of-00002.safetensors"
+            ],
+            "three tensors across two shards should yield two unique files"
+        );
+    }
+
+    #[test]
+    fn test_shard_names_rejects_a_non_index() {
+        let dir = std::env::temp_dir().join("ferritin-shard-index-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("not-an-index.json");
+        std::fs::write(&path, r#"{"hello": "world"}"#).unwrap();
+
+        let err = WeightSource::shard_names(&path)
+            .map(|_| ())
+            .expect_err("a file without weight_map is not a shard index");
+        assert!(
+            err.to_string().contains("weight_map"),
+            "error should say what was expected; got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_shard_names_rejects_an_empty_weight_map() {
+        let dir = std::env::temp_dir().join("ferritin-shard-index-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("empty-index.json");
+        std::fs::write(&path, r#"{"weight_map": {}}"#).unwrap();
+
+        let err = WeightSource::shard_names(&path)
+            .map(|_| ())
+            .expect_err("an empty weight_map names no shards");
+        assert!(err.to_string().contains("empty weight_map"));
+    }
+
+    /// candle resolves tensors across several mmapped shards.
+    ///
+    /// This is the mechanism ESMC-6B needs, exercised on real safetensors
+    /// files rather than assumed. The 6B checkpoint itself cannot be loaded
+    /// here — it is ~24 GB at F32 and ~12 GB at F16 — so this stands in for
+    /// the multi-file part of it (ferritin-100.24).
+    #[test]
+    fn test_var_builder_resolves_tensors_across_shards() {
+        use candle_core::Tensor;
+        use std::collections::HashMap;
+
+        let dir = std::env::temp_dir().join("ferritin-shard-vb-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let device = Device::Cpu;
+
+        let shard_a = dir.join("model-00001-of-00002.safetensors");
+        let shard_b = dir.join("model-00002-of-00002.safetensors");
+
+        let mut a = HashMap::new();
+        a.insert(
+            "block.0.weight".to_string(),
+            Tensor::zeros((2, 3), DType::F32, &device).unwrap(),
+        );
+        candle_core::safetensors::save(&a, &shard_a).unwrap();
+
+        let mut b = HashMap::new();
+        b.insert(
+            "block.1.weight".to_string(),
+            Tensor::ones((4, 5), DType::F32, &device).unwrap(),
+        );
+        candle_core::safetensors::save(&b, &shard_b).unwrap();
+
+        // SAFETY: files this test just wrote and does not mutate.
+        let vb = unsafe {
+            VarBuilder::from_mmaped_safetensors(&[shard_a, shard_b], DType::F32, &device).unwrap()
+        };
+
+        assert!(
+            vb.contains_tensor("block.0.weight"),
+            "a tensor from the first shard should resolve"
+        );
+        assert!(
+            vb.contains_tensor("block.1.weight"),
+            "a tensor from the second shard should resolve"
+        );
+        assert_eq!(vb.get((2, 3), "block.0.weight").unwrap().dims(), &[2, 3]);
+        assert_eq!(vb.get((4, 5), "block.1.weight").unwrap().dims(), &[4, 5]);
+    }
+
+    /// A `.pth` source cannot be sharded this way, and says so rather than
+    /// producing a confusing mmap failure.
+    #[test]
+    fn test_sharded_loading_is_refused_for_pth() {
+        let err = WeightSource::pth("owner/name", None)
+            .var_builder_sharded(
+                "model.safetensors.index.json",
+                &LoadOptions::new(Device::Cpu),
+            )
+            .map(|_| ())
+            .expect_err("pth sources cannot be sharded");
+        assert!(
+            err.to_string().contains("only defined for safetensors"),
+            "got: {err}"
         );
     }
 

--- a/crates/ferritin-plms/src/registry.rs
+++ b/crates/ferritin-plms/src/registry.rs
@@ -353,8 +353,9 @@ pub const REGISTRY: &[ModelCard] = &[
         id: "esmc-6b",
         family: Family::Esmc,
         source: WeightSource::safetensors("EvolutionaryScale/esmc-6b-2024-12"),
-        // Sharded across six files; see `unsupported`.
-        file: "model-00001-of-00006.safetensors",
+        // Sharded across six files; the loader follows this index
+        // (ferritin-100.24).
+        file: "model.safetensors.index.json",
         tokenizer: TokenizerSpec::BuiltinVocab("esmc::tokenizer::EsmSequenceTokenizer"),
         specials: SpecialTokenLayout::BOS_EOS,
         metadata: ModelMetadata {
@@ -365,11 +366,7 @@ pub const REGISTRY: &[ModelCard] = &[
         },
         approx_bytes_f32: 24 * GB,
         parity: ParityStatus::Unverified,
-        unsupported: Some(
-            "weights are sharded across six safetensors files, which the loader cannot yet \
-             follow, and the head is named lm_head at the top level rather than sequence_head \
-             (ferritin-100.24)",
-        ),
+        unsupported: None,
     },
     // ── ESM3 ─────────────────────────────────────────────────────────────────
     ModelCard {
@@ -649,10 +646,7 @@ mod tests {
             .map(|c| c.id)
             .collect();
         unsupported.sort_unstable();
-        assert_eq!(
-            unsupported,
-            ["esm3-structure-encoder-v0", "esmc-6b", "esmfold2-fast"]
-        );
+        assert_eq!(unsupported, ["esm3-structure-encoder-v0", "esmfold2-fast"]);
 
         for card in REGISTRY.iter().filter(|c| !c.is_loadable()) {
             let reason = card.unsupported.unwrap();

--- a/crates/ferritin-plms/tests/test_plm_esmc.rs
+++ b/crates/ferritin-plms/tests/test_plm_esmc.rs
@@ -253,6 +253,11 @@ fn test_esmc_model_info_targets_evolutionaryscale() {
             "EvolutionaryScale/esmc-600m-2024-12",
             "data/weights/esmc_600m_2024_12_v0.pth",
         ),
+        (
+            ESMCModels::ESMC6B,
+            "EvolutionaryScale/esmc-6b-2024-12",
+            "model.safetensors.index.json",
+        ),
     ] {
         let (source, filename, _config) =
             variant.model_info().expect("variant should be supported");
@@ -261,23 +266,71 @@ fn test_esmc_model_info_targets_evolutionaryscale() {
     }
 }
 
-/// ESMC6B refuses with the specific reason rather than failing partway through
-/// a six-shard download (ferritin-100.24).
+/// Every tensor path the ESMC loader will request exists in the real ESMC-6B
+/// shard index (ferritin-100.24).
+///
+/// The 6B model itself cannot be loaded on a modest machine — ~24 GB at F32,
+/// ~12 GB at F16 — so this checks the part that can be checked cheaply: that
+/// the names the loader asks for are the names the checkpoint has. It fetches
+/// only `model.safetensors.index.json` (~60 KB), not the 12 GB of shards.
+///
+/// Catches the two things that made 6B special: the backbone nests under
+/// `esmc.` while the head sits at the top level as `lm_head`, and the weights
+/// are split across six shards.
 #[test]
-fn test_esmc_6b_refuses_with_reason() {
+#[ignore = "fetches the ESMC-6B shard index (~60 KB, no weights)"]
+fn test_esmc_6b_index_contains_every_path_the_loader_requests() -> Result<()> {
     use ferritin_plms::esmc::pretrained::ESMCModels;
+    use std::collections::BTreeMap;
 
-    let err = ESMCModels::ESMC6B
-        .model_info()
-        .map(|_| ())
-        .expect_err("ESMC6B is not supported yet");
-    let msg = err.to_string();
+    let (source, index_file, config) = ESMCModels::ESMC6B.model_info()?;
     assert!(
-        msg.contains("shards"),
-        "error should name the sharding problem; got: {msg}"
+        index_file.ends_with(".index.json"),
+        "6B should be loaded through its shard index; got {index_file}"
     );
+
+    let path = source.fetch(index_file)?;
+    let raw = std::fs::read_to_string(&path)?;
+    let index: serde_json::Value = serde_json::from_str(&raw)?;
+    let weight_map: BTreeMap<String, String> = serde_json::from_value(index["weight_map"].clone())?;
+
+    assert_eq!(
+        weight_map
+            .values()
+            .collect::<std::collections::BTreeSet<_>>()
+            .len(),
+        6,
+        "ESMC-6B is published as six shards"
+    );
+
+    let mut expected = vec![
+        // Backbone, under the "esmc." prefix optional_prefix descends into.
+        "esmc.embed.weight".to_string(),
+        "esmc.transformer.norm.weight".to_string(),
+        // Head, at the TOP level and named lm_head — not sequence_head.
+        "lm_head.0.weight".to_string(),
+        "lm_head.2.weight".to_string(),
+        "lm_head.3.weight".to_string(),
+    ];
+    for layer in 0..config.n_layers {
+        expected.push(format!(
+            "esmc.transformer.blocks.{layer}.attn.out_proj.weight"
+        ));
+        expected.push(format!("esmc.transformer.blocks.{layer}.ffn.1.weight"));
+    }
+
+    for name in &expected {
+        assert!(
+            weight_map.contains_key(name),
+            "the loader will request {name}, which the 6B index does not contain"
+        );
+    }
+
+    // And the head is genuinely NOT where the flat checkpoints keep it.
     assert!(
-        msg.contains("ESMC300M and ESMC600M work"),
-        "error should say which variants do work; got: {msg}"
+        !weight_map.contains_key("esmc.sequence_head.0.weight")
+            && !weight_map.contains_key("sequence_head.0.weight"),
+        "6B should have no sequence_head; that is why load_with_head exists"
     );
+    Ok(())
 }

--- a/crates/ferritin-plms/tests/test_registry_conformance.rs
+++ b/crates/ferritin-plms/tests/test_registry_conformance.rs
@@ -150,9 +150,48 @@ fn test_loadable_embedding_models_are_covered() {
             "esm3-sm-open-v1",
             "esmc-300m",
             "esmc-600m",
+            "esmc-6b",
         ],
         "the set of loadable embedding models changed; add or remove a \
          conformance test to match"
+    );
+}
+
+/// Which loadable models have no conformance test above, and why.
+///
+/// Kept as an explicit list rather than a silent gap. Every entry here is a
+/// model whose card is unchecked against real weights, so a wrong dimension
+/// would not be caught.
+#[test]
+fn test_uncovered_loadable_models_are_accounted_for() {
+    let covered = ["esm2-t6-8m", "amplify-120m", "esmc-300m"];
+
+    let uncovered: Vec<&str> = REGISTRY
+        .iter()
+        .filter(|c| c.is_loadable() && c.is_embedding_model())
+        .map(|c| c.id)
+        .filter(|id| !covered.contains(id))
+        .collect();
+
+    // The larger ESM2 variants, AMPLIFY-350M, ESMC-600M and ESM3 are simply
+    // big downloads. ESMC-6B is different in kind: at ~24 GB F32 / ~12 GB F16
+    // it cannot be loaded on a modest machine at all, so its card was verified
+    // against the published shard index instead — see
+    // test_esmc_6b_index_contains_every_path_the_loader_requests.
+    assert_eq!(
+        uncovered,
+        [
+            "esm2-t12-35m",
+            "esm2-t30-150m",
+            "esm2-t33-650m",
+            "esm2-t36-3b",
+            "esm2-t48-15b",
+            "amplify-350m",
+            "esmc-600m",
+            "esmc-6b",
+            "esm3-sm-open-v1",
+        ],
+        "a model gained or lost conformance coverage; say which and why"
     );
 }
 


### PR DESCRIPTION
Two things kept ESMC-6B refusing, both plumbing rather than architecture.

**Sharding.** Its 808 tensors are split across six safetensors files while the loader took a single filename. `WeightSource::var_builder` now detects a `.index.json` filename and follows it — reading the `weight_map`, fetching each unique shard, handing candle the set (`from_mmaped_safetensors` already accepts a slice). Shards are deduped and sorted so the mmap set is deterministic. A `.pth` source asking for sharded loading is refused with that reason rather than a confusing mmap failure.

**Head placement.** The 6B head sits at the top level as `lm_head`; 300M/600M keep theirs at `sequence_head`. Crucially the 6B head is **not reachable by descending from the backbone's root** — the backbone is under `esmc.` and the head is *above* it. So `ESMC::load_with_head` takes the head's `VarBuilder` separately, and the runner picks by probing for `lm_head.0.weight`.

## What is and isn't verified

**This machine has 8 GB of RAM.** ESMC-6B needs ~24 GB at F32 or ~12 GB at F16, so **I never loaded the model.** Rather than ship on that basis, the two mechanisms are tested separately against real artifacts:

| mechanism | how it's checked |
|---|---|
| multi-shard resolution | writes two real safetensors files, mmaps both, reads a tensor from each |
| tensor naming | fetches the **real** ESMC-6B shard index (~60 KB, *not* the 12 GB of weights) and asserts every path the loader will request is present — all 80 blocks — and that no `sequence_head` exists |

That last check is the one I'd point at: it confirms against the published checkpoint both that the names are right and that `load_with_head` is necessary rather than speculative.

What remains unexercised is the 12 GB download and the load itself. ESMC-6B's card stays `ParityStatus::Unverified`, declares its 24 GB footprint, and `test_uncovered_loadable_models_are_accounted_for` records that it has no conformance test and why — an explicit list rather than a silent gap.

## An aside

The drift test from #193 earned its keep immediately: flipping `esmc-6b` to supported failed `test_lib_rs_support_matrix_is_current` until I regenerated the embedded matrix. Working as intended, one PR after being written.

```
cargo test -p ferritin-plms --test test_plm_esmc -- --include-ignored   # 9 passed
cargo clippy --workspace --all-targets -- -D warnings                   # clean
cargo test --workspace                                                  # pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
