### PR TITLE
SaProt 35M/650M — structure-aware PLM on the ESM-2 module (ferritin-goh.3)

### DIFF
--- a/crates/ferritin-plms/src/esm2/esm2.rs
+++ b/crates/ferritin-plms/src/esm2/esm2.rs
@@ -135,6 +135,36 @@ impl ESM2Config {
         }
     }
 
+    /// SaProt 35M — the ESM-2 architecture over a 446-token structure-aware
+    /// alphabet (ferritin-goh.3).
+    ///
+    /// Only a fallback: the hub config.json parses since ferritin-goh.9, so
+    /// this is used only when that download fails.
+    pub fn saprot_35m() -> Self {
+        Self {
+            num_attention_heads: 20,
+            hidden_size: 480,
+            intermediate_size: 1920,
+            num_hidden_layers: 12,
+            vocab_size: 446,
+            mask_token_id: 4,
+            ..Self::base_config()
+        }
+    }
+
+    /// SaProt 650M — same alphabet, ESM-2 650M dimensions.
+    pub fn saprot_650m() -> Self {
+        Self {
+            num_attention_heads: 20,
+            hidden_size: 1280,
+            intermediate_size: 5120,
+            num_hidden_layers: 33,
+            vocab_size: 446,
+            mask_token_id: 4,
+            ..Self::base_config()
+        }
+    }
+
     pub fn t6_8m() -> Self {
         Self {
             num_attention_heads: 20,
@@ -614,7 +644,12 @@ pub struct ESM2 {
     layers: Vec<ESM2Layer>,
     layer_norm_after: LayerNorm,
     lm_head: ESM2LMHead,
-    contact_head: ESM2ContactHead,
+    /// Absent when the checkpoint ships no contact head.
+    ///
+    /// It is only needed by `predict_contacts`, and real checkpoints differ:
+    /// SaProt-35M ships one, SaProt-650M does not (ferritin-goh.3). Loading it
+    /// eagerly made a model that embeds perfectly well fail to load at all.
+    contact_head: Option<ESM2ContactHead>,
 }
 
 impl ESM2 {
@@ -623,7 +658,12 @@ impl ESM2 {
         let layers = (0..config.num_hidden_layers)
             .map(|i| ESM2Layer::load(vb.pp(format!("esm.encoder.layer.{}", i)), &config))
             .collect::<Result<Vec<_>>>()?;
-        let contact_head = ESM2ContactHead::load(vb.pp("esm.contact_head"), &config)?;
+        // Probe rather than assume: see the field's documentation.
+        let contact_head = if vb.contains_tensor("esm.contact_head.regression.weight") {
+            Some(ESM2ContactHead::load(vb.pp("esm.contact_head"), &config)?)
+        } else {
+            None
+        };
         let layer_norm_after = candle_nn::layer_norm(
             config.hidden_size,
             config.layer_norm_eps as f64,
@@ -740,7 +780,14 @@ impl ESM2 {
             let _ = attentions.broadcast_mul(&m1)?.broadcast_mul(&m2)?;
         }
 
-        self.contact_head.forward(tokens, &attentions)
+        let head = self.contact_head.as_ref().ok_or_else(|| {
+            candle_core::Error::Msg(
+                "this checkpoint ships no contact head, so contacts cannot be predicted \
+                 from it (ferritin-goh.3)"
+                    .to_string(),
+            )
+        })?;
+        head.forward(tokens, &attentions)
     }
 }
 

--- a/crates/ferritin-plms/src/esm2/esm2_runner.rs
+++ b/crates/ferritin-plms/src/esm2/esm2_runner.rs
@@ -2,9 +2,10 @@
 //!
 //! Class for loading and running the ESM2 models
 use super::esm2::{ESM2, ESM2Config, ESM2Output};
+use crate::esm2::saprot_tokenizer::SaProtTokenizer;
 use crate::loader::{LoadOptions, WeightSource};
 use crate::plm_runner::{ModelMetadata, PlmRunner, SpecialTokenLayout};
-use crate::registry::{self, ModelCard};
+use crate::registry::{self, ModelCard, TokenizerSpec};
 use crate::types::PseudoProbability;
 use anyhow::{Error as E, Result, anyhow};
 use candle_core::{Device, Tensor};
@@ -43,6 +44,10 @@ pub enum ESM2Models {
     T33_650M,
     T36_3B,
     T48_15B,
+    /// SaProt 35M — ESM-2 architecture, structure-aware alphabet (ferritin-goh.3).
+    SaProt35M,
+    /// SaProt 650M — the variant most people use.
+    SaProt650M,
 }
 impl ESM2Models {
     /// This variant's registry id.
@@ -54,6 +59,8 @@ impl ESM2Models {
             Self::T33_650M => "esm2-t33-650m",
             Self::T36_3B => "esm2-t36-3b",
             Self::T48_15B => "esm2-t48-15b",
+            Self::SaProt35M => "saprot-35m-af2",
+            Self::SaProt650M => "saprot-650m-af2",
         }
     }
 
@@ -77,6 +84,8 @@ impl ESM2Models {
             Self::T33_650M => ESM2Config::t33_650m(),
             Self::T36_3B => ESM2Config::t36_3b(),
             Self::T48_15B => ESM2Config::t48_15b(),
+            Self::SaProt35M => ESM2Config::saprot_35m(),
+            Self::SaProt650M => ESM2Config::saprot_650m(),
         };
         (self.card().source, config)
     }
@@ -88,9 +97,59 @@ impl ESM2Models {
     }
 }
 
+/// Which tokenizer an ESM-2-family model uses.
+///
+/// The architecture is shared, the alphabet is not: stock ESM-2 has a 33-token
+/// `tokenizer.json` compiled into the crate, while SaProt ships a bare 446-line
+/// `vocab.txt` and reads two characters per residue (ferritin-goh.3).
+enum SequenceTokenizer {
+    /// The embedded HuggingFace tokenizer, one byte per residue.
+    Esm(Box<Tokenizer>),
+    /// SaProt's (amino acid, 3Di) product alphabet, two bytes per residue.
+    SaProt(SaProtTokenizer),
+}
+
+impl SequenceTokenizer {
+    fn token_to_id(&self, token: &str) -> Option<u32> {
+        match self {
+            Self::Esm(t) => t.token_to_id(token),
+            Self::SaProt(t) => t.token_to_id(token),
+        }
+    }
+
+    fn encode(&self, sequence: &str) -> Result<Vec<u32>> {
+        Ok(match self {
+            Self::Esm(t) => t
+                .encode(sequence.to_string(), false)
+                .map_err(E::msg)?
+                .get_ids()
+                .to_vec(),
+            Self::SaProt(t) => t.encode(sequence),
+        })
+    }
+
+    fn residue_count(&self, sequence: &str) -> usize {
+        match self {
+            Self::Esm(_) => sequence.len(),
+            Self::SaProt(t) => t.residue_count(sequence),
+        }
+    }
+
+    /// Decode ids back to a sequence, dropping special tokens.
+    fn decode(&self, ids: &[u32]) -> Result<String> {
+        Ok(match self {
+            Self::Esm(t) => t
+                .decode(ids, true)
+                .map_err(|e| anyhow!("Failed to decode tokens: {e}"))?
+                .replace(' ', ""),
+            Self::SaProt(t) => t.decode(ids),
+        })
+    }
+}
+
 pub struct ESM2Runner {
     model: ESM2,
-    tokenizer: Tokenizer,
+    tokenizer: SequenceTokenizer,
     /// Retained so `PlmRunner::metadata` can report dimensions without
     /// hardcoding them per variant.
     config: ESM2Config,
@@ -126,9 +185,20 @@ impl ESM2Runner {
     pub fn from_pretrained_with(modeltype: ESM2Models, opts: &LoadOptions) -> Result<ESM2Runner> {
         let (source, fallback_config) = modeltype.model_info();
         let config = Self::resolve_config(&source, fallback_config)?;
-        let vb = source.var_builder("model.safetensors", opts)?;
+        let card = modeltype.card();
+        let vb = source.var_builder(card.file, opts)?;
         let model = ESM2::load(vb, config.clone())?;
-        let tokenizer = ESM2::load_tokenizer()?;
+
+        // The alphabet follows the card, not the family: SaProt reuses this
+        // architecture with a 446-token vocab.txt (ferritin-goh.3).
+        let tokenizer = match card.tokenizer {
+            TokenizerSpec::HfVocabTxt => {
+                let path = source.fetch("vocab.txt")?;
+                let contents = std::fs::read_to_string(path)?;
+                SequenceTokenizer::SaProt(SaProtTokenizer::from_vocab_txt(&contents)?)
+            }
+            _ => SequenceTokenizer::Esm(Box::new(ESM2::load_tokenizer()?)),
+        };
         Ok(ESM2Runner {
             model,
             tokenizer,
@@ -189,13 +259,10 @@ impl ESM2Runner {
             .tokenizer
             .token_to_id("<eos>")
             .ok_or_else(|| anyhow!("ESM2 tokenizer missing <eos> token"))?;
-        let inner = self
-            .tokenizer
-            .encode(sequence.to_string(), false)
-            .map_err(E::msg)?;
-        let mut ids = Vec::with_capacity(inner.get_ids().len() + 2);
+        let inner = self.tokenizer.encode(sequence)?;
+        let mut ids = Vec::with_capacity(inner.len() + 2);
         ids.push(bos);
-        ids.extend_from_slice(inner.get_ids());
+        ids.extend_from_slice(&inner);
         ids.push(eos);
         Ok(ids)
     }
@@ -231,12 +298,7 @@ impl ESM2Runner {
             predicted_token_ids
         };
         let token_ids: Vec<u32> = predicted_token_ids.to_vec1::<u32>()?;
-        let decoded_sequence = self
-            .tokenizer
-            .decode(&token_ids, true) // set skip_special_tokens to true
-            .map_err(|e| anyhow!("Failed to decode tokens: {}", e))?
-            .replace(" ", "");
-        Ok(decoded_sequence)
+        self.tokenizer.decode(&token_ids)
     }
 
     /// Run ESM2 and return per-residue pseudo-probabilities for the 20 standard amino acids.
@@ -301,6 +363,11 @@ impl PlmRunner for ESM2Runner {
 
     fn device(&self) -> &Device {
         self.model.get_device()
+    }
+
+    /// SaProt reads two characters per residue; stock ESM-2 reads one.
+    fn residue_count(&self, sequence: &str) -> usize {
+        self.tokenizer.residue_count(sequence)
     }
 
     /// Masked-LM logits `(1, L + 2, vocab_size)`.

--- a/crates/ferritin-plms/src/esm2/mod.rs
+++ b/crates/ferritin-plms/src/esm2/mod.rs
@@ -17,3 +17,4 @@
 
 pub mod esm2;
 pub mod esm2_runner;
+pub mod saprot_tokenizer;

--- a/crates/ferritin-plms/src/esm2/saprot_tokenizer.rs
+++ b/crates/ferritin-plms/src/esm2/saprot_tokenizer.rs
@@ -1,0 +1,209 @@
+//! SaProt's structure-aware tokenizer (ferritin-goh.3).
+//!
+//! SaProt is the ESM-2 architecture with a different alphabet. Each residue is
+//! an (amino acid, 3Di structural state) pair over a 20×20 product alphabet —
+//! `"Ma"`, `"Ld"`, `"Kp"` — so a sequence is read two characters at a time and
+//! `"MdAaLp"` is **three** residues, not six.
+//!
+//! # Why not `tokenizers::Tokenizer`
+//!
+//! SaProt's repo ships no `tokenizer.json`. It has a bare `vocab.txt`: 446
+//! lines, one token per line, the line number being the id. Reconstructing an
+//! HF tokenizer from that would mean assembling a `WordLevel` model plus a
+//! two-character `Split` pre-tokenizer to reproduce behaviour that is, written
+//! directly, a lookup table and `chunks(2)`.
+//!
+//! # Vocabulary layout
+//!
+//! ```text
+//! 0  <cls>
+//! 1  <pad>
+//! 2  <eos>
+//! 3  <unk>
+//! 4  <mask>
+//! 5+ Ap, Ay, An, ...   (amino acid, 3Di state) pairs
+//! ```
+//!
+//! Those ids match `config.json`'s `pad_token_id: 1` and `mask_token_id: 4`,
+//! which is the cross-check that the file is being read as intended.
+
+use anyhow::{Result, bail};
+use std::collections::HashMap;
+
+/// Characters per residue in SaProt's product alphabet.
+pub const CHARS_PER_RESIDUE: usize = 2;
+
+/// A tokenizer built from SaProt's `vocab.txt`.
+#[derive(Debug, Clone)]
+pub struct SaProtTokenizer {
+    ids: HashMap<String, u32>,
+    vocab: Vec<String>,
+}
+
+impl SaProtTokenizer {
+    /// Parse a `vocab.txt`: one token per line, line number is the id.
+    ///
+    /// Rejects a file whose special tokens are absent or misplaced, since the
+    /// ids are load-bearing — `<cls>` and `<eos>` wrap every sequence, and a
+    /// silently-wrong `<unk>` would turn unknown residues into a real amino
+    /// acid rather than an unknown.
+    pub fn from_vocab_txt(contents: &str) -> Result<Self> {
+        let vocab: Vec<String> = contents
+            .lines()
+            .map(|l| l.trim_end_matches('\r').to_string())
+            .filter(|l| !l.is_empty())
+            .collect();
+
+        if vocab.is_empty() {
+            bail!("SaProt vocab.txt is empty");
+        }
+
+        let ids: HashMap<String, u32> = vocab
+            .iter()
+            .enumerate()
+            .map(|(i, t)| (t.clone(), i as u32))
+            .collect();
+
+        for (expected_id, token) in [(0u32, "<cls>"), (1, "<pad>"), (2, "<eos>"), (3, "<unk>")] {
+            match ids.get(token) {
+                Some(&id) if id == expected_id => {}
+                Some(&id) => bail!(
+                    "SaProt vocab.txt has {token} at id {id}, expected {expected_id}; \
+                     the special-token ids are load-bearing"
+                ),
+                None => bail!("SaProt vocab.txt is missing {token}"),
+            }
+        }
+
+        Ok(Self { ids, vocab })
+    }
+
+    /// Number of tokens in the vocabulary.
+    pub fn len(&self) -> usize {
+        self.vocab.len()
+    }
+
+    /// Whether the vocabulary is empty. Never true for a valid vocab.
+    pub fn is_empty(&self) -> bool {
+        self.vocab.is_empty()
+    }
+
+    /// Look up a token's id.
+    pub fn token_to_id(&self, token: &str) -> Option<u32> {
+        self.ids.get(token).copied()
+    }
+
+    /// How many residues `sequence` encodes.
+    ///
+    /// A trailing odd character is its own (malformed) residue rather than
+    /// being dropped, so [`encode`][Self::encode] can report it as `<unk>`
+    /// instead of silently shortening the sequence.
+    pub fn residue_count(&self, sequence: &str) -> usize {
+        sequence.len().div_ceil(CHARS_PER_RESIDUE)
+    }
+
+    /// Encode a SaProt sequence to token ids, **without** special tokens.
+    ///
+    /// Unknown pairs map to `<unk>` rather than erroring: a residue whose 3Di
+    /// state could not be determined is written with a `#` placeholder in
+    /// practice, and refusing the whole sequence for one such residue would be
+    /// unhelpful.
+    pub fn encode(&self, sequence: &str) -> Vec<u32> {
+        let unk = self.ids["<unk>"];
+        sequence
+            .as_bytes()
+            .chunks(CHARS_PER_RESIDUE)
+            .map(|pair| {
+                std::str::from_utf8(pair)
+                    .ok()
+                    .and_then(|t| self.ids.get(t).copied())
+                    .unwrap_or(unk)
+            })
+            .collect()
+    }
+
+    /// Decode ids back to a SaProt sequence, skipping special tokens.
+    pub fn decode(&self, ids: &[u32]) -> String {
+        ids.iter()
+            .filter_map(|&id| self.vocab.get(id as usize))
+            .filter(|t| !(t.starts_with('<') && t.ends_with('>')))
+            .map(String::as_str)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The first lines of the real SaProt vocab.txt, plus a few residue pairs.
+    fn vocab() -> &'static str {
+        "<cls>\n<pad>\n<eos>\n<unk>\n<mask>\nAp\nAy\nAn\nMd\nLp\n"
+    }
+
+    #[test]
+    fn test_special_token_ids_match_the_config() {
+        let t = SaProtTokenizer::from_vocab_txt(vocab()).unwrap();
+        assert_eq!(t.token_to_id("<cls>"), Some(0));
+        assert_eq!(t.token_to_id("<pad>"), Some(1));
+        assert_eq!(t.token_to_id("<eos>"), Some(2));
+        assert_eq!(t.token_to_id("<unk>"), Some(3));
+        // config.json declares mask_token_id 4 and pad_token_id 1.
+        assert_eq!(t.token_to_id("<mask>"), Some(4));
+    }
+
+    /// Two characters per residue — the property the whole module exists for.
+    #[test]
+    fn test_encodes_two_characters_per_residue() {
+        let t = SaProtTokenizer::from_vocab_txt(vocab()).unwrap();
+        let ids = t.encode("ApAyAn");
+        assert_eq!(ids.len(), 3, "six characters are three residues");
+        assert_eq!(ids, vec![5, 6, 7]);
+        assert_eq!(t.residue_count("ApAyAn"), 3);
+    }
+
+    #[test]
+    fn test_unknown_pairs_become_unk_not_an_error() {
+        let t = SaProtTokenizer::from_vocab_txt(vocab()).unwrap();
+        // "Zz" is not in the vocabulary.
+        assert_eq!(t.encode("ApZz"), vec![5, 3]);
+    }
+
+    /// A trailing odd character is reported as unknown rather than dropped,
+    /// so a malformed sequence does not silently lose its last residue.
+    #[test]
+    fn test_odd_length_input_is_not_silently_truncated() {
+        let t = SaProtTokenizer::from_vocab_txt(vocab()).unwrap();
+        assert_eq!(t.residue_count("ApA"), 2);
+        assert_eq!(t.encode("ApA"), vec![5, 3]);
+    }
+
+    #[test]
+    fn test_decode_round_trips_and_drops_specials() {
+        let t = SaProtTokenizer::from_vocab_txt(vocab()).unwrap();
+        let ids = t.encode("ApMdLp");
+        assert_eq!(t.decode(&ids), "ApMdLp");
+
+        let wrapped = [&[0u32][..], &ids, &[2u32][..]].concat();
+        assert_eq!(t.decode(&wrapped), "ApMdLp", "specials should be dropped");
+    }
+
+    /// A vocab whose specials are misplaced is rejected, because those ids are
+    /// used directly rather than looked up everywhere.
+    #[test]
+    fn test_rejects_misplaced_special_tokens() {
+        let bad = "<pad>\n<cls>\n<eos>\n<unk>\n<mask>\nAp\n";
+        let err = SaProtTokenizer::from_vocab_txt(bad)
+            .map(|_| ())
+            .expect_err("swapped cls/pad must be rejected");
+        assert!(err.to_string().contains("load-bearing"), "got: {err}");
+    }
+
+    #[test]
+    fn test_rejects_a_vocab_missing_specials() {
+        let err = SaProtTokenizer::from_vocab_txt("Ap\nAy\n")
+            .map(|_| ())
+            .expect_err("a vocab without <cls> is not a SaProt vocab");
+        assert!(err.to_string().contains("missing"), "got: {err}");
+    }
+}

--- a/crates/ferritin-plms/src/lib.rs
+++ b/crates/ferritin-plms/src/lib.rs
@@ -27,6 +27,8 @@
 //! | `esm2-t33-650m` | Esm2 | `facebook/esm2_t33_650M_UR50D` (safetensors) | **not checked** | supported |
 //! | `esm2-t36-3b` | Esm2 | `facebook/esm2_t36_3B_UR50D` (safetensors) | **not checked** | supported |
 //! | `esm2-t48-15b` | Esm2 | `facebook/esm2_t48_15B_UR50D` (safetensors) | **not checked** | supported |
+//! | `saprot-35m-af2` | Esm2 | `westlake-repl/SaProt_35M_AF2` (pth) | **not checked** | supported |
+//! | `saprot-650m-af2` | Esm2 | `westlake-repl/SaProt_650M_AF2` (pth) | **not checked** | supported |
 //! | `amplify-120m` | Amplify | `chandar-lab/AMPLIFY_120M` (safetensors) | verified (`amplify_parity`) | supported |
 //! | `amplify-350m` | Amplify | `chandar-lab/AMPLIFY_350M` (safetensors) | **not checked** | supported |
 //! | `esmc-300m` | Esmc | `EvolutionaryScale/esmc-300m-2024-12` (pth) | **not checked** | supported |

--- a/crates/ferritin-plms/src/plm_runner.rs
+++ b/crates/ferritin-plms/src/plm_runner.rs
@@ -120,6 +120,20 @@ pub trait PlmRunner {
     /// Device the model's weights live on.
     fn device(&self) -> &Device;
 
+    /// How many residues `sequence` encodes.
+    ///
+    /// One per byte for the standard amino-acid alphabets, which is the
+    /// default. SaProt is the exception: it tokenizes each residue as an
+    /// (amino acid, 3Di structural state) pair over a 20x20 product alphabet,
+    /// so `"MdAaLp"` is three residues, not six (ferritin-goh.3).
+    ///
+    /// [`embed_residues`][Self::embed_residues] uses this rather than
+    /// `sequence.len()`, so a model whose alphabet is not one byte per residue
+    /// still gets exactly one row per residue.
+    fn residue_count(&self, sequence: &str) -> usize {
+        sequence.len()
+    }
+
     /// Per-residue embeddings with special-token rows removed.
     ///
     /// Shape: `(1, sequence.len(), d_model)` — guaranteed, and therefore
@@ -133,20 +147,20 @@ pub trait PlmRunner {
     fn embed_residues(&self, sequence: &str) -> Result<Tensor> {
         let raw = self.embed(sequence)?;
         let layout = self.special_tokens();
+        let residues = self.residue_count(sequence);
         let rows = raw.dim(1)?;
-        let expected = sequence.len() + layout.total();
+        let expected = residues + layout.total();
         if rows != expected {
             bail!(
-                "{}: embed() returned {rows} rows for a {}-residue sequence, but its \
+                "{}: embed() returned {rows} rows for a {residues}-residue sequence, but its \
                  declared special-token layout ({} leading, {} trailing) implies {expected}. \
                  The runner's SpecialTokenLayout does not match its tokenizer.",
                 self.model_name(),
-                sequence.len(),
                 layout.leading,
                 layout.trailing,
             );
         }
-        Ok(raw.narrow(1, layout.leading, sequence.len())?)
+        Ok(raw.narrow(1, layout.leading, residues)?)
     }
 
     /// Masked-LM logits over the token vocabulary.

--- a/crates/ferritin-plms/src/registry.rs
+++ b/crates/ferritin-plms/src/registry.rs
@@ -68,6 +68,9 @@ pub enum TokenizerSpec {
     Embedded(&'static str),
     /// A hand-written vocabulary table in Rust, named by its module path.
     BuiltinVocab(&'static str),
+    /// A bare `vocab.txt` from the model's repo — one token per line, the line
+    /// number being the id. SaProt ships this instead of a `tokenizer.json`.
+    HfVocabTxt,
     /// No tokenizer: the model consumes structure, not sequence.
     None,
 }
@@ -271,6 +274,43 @@ pub const REGISTRY: &[ModelCard] = &[
             max_positions: Some(1026),
         },
         approx_bytes_f32: 60 * GB,
+        parity: ParityStatus::Unverified,
+        unsupported: None,
+    },
+    // ── SaProt: ESM-2 architecture over a structure-aware alphabet ───────────
+    ModelCard {
+        id: "saprot-35m-af2",
+        family: Family::Esm2,
+        source: WeightSource::pth("westlake-repl/SaProt_35M_AF2", None),
+        // No safetensors in this repo; weights are a PyTorch pickle.
+        file: "pytorch_model.bin",
+        tokenizer: TokenizerSpec::HfVocabTxt,
+        specials: SpecialTokenLayout::BOS_EOS,
+        metadata: ModelMetadata {
+            d_model: 480,
+            n_layers: 12,
+            // 20x20 (amino acid, 3Di) pairs plus specials.
+            vocab_size: 446,
+            max_positions: Some(1026),
+        },
+        approx_bytes_f32: 140 * MB,
+        parity: ParityStatus::Unverified,
+        unsupported: None,
+    },
+    ModelCard {
+        id: "saprot-650m-af2",
+        family: Family::Esm2,
+        source: WeightSource::pth("westlake-repl/SaProt_650M_AF2", None),
+        file: "pytorch_model.bin",
+        tokenizer: TokenizerSpec::HfVocabTxt,
+        specials: SpecialTokenLayout::BOS_EOS,
+        metadata: ModelMetadata {
+            d_model: 1280,
+            n_layers: 33,
+            vocab_size: 446,
+            max_positions: Some(1026),
+        },
+        approx_bytes_f32: 2 * GB + 600 * MB,
         parity: ParityStatus::Unverified,
         unsupported: None,
     },

--- a/crates/ferritin-plms/tests/test_conformance.rs
+++ b/crates/ferritin-plms/tests/test_conformance.rs
@@ -55,7 +55,7 @@ mod support;
 use anyhow::{Result, bail};
 use candle_core::DType;
 use ferritin_plms::plm_runner::PlmRunner;
-use ferritin_plms::registry::{ModelCard, ParityStatus, REGISTRY};
+use ferritin_plms::registry::{ModelCard, ParityStatus, REGISTRY, TokenizerSpec};
 use ferritin_plms::{
     AmplifyModels, AmplifyRunner, ESM2Models, ESM2Runner, ESM3Models, ESM3Runner, ESMCModels,
     ESMCRunner, device,
@@ -80,6 +80,23 @@ const LOADABLE_IN_CI_MAX_BYTES: u64 = 8 * 1024 * 1024 * 1024;
 /// Ubiquitin (76 aa) — long enough to exercise attention, short enough to be fast.
 const SEQ: &str = "MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG";
 
+/// The sequence to feed a given model.
+///
+/// Most models take a plain amino-acid string. SaProt takes (amino acid, 3Di
+/// state) pairs, so feeding it [`SEQ`] would read "MQ", "IF", … as residues —
+/// none of which are in its vocabulary, making every position `<unk>`. The
+/// shape assertions would still pass, which is precisely the kind of
+/// meaningless-but-correctly-shaped input this suite exists to catch.
+///
+/// `#` is SaProt's "structure unknown" state, so `M#Q#I#…` is the documented
+/// way to run it sequence-only (ferritin-goh.3).
+fn test_sequence(card: &ModelCard) -> String {
+    match card.tokenizer {
+        TokenizerSpec::HfVocabTxt => SEQ.chars().flat_map(|c| [c, '#']).collect(),
+        _ => SEQ.to_string(),
+    }
+}
+
 /// Build the runner for a registry id.
 ///
 /// A `match` rather than anything clever: the point of the registry is that
@@ -89,6 +106,8 @@ fn runner_for(card: &ModelCard) -> Result<Box<dyn PlmRunner>> {
     let dev = device(false)?;
     Ok(match card.id {
         "esm2-t6-8m" => Box::new(ESM2Runner::from_pretrained(ESM2Models::T6_8M, dev)?),
+        "saprot-35m-af2" => Box::new(ESM2Runner::from_pretrained(ESM2Models::SaProt35M, dev)?),
+        "saprot-650m-af2" => Box::new(ESM2Runner::from_pretrained(ESM2Models::SaProt650M, dev)?),
         "esm2-t12-35m" => Box::new(ESM2Runner::from_pretrained(ESM2Models::T12_35M, dev)?),
         "esm2-t30-150m" => Box::new(ESM2Runner::from_pretrained(ESM2Models::T30_150M, dev)?),
         "esm2-t33-650m" => Box::new(ESM2Runner::from_pretrained(ESM2Models::T33_650M, dev)?),
@@ -128,19 +147,31 @@ fn conform(card: &ModelCard) -> Result<()> {
     );
 
     // ── 3. residue alignment — the contract downstream code depends on ──
-    let residues = runner.embed_residues(SEQ)?;
+    //
+    // Note this uses runner.residue_count rather than seq.len(): SaProt reads
+    // two characters per residue, and hardcoding the byte length here would
+    // re-introduce the very assumption residue_count exists to break.
+    let seq = test_sequence(card);
+    let residues_expected = runner.residue_count(&seq);
+    assert_eq!(
+        residues_expected,
+        SEQ.len(),
+        "{id}: the test sequence should encode the same 76 residues for every model"
+    );
+
+    let residues = runner.embed_residues(&seq)?;
     assert_eq!(
         residues.dim(1)?,
-        SEQ.len(),
+        residues_expected,
         "{id}: embed_residues must return exactly one row per residue"
     );
     assert_eq!(residues.dim(2)?, card.metadata.d_model, "{id}: width");
 
     // The raw form keeps the special tokens, per the declared layout.
-    let raw = runner.embed(SEQ)?;
+    let raw = runner.embed(&seq)?;
     assert_eq!(
         raw.dim(1)?,
-        SEQ.len() + card.specials.total(),
+        residues_expected + card.specials.total(),
         "{id}: embed must keep the special-token rows"
     );
 
@@ -161,7 +192,7 @@ fn conform(card: &ModelCard) -> Result<()> {
 
     // ── 4. determinism ──
     let again = runner
-        .embed_residues(SEQ)?
+        .embed_residues(&seq)?
         .to_dtype(DType::F32)?
         .flatten_all()?
         .to_vec1::<f32>()?;
@@ -255,6 +286,8 @@ fn test_every_loadable_model_can_be_constructed() {
         "esm2-t33-650m",
         "esm2-t36-3b",
         "esm2-t48-15b",
+        "saprot-35m-af2",
+        "saprot-650m-af2",
         "amplify-120m",
         "amplify-350m",
         "esmc-300m",
@@ -333,4 +366,36 @@ fn test_pr_tier_is_small() {
             card.approx_bytes_f32
         );
     }
+}
+
+/// SaProt loads and reads two characters per residue (ferritin-goh.3).
+///
+/// The residue-count property is the one worth pinning: SaProt is the first
+/// model where `sequence.len()` is not the residue count, and
+/// `embed_residues` would silently return twice as many rows as residues if
+/// `PlmRunner::residue_count` were not overridden.
+#[test]
+#[ignore = "downloads westlake-repl/SaProt_35M_AF2 (~130 MB)"]
+fn test_saprot_reads_two_chars_per_residue() -> Result<()> {
+    use ferritin_plms::registry::lookup;
+
+    let card = lookup("saprot-35m-af2").expect("registered");
+    let runner = runner_for(card)?;
+
+    // Three residues, six characters: (amino acid, 3Di state) pairs.
+    let seq = "MdAaLp";
+    assert_eq!(
+        runner.residue_count(seq),
+        3,
+        "SaProt reads two characters per residue"
+    );
+
+    let residues = runner.embed_residues(seq)?;
+    assert_eq!(
+        residues.dim(1)?,
+        3,
+        "embed_residues must return one row per residue, not per character"
+    );
+    assert_eq!(residues.dim(2)?, card.metadata.d_model);
+    Ok(())
 }

--- a/crates/ferritin-plms/tests/test_registry_conformance.rs
+++ b/crates/ferritin-plms/tests/test_registry_conformance.rs
@@ -151,6 +151,8 @@ fn test_loadable_embedding_models_are_covered() {
             "esmc-300m",
             "esmc-600m",
             "esmc-6b",
+            "saprot-35m-af2",
+            "saprot-650m-af2",
         ],
         "the set of loadable embedding models changed; add or remove a \
          conformance test to match"
@@ -186,6 +188,8 @@ fn test_uncovered_loadable_models_are_accounted_for() {
             "esm2-t33-650m",
             "esm2-t36-3b",
             "esm2-t48-15b",
+            "saprot-35m-af2",
+            "saprot-650m-af2",
             "amplify-350m",
             "esmc-600m",
             "esmc-6b",


### PR DESCRIPTION
The issue's premise holds: SaProt is the ESM-2 architecture over a 446-token (amino acid, 3Di state) alphabet, and the model code is a genuine no-op. I confirmed that by dumping the checkpoint — `esm.embeddings.*`, `esm.encoder.layer.{i}.*`, `lm_head.*`, exactly the HF `EsmForMaskedLM` layout this port already reads, differing only in vocab width.

## Two of the issue's assumptions didn't survive the repos

- **No `model.safetensors`.** All three SaProt repos ship `pytorch_model.bin` only, so they load through `Format::Pth`.
- **No `tokenizer.json`.** Just a bare 446-line `vocab.txt`. Reconstructing an HF tokenizer from it would mean assembling a `WordLevel` model plus a two-character `Split` pre-tokenizer to reproduce what is, written directly, a lookup table and `chunks(2)`.

The blocker the issue flags at the end — SaProt's config swallowed by `unwrap_or(fallback_config)` — was already fixed in #184.

## A contract problem the issue didn't anticipate

SaProt is the **first model where `sequence.len()` is not the residue count**: `"MdAaLp"` is three residues, not six. `PlmRunner::embed_residues` derived its row count from `sequence.len()`, so SaProt would have failed its own alignment check.

Added `PlmRunner::residue_count`, defaulting to `sequence.len()` and overridden for SaProt. This is the #181 contract holding up under a model that breaks its implicit assumption — which is what it was for.

## Two bugs the conformance suite found, one in itself

**The suite was wrong.** It hardcoded `SEQ.len()` as the residue count — the very assumption `residue_count` exists to break. And worse: it fed SaProt a plain amino-acid string, which SaProt reads as pairs (`"MQ"`, `"IF"`) that aren't in its vocabulary, making every position `<unk>`. **With only the arithmetic fixed, every shape assertion would have passed on meaningless input** — exactly what checks 4 and 6 exist to catch, arriving through the harness instead of the model. It now picks a per-model sequence (`M#Q#I#…`, SaProt's documented "structure unknown" state), with an assertion that every model's sequence encodes the same 76 residues.

**SaProt-650M ships no contact head** (571 keys, no `esm.contact_head.*`) while 35M does. `ESM2::load` loaded it eagerly, so a model that embeds perfectly well **failed to load at all**. Now `Option`, probed by tensor presence, with `predict_contacts` saying plainly when a checkpoint has none.

That's the third checkpoint-vs-port mismatch this session where the port assumed a uniformity the published artifacts don't have — after ESM3's `data/weights/` path (#183) and ESMC's fused re-exports (#185).

## Verified

The full nightly conformance tier passes for **all ten models**, including both SaProt variants:

```
esm2-t12-35m ✓  esm2-t30-150m ✓  esm2-t33-650m ✓
saprot-35m-af2 ✓  saprot-650m-af2 ✓
amplify-120m ✓  amplify-350m ✓
esmc-300m ✓  esmc-600m ✓  esm3-sm-open-v1 ✓
```

Per the issue, I took option (a): pre-computed 3Di strings as input. Unknown pairs map to `<unk>` rather than erroring, and an odd trailing character is reported as unknown rather than silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
