### PR TITLE
Conformance suite parameterized over the registry (ferritin-goh.2)

### DIFF
--- a/crates/ferritin-plms/tests/test_conformance.rs
+++ b/crates/ferritin-plms/tests/test_conformance.rs
@@ -1,0 +1,336 @@
+//! One conformance suite every registered model must pass (ferritin-goh.2).
+//!
+//! Adding a model used to mean writing a bespoke test file, and what got
+//! asserted varied by author. This suite is parameterized over
+//! [`REGISTRY`][ferritin_plms::registry::REGISTRY], so a new model inherits
+//! coverage by being registered rather than by someone remembering to write it.
+//!
+//! # The checks
+//!
+//! | # | check | catches |
+//! |---|---|---|
+//! | 1 | loads, and the loaded dims equal `card.metadata` | a card that lies about the model |
+//! | 3 | `embed_residues(seq).dim(1) == seq.len()` | special-token misalignment (ferritin-100.7) |
+//! | 4 | the same input twice is bitwise identical | run-to-run variance |
+//! | 6 | no NaN or Inf anywhere in the embedding | a bad weight-key mapping |
+//! | 7 | a `Verified` card's fixture really exists and matches the model | a registry parity claim that nothing backs |
+//! | 8 | every family is populated and every card has a generator script | the registry drifting ahead of the fixtures |
+//!
+//! Checks 4 and 6 are the cheap ones that matter most. A transposed weight
+//! matrix or a wrong VarBuilder prefix usually produces *correctly shaped*
+//! garbage, which shape assertions sail straight past — NaN and run-to-run
+//! variance surface it long before a human notices the embeddings are
+//! meaningless. Check 3 is the one that must never be relaxed: it is the
+//! contract downstream code depends on.
+//!
+//! # Not yet implemented
+//!
+//! - **Check 2, tokenizer round-trip.** `PlmRunner` exposes no `encode`/
+//!   `decode`, and the four families tokenize through different types. It
+//!   needs the trait widened the way ferritin-100.7 widened it for embeddings.
+//! - **Check 5, batch equivalence.** There is no `embed_batch`; every runner is
+//!   hardcoded to batch size 1. Blocked on ferritin-100.12.
+//!
+//! # Tiering
+//!
+//! Execution is tiered by `card.approx_bytes_f32` rather than by `#[ignore]`,
+//! so the tier follows the model rather than a hand-maintained attribute.
+//!
+//! | tier | size | runs |
+//! |---|---|---|
+//! | PR | ≤ [`PR_TIER_MAX_BYTES`] | every PR |
+//! | nightly | ≤ [`LOADABLE_IN_CI_MAX_BYTES`] | nightly, with `FERRITIN_HF_TESTS=1` |
+//! | too large | above that | nowhere — see below |
+//!
+//! The third tier is not in the issue's design and was added because the
+//! two-tier version does not survive contact with a CI runner: `esm2-t48-15b`
+//! is ~60 GB at F32 and `esmc-6b` ~24 GB, against 16 GB on a standard
+//! GitHub-hosted runner. A nightly that tries to load those does not report a
+//! model problem, it reports an OOM — and an unfixable red nightly is what
+//! ferritin-100.20 was about. So they are excluded by size, with the excluded
+//! set pinned by a test so the exclusion stays deliberate.
+
+mod support;
+
+use anyhow::{Result, bail};
+use candle_core::DType;
+use ferritin_plms::plm_runner::PlmRunner;
+use ferritin_plms::registry::{ModelCard, ParityStatus, REGISTRY};
+use ferritin_plms::{
+    AmplifyModels, AmplifyRunner, ESM2Models, ESM2Runner, ESM3Models, ESM3Runner, ESMCModels,
+    ESMCRunner, device,
+};
+use support::parity::{ParityFixture, fixture_path, hf_tests_enabled};
+
+/// Models at or below this size run on every PR; larger ones are nightly-only.
+///
+/// 100 MB is chosen so the PR tier is a genuine smoke test that costs seconds,
+/// not a weights download that dominates the run.
+const PR_TIER_MAX_BYTES: u64 = 100 * 1024 * 1024;
+
+/// Above this, no CI runner can load the model, so nothing tries.
+///
+/// A standard GitHub-hosted runner has 16 GB; 8 GB leaves room for the OS, the
+/// test process, and the fact that `approx_bytes_f32` is approximate. Loading
+/// at F16 roughly halves the requirement, so raising this is reasonable once a
+/// tier actually loads reduced-precision — see ferritin-100.9 for what that
+/// costs numerically.
+const LOADABLE_IN_CI_MAX_BYTES: u64 = 8 * 1024 * 1024 * 1024;
+
+/// Ubiquitin (76 aa) — long enough to exercise attention, short enough to be fast.
+const SEQ: &str = "MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG";
+
+/// Build the runner for a registry id.
+///
+/// A `match` rather than anything clever: the point of the registry is that
+/// adding a model is a reviewed act, and a model that has no arm here fails
+/// loudly rather than being silently skipped.
+fn runner_for(card: &ModelCard) -> Result<Box<dyn PlmRunner>> {
+    let dev = device(false)?;
+    Ok(match card.id {
+        "esm2-t6-8m" => Box::new(ESM2Runner::from_pretrained(ESM2Models::T6_8M, dev)?),
+        "esm2-t12-35m" => Box::new(ESM2Runner::from_pretrained(ESM2Models::T12_35M, dev)?),
+        "esm2-t30-150m" => Box::new(ESM2Runner::from_pretrained(ESM2Models::T30_150M, dev)?),
+        "esm2-t33-650m" => Box::new(ESM2Runner::from_pretrained(ESM2Models::T33_650M, dev)?),
+        "esm2-t36-3b" => Box::new(ESM2Runner::from_pretrained(ESM2Models::T36_3B, dev)?),
+        "esm2-t48-15b" => Box::new(ESM2Runner::from_pretrained(ESM2Models::T48_15B, dev)?),
+        "amplify-120m" => Box::new(AmplifyRunner::from_pretrained(AmplifyModels::AMP120M, dev)?),
+        "amplify-350m" => Box::new(AmplifyRunner::from_pretrained(AmplifyModels::AMP350M, dev)?),
+        "esmc-300m" => Box::new(ESMCRunner::from_pretrained(ESMCModels::ESMC300M, dev)?),
+        "esmc-600m" => Box::new(ESMCRunner::from_pretrained(ESMCModels::ESMC600M, dev)?),
+        "esmc-6b" => Box::new(ESMCRunner::from_pretrained(ESMCModels::ESMC6B, dev)?),
+        "esm3-sm-open-v1" => Box::new(ESM3Runner::from_pretrained(ESM3Models::SmOpen, dev)?),
+        other => bail!(
+            "{other} is a loadable embedding model with no arm in runner_for; \
+             add one so it inherits conformance coverage"
+        ),
+    })
+}
+
+/// Run every implemented check against one model.
+fn conform(card: &ModelCard) -> Result<()> {
+    let id = card.id;
+    let runner = runner_for(card)?;
+
+    // ── 1. loads, and the loaded dims equal the card ──
+    let loaded = runner.metadata();
+    assert_eq!(loaded.d_model, card.metadata.d_model, "{id}: d_model");
+    assert_eq!(loaded.n_layers, card.metadata.n_layers, "{id}: n_layers");
+    assert_eq!(loaded.vocab_size, card.metadata.vocab_size, "{id}: vocab");
+    assert_eq!(
+        loaded.max_positions, card.metadata.max_positions,
+        "{id}: max_positions"
+    );
+    assert_eq!(
+        runner.special_tokens(),
+        card.specials,
+        "{id}: special-token layout"
+    );
+
+    // ── 3. residue alignment — the contract downstream code depends on ──
+    let residues = runner.embed_residues(SEQ)?;
+    assert_eq!(
+        residues.dim(1)?,
+        SEQ.len(),
+        "{id}: embed_residues must return exactly one row per residue"
+    );
+    assert_eq!(residues.dim(2)?, card.metadata.d_model, "{id}: width");
+
+    // The raw form keeps the special tokens, per the declared layout.
+    let raw = runner.embed(SEQ)?;
+    assert_eq!(
+        raw.dim(1)?,
+        SEQ.len() + card.specials.total(),
+        "{id}: embed must keep the special-token rows"
+    );
+
+    // ── 6. finite outputs ──
+    let values = residues
+        .to_dtype(DType::F32)?
+        .flatten_all()?
+        .to_vec1::<f32>()?;
+    if let Some((i, bad)) = values.iter().enumerate().find(|(_, v)| !v.is_finite()) {
+        bail!("{id}: embedding value at flat index {i} is {bad}, not finite");
+    }
+    // All-zeros is not an error but is never right for a real checkpoint, and
+    // is what a silently-unloaded model produces.
+    assert!(
+        values.iter().any(|v| *v != 0.0),
+        "{id}: every embedding value is zero, which no loaded model produces"
+    );
+
+    // ── 4. determinism ──
+    let again = runner
+        .embed_residues(SEQ)?
+        .to_dtype(DType::F32)?
+        .flatten_all()?
+        .to_vec1::<f32>()?;
+    assert_eq!(
+        values, again,
+        "{id}: two identical inputs produced different outputs"
+    );
+
+    // ── 7. parity claim is backed by a real fixture ──
+    if let ParityStatus::Verified { fixture } = card.parity {
+        let path = fixture_path(fixture);
+        assert!(
+            path.exists(),
+            "{id}: card claims parity against {fixture}, which is not committed"
+        );
+        let loaded_fixture = ParityFixture::load(fixture, &device(false)?)?;
+        assert_eq!(loaded_fixture.name(), fixture);
+        // The full numerical comparison lives in the per-model parity tests;
+        // this only enforces that the registry's claim is not empty.
+    }
+
+    println!("{id}: conformance OK");
+    Ok(())
+}
+
+/// Models small enough that some tier will actually load them.
+fn testable() -> impl Iterator<Item = &'static ModelCard> {
+    REGISTRY.iter().filter(|c| {
+        c.is_loadable() && c.is_embedding_model() && c.approx_bytes_f32 <= LOADABLE_IN_CI_MAX_BYTES
+    })
+}
+
+fn cards_in_tier(nightly: bool) -> impl Iterator<Item = &'static ModelCard> {
+    testable().filter(move |c| (c.approx_bytes_f32 > PR_TIER_MAX_BYTES) == nightly)
+}
+
+/// Models no CI runner can load, and why each is excluded.
+fn too_large_for_ci() -> impl Iterator<Item = &'static ModelCard> {
+    REGISTRY.iter().filter(|c| {
+        c.is_loadable() && c.is_embedding_model() && c.approx_bytes_f32 > LOADABLE_IN_CI_MAX_BYTES
+    })
+}
+
+/// Small models run on every PR.
+#[test]
+fn test_conformance_pr_tier() -> Result<()> {
+    let mut ran = 0;
+    for card in cards_in_tier(false) {
+        conform(card)?;
+        ran += 1;
+    }
+    assert!(
+        ran > 0,
+        "the PR tier is empty; every model is now above {PR_TIER_MAX_BYTES} bytes, \
+         which means no conformance coverage runs on PRs at all"
+    );
+    Ok(())
+}
+
+/// Everything larger runs in the nightly job.
+#[test]
+fn test_conformance_nightly_tier() -> Result<()> {
+    if !hf_tests_enabled() {
+        let ids: Vec<&str> = cards_in_tier(true).map(|c| c.id).collect();
+        eprintln!(
+            "skipping the nightly conformance tier ({} models: {}); \
+             set FERRITIN_HF_TESTS=1 to run",
+            ids.len(),
+            ids.join(", ")
+        );
+        return Ok(());
+    }
+    for card in cards_in_tier(true) {
+        conform(card)?;
+    }
+    Ok(())
+}
+
+// ── Check 8: registry completeness ────────────────────────────────────────────
+
+/// Every loadable embedding model has an arm in `runner_for`.
+///
+/// Checked without loading anything, so a model added to the registry fails
+/// here immediately rather than only when someone runs the nightly.
+#[test]
+fn test_every_loadable_model_can_be_constructed() {
+    const KNOWN: &[&str] = &[
+        "esm2-t6-8m",
+        "esm2-t12-35m",
+        "esm2-t30-150m",
+        "esm2-t33-650m",
+        "esm2-t36-3b",
+        "esm2-t48-15b",
+        "amplify-120m",
+        "amplify-350m",
+        "esmc-300m",
+        "esmc-600m",
+        "esmc-6b",
+        "esm3-sm-open-v1",
+    ];
+    for card in REGISTRY
+        .iter()
+        .filter(|c| c.is_loadable() && c.is_embedding_model())
+    {
+        assert!(
+            KNOWN.contains(&card.id),
+            "{} has no arm in runner_for, so it would inherit no conformance \
+             coverage; add one",
+            card.id
+        );
+    }
+}
+
+/// Every card names a family that has a fixture-generation script, so a model
+/// can in principle be given parity coverage.
+///
+/// A card with no way to generate a fixture can never move off
+/// `ParityStatus::Unverified`, which would make that status permanent rather
+/// than provisional.
+#[test]
+fn test_every_family_has_a_fixture_generator() {
+    let scripts = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../scripts")
+        .canonicalize()
+        .expect("scripts/ should exist");
+
+    for card in REGISTRY {
+        // ESMFold2 has no generator yet and is unsupported anyway; it would be
+        // dishonest to imply a fixture could be produced for a port that does
+        // not load (ferritin-100.17).
+        if !card.is_loadable() {
+            continue;
+        }
+        let script = scripts.join(format!("generate_{}_fixtures.py", card.family_str()));
+        assert!(
+            script.exists(),
+            "{}: no {} to generate a parity fixture from",
+            card.id,
+            script.display()
+        );
+    }
+}
+
+/// The models excluded for size are exactly the ones that cannot fit.
+///
+/// Pinned so that excluding a model is a deliberate act rather than something
+/// that happens quietly when someone edits `approx_bytes_f32`. Every model
+/// here has NO conformance coverage anywhere.
+#[test]
+fn test_models_too_large_for_ci_are_the_known_set() {
+    let mut excluded: Vec<&str> = too_large_for_ci().map(|c| c.id).collect();
+    excluded.sort_unstable();
+    assert_eq!(
+        excluded,
+        ["esm2-t36-3b", "esm2-t48-15b", "esmc-6b"],
+        "the set of models too large to test in CI changed; that is a \
+         deliberate act, and each one loses all conformance coverage"
+    );
+}
+
+/// The PR tier must stay cheap, or it stops running.
+#[test]
+fn test_pr_tier_is_small() {
+    for card in cards_in_tier(false) {
+        assert!(
+            card.approx_bytes_f32 <= PR_TIER_MAX_BYTES,
+            "{}: {} bytes is above the PR tier ceiling",
+            card.id,
+            card.approx_bytes_f32
+        );
+    }
+}


### PR DESCRIPTION
The second P0 of the `ferritin-goh` epic, unblocked by #192. Adding a model meant writing a bespoke test file, and what got asserted varied by author — `test_plm_esmfold2.rs` checked nine things, `test_plm_esm2.rs` three. This suite is parameterized over `REGISTRY`, so a model inherits coverage by being **registered** rather than by someone remembering to write it.

## Six of eight checks

Card dims match the loaded model · `embed_residues` returns exactly one row per residue · `embed` keeps the special-token rows · outputs are finite and not all-zero · the same input twice is bitwise identical · a `Verified` parity claim is backed by a fixture that exists.

Checks 4 and 6 are the cheap ones that matter most. A transposed weight matrix or wrong `VarBuilder` prefix produces **correctly-shaped garbage** that shape assertions sail straight past; NaN and run-to-run variance surface it. The all-zero check is there because that's exactly what a silently-unloaded model returns — the ESMFold2 stub path produced precisely that.

**Two checks are blocked, not skipped**, and named in the module docs rather than quietly absent:

- **Check 2** (tokenizer round-trip) — `PlmRunner` has no `encode`/`decode`, and the four families tokenize through different types. Needs the trait widened the way #181 widened it for embeddings.
- **Check 5** (batch equivalence) — there is no `embed_batch`; every runner is hardcoded to batch size 1 (ferritin-100.12).

## The two-tier scheme needed a third tier

The issue says small models run on PRs and "everything larger runs in the nightly." That doesn't survive contact with a runner:

| model | F32 size |
|---|---|
| `esm2-t48-15b` | ~60 GB |
| `esmc-6b` | ~24 GB |
| `esm2-t36-3b` | ~12 GB |

A standard GitHub-hosted runner has **16 GB**. A nightly that tries to load those doesn't report a model problem — it reports an OOM, which the suite can't fix, and which is exactly the permanently-red nightly #183 removed.

So: **≤100 MB** every PR · **≤8 GB** nightly · **above that, nowhere**, with the excluded set pinned by a test so dropping a model's coverage stays deliberate rather than a side effect of editing a size. All three thresholds read `approx_bytes_f32`, so the tier follows the model rather than a hand-maintained `#[ignore]`. The ceiling could roughly double once a tier loads at F16 — #182 records what that costs numerically.

## Verified, not asserted

The PR tier passes, and the nightly tier passes for **all eight models under the ceiling** — esm2 12M/35M/150M/650M, amplify 120M/350M, esmc 300M/600M, esm3-sm-open — in ~17 minutes against real checkpoints:

```
esm2-t12-35m: conformance OK
esm2-t30-150m: conformance OK
esm2-t33-650m: conformance OK
amplify-120m: conformance OK
amplify-350m: conformance OK
esmc-300m: conformance OK
esmc-600m: conformance OK
esm3-sm-open-v1: conformance OK
```

That's the first time ESMC-600M and several ESM2 variants have been **loaded and checked at all** — and it confirms their registry cards against real weights rather than against my reading of a config file.

Note the ~17 minutes is additive to the nightly's current ~33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
