### PR TITLE
ProtBert tokenizer and config mapping; record the legacy-pickle blocker (ferritin-goh.7, ferritin-goh.10)

### DIFF
--- a/crates/ferritin-plms/src/esm2/esm2_runner.rs
+++ b/crates/ferritin-plms/src/esm2/esm2_runner.rs
@@ -5,7 +5,7 @@ use super::esm2::{ESM2, ESM2Config, ESM2Output};
 use crate::esm2::saprot_tokenizer::SaProtTokenizer;
 use crate::loader::{LoadOptions, WeightSource};
 use crate::plm_runner::{ModelMetadata, PlmRunner, SpecialTokenLayout};
-use crate::registry::{self, ModelCard, TokenizerSpec};
+use crate::registry::{self, ModelCard, TokenizerSpec, VocabAlphabet};
 use crate::types::PseudoProbability;
 use anyhow::{Error as E, Result, anyhow};
 use candle_core::{Device, Tensor};
@@ -216,7 +216,7 @@ impl ESM2Runner {
         // The alphabet follows the card, not the family: SaProt reuses this
         // architecture with a 446-token vocab.txt (ferritin-goh.3).
         let tokenizer = match card.tokenizer {
-            TokenizerSpec::HfVocabTxt => {
+            TokenizerSpec::HfVocabTxt(VocabAlphabet::SaProtPairs) => {
                 let path = source.fetch("vocab.txt")?;
                 let contents = std::fs::read_to_string(path)?;
                 SequenceTokenizer::SaProt(SaProtTokenizer::from_vocab_txt(&contents)?)

--- a/crates/ferritin-plms/src/lib.rs
+++ b/crates/ferritin-plms/src/lib.rs
@@ -44,6 +44,8 @@
 //! | `esm3-structure-encoder-v0` | Esm3 | `EvolutionaryScale/esm3-sm-open-v1` (pth) | **not checked** | **unsupported** — the ported VQ-VAE encoder is a different shape from the released checkpoint (ferritin-100.22) |
 //! | `esmfold2-fast` | Esmfold2 | `biohub/ESMFold2-Fast` (safetensors) | **not checked** | **unsupported** — the ported architecture does not match the released checkpoint (ferritin-100.17) |
 //! | `proteinmpnn-v48-020` | Mpnn | `zcpbx/ligandmpnn-weights` (pth) | **not checked** | supported |
+//! | `prot-bert` | Bert | `Rostlab/prot_bert` (pth) | **not checked** | **unsupported** — pytorch_model.bin is a legacy pre-torch-1.6 pickle (ferritin-goh.10) |
+//! | `prot-bert-bfd` | Bert | `Rostlab/prot_bert_bfd` (pth) | **not checked** | **unsupported** — same legacy pickle container as prot-bert (ferritin-goh.10) |
 //! <!-- END SUPPORT MATRIX -->
 
 // The crate deliberately uses the `foo/mod.rs` + inner `mod foo` layout for
@@ -81,11 +83,12 @@ pub mod featurize;
 pub mod ligandmpnn;
 pub mod loader;
 pub mod plm_runner;
+pub mod protbert;
 pub mod registry;
 pub mod types;
 pub mod utils;
 pub use plm_runner::{ModelMetadata, PlmRunner, SpecialTokenLayout};
-pub use registry::{Family, ModelCard, ParityStatus, REGISTRY, TokenizerSpec};
+pub use registry::{Family, ModelCard, ParityStatus, REGISTRY, TokenizerSpec, VocabAlphabet};
 
 /// Returns the best available device for computation.
 ///

--- a/crates/ferritin-plms/src/protbert/config.rs
+++ b/crates/ferritin-plms/src/protbert/config.rs
@@ -1,0 +1,166 @@
+//! Mapping ProtBert's `config.json` onto candle's BERT config.
+//!
+//! The two do not line up directly. `Rostlab/prot_bert/config.json` omits
+//! three fields that `candle_transformers::models::bert::Config` requires —
+//! `layer_norm_eps`, `pad_token_id` and `model_type` — so deserializing it
+//! straight into candle's struct fails. Rather than patch the JSON, this
+//! module parses the published shape and fills the gaps with HuggingFace's
+//! documented `BertConfig` defaults, which is what `transformers` does when it
+//! loads the same file.
+
+use candle_transformers::models::bert::{Config as BertConfig, HiddenAct, PositionEmbeddingType};
+use serde::Deserialize;
+
+/// HuggingFace `BertConfig`'s default layer-norm epsilon.
+///
+/// Not stated in either Rostlab `config.json`, so `transformers` supplies it.
+/// Recorded as a named constant because a silently different epsilon changes
+/// every layer's output slightly and would be invisible in a diff.
+const DEFAULT_LAYER_NORM_EPS: f64 = 1e-12;
+
+/// `[PAD]` is line 0 of ProtBert's `vocab.txt`.
+const PAD_TOKEN_ID: usize = 0;
+
+/// ProtBert's `config.json`, as published.
+///
+/// Only the fields the checkpoint actually declares. Anything absent is
+/// supplied by [`to_candle`][Self::to_candle] rather than defaulted here, so
+/// the distinction between "the file said this" and "we chose this" stays
+/// visible.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ProtBertConfig {
+    /// Hidden width.
+    pub hidden_size: usize,
+    /// Number of transformer blocks.
+    pub num_hidden_layers: usize,
+    /// Attention heads per block.
+    pub num_attention_heads: usize,
+    /// Feed-forward inner width.
+    pub intermediate_size: usize,
+    /// Activation; `"gelu"` in both repos.
+    pub hidden_act: HiddenAct,
+    /// Dropout probability; 0.0 in both repos, and unused at inference.
+    pub hidden_dropout_prob: f64,
+    /// Size of the learned absolute position table — 40000 here, which is
+    /// unusually large and accounts for ~164 MB of the checkpoint.
+    pub max_position_embeddings: usize,
+    /// Segment-embedding vocabulary; 2, as in stock BERT.
+    pub type_vocab_size: usize,
+    /// Weight-init range. Unused at inference, kept for fidelity.
+    pub initializer_range: f64,
+    /// Alphabet size: 5 specials plus 25 residue symbols.
+    pub vocab_size: usize,
+}
+
+impl ProtBertConfig {
+    /// Convert to the config candle's BERT implementation expects.
+    pub fn to_candle(&self) -> BertConfig {
+        BertConfig {
+            vocab_size: self.vocab_size,
+            hidden_size: self.hidden_size,
+            num_hidden_layers: self.num_hidden_layers,
+            num_attention_heads: self.num_attention_heads,
+            intermediate_size: self.intermediate_size,
+            hidden_act: self.hidden_act,
+            hidden_dropout_prob: self.hidden_dropout_prob,
+            max_position_embeddings: self.max_position_embeddings,
+            type_vocab_size: self.type_vocab_size,
+            initializer_range: self.initializer_range,
+            // Supplied, not published — see the constants above.
+            layer_norm_eps: DEFAULT_LAYER_NORM_EPS,
+            pad_token_id: PAD_TOKEN_ID,
+            position_embedding_type: PositionEmbeddingType::Absolute,
+            use_cache: false,
+            classifier_dropout: None,
+            // `BertModel::load` uses this only as a fallback weight prefix.
+            // The checkpoint is a `BertForMaskedLM`, so its parameters live
+            // under `bert.`, which `BertForMaskedLM::load` handles directly.
+            model_type: Some("bert".to_string()),
+        }
+    }
+}
+
+/// The config shared by `prot_bert` and `prot_bert_bfd`.
+///
+/// Both repos publish byte-identical `config.json` files, so one built-in
+/// config covers them. It exists as a fallback for the same reason ESM-2 has
+/// one — but note that the ESM-2 loader's silent `unwrap_or(fallback)` was a
+/// real bug (ferritin-goh.9), so any caller using this must be loud about it.
+pub fn protbert_config() -> ProtBertConfig {
+    ProtBertConfig {
+        hidden_size: 1024,
+        num_hidden_layers: 30,
+        num_attention_heads: 16,
+        intermediate_size: 4096,
+        hidden_act: HiddenAct::Gelu,
+        hidden_dropout_prob: 0.0,
+        max_position_embeddings: 40000,
+        type_vocab_size: 2,
+        initializer_range: 0.02,
+        vocab_size: 30,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The exact contents of `Rostlab/prot_bert/config.json`, and of
+    /// `Rostlab/prot_bert_bfd/config.json`, which is byte-identical.
+    const PUBLISHED: &str = r#"{
+      "architectures": ["BertForMaskedLM"],
+      "attention_probs_dropout_prob": 0.0,
+      "hidden_act": "gelu",
+      "hidden_dropout_prob": 0.0,
+      "hidden_size": 1024,
+      "initializer_range": 0.02,
+      "intermediate_size": 4096,
+      "max_position_embeddings": 40000,
+      "num_attention_heads": 16,
+      "num_hidden_layers": 30,
+      "type_vocab_size": 2,
+      "vocab_size": 30
+    }"#;
+
+    /// The published file parses. This is the check that would have caught the
+    /// mismatch had it been written before the config mapping.
+    #[test]
+    fn test_published_config_parses() {
+        let c: ProtBertConfig = serde_json::from_str(PUBLISHED).unwrap();
+        assert_eq!(c.hidden_size, 1024);
+        assert_eq!(c.num_hidden_layers, 30);
+        assert_eq!(c.num_attention_heads, 16);
+        assert_eq!(c.vocab_size, 30);
+        assert_eq!(c.max_position_embeddings, 40000);
+    }
+
+    /// candle's own `Config` cannot read the published file: it requires
+    /// `layer_norm_eps` and `pad_token_id`, which Rostlab omits. This is the
+    /// entire reason [`ProtBertConfig`] exists, so pin it — if a future candle
+    /// gives those fields defaults, this test fails and the wrapper can go.
+    #[test]
+    fn test_candle_config_cannot_read_the_published_file() {
+        let direct: Result<BertConfig, _> = serde_json::from_str(PUBLISHED);
+        assert!(
+            direct.is_err(),
+            "candle's Config parsed the published config.json; the ProtBertConfig \
+             wrapper may no longer be needed"
+        );
+    }
+
+    #[test]
+    fn test_built_in_config_matches_the_published_one() {
+        let published: ProtBertConfig = serde_json::from_str(PUBLISHED).unwrap();
+        let built_in = protbert_config();
+        let (a, b) = (published.to_candle(), built_in.to_candle());
+        assert_eq!(a, b, "the built-in fallback has drifted from config.json");
+    }
+
+    #[test]
+    fn test_defaults_are_supplied_for_the_omitted_fields() {
+        let c = protbert_config().to_candle();
+        assert_eq!(c.layer_norm_eps, DEFAULT_LAYER_NORM_EPS);
+        assert_eq!(c.pad_token_id, PAD_TOKEN_ID, "[PAD] is line 0 of vocab.txt");
+        assert_eq!(c.position_embedding_type, PositionEmbeddingType::Absolute);
+    }
+}

--- a/crates/ferritin-plms/src/protbert/mod.rs
+++ b/crates/ferritin-plms/src/protbert/mod.rs
@@ -1,0 +1,27 @@
+//! ProtBert — BERT over an amino-acid alphabet (ferritin-goh.7).
+//!
+//! `Rostlab/prot_bert` and `Rostlab/prot_bert_bfd` are plain BERT:
+//! `BertForMaskedLM`, hidden 1024, 30 layers, 16 heads, a 30-token vocabulary
+//! of single amino-acid letters. `candle_transformers::models::bert` already
+//! implements the architecture, so this module adds no attention or FFN code —
+//! only a config mapping and the [`tokenizer`].
+//!
+//! # Status: the weights cannot currently be loaded
+//!
+//! Both repos publish `pytorch_model.bin` in PyTorch's **legacy**
+//! (pre-1.6) pickle container, not the zip-based one. `candle`'s `PthTensors`
+//! opens a `.pth` as a zip archive, so it rejects these files outright with
+//! `invalid Zip archive: Could not find EOCD`. Neither repo ships safetensors,
+//! and no upstream mirror does either.
+//!
+//! What that leaves is real but partial, so it is kept rather than deleted:
+//! the [`tokenizer`] and [`config`] mapping are implemented and unit-tested
+//! against the published `vocab.txt` and `config.json`, and the registry rows
+//! carry `unsupported` explaining why they cannot load. Reading the weights
+//! needs a legacy-pickle reader, tracked as `ferritin-goh.10`.
+
+pub mod config;
+pub mod tokenizer;
+
+pub use config::{ProtBertConfig, protbert_config};
+pub use tokenizer::{ProtBertTokenizer, UNKNOWN_RESIDUE};

--- a/crates/ferritin-plms/src/protbert/tokenizer.rs
+++ b/crates/ferritin-plms/src/protbert/tokenizer.rs
@@ -1,0 +1,268 @@
+//! ProtBert's residue tokenizer (ferritin-goh.7).
+//!
+//! ProtBert is BERT over an alphabet of single amino-acid letters. Upstream it
+//! is driven by a `BertTokenizer` in WordPiece mode, which splits on
+//! **whitespace** — so the documented way to call it is `"M L K L R V"`, not
+//! `"MLKLRV"`.
+//!
+//! That detail is the reason this module exists rather than a `TokenizerSpec`
+//! pointing at a stock tokenizer. Handing WordPiece an unspaced sequence does
+//! not fail: `"MLKLRV"` is not in the vocabulary and there are no `##`
+//! continuation tokens to fall back on, so the whole protein collapses to a
+//! single `[UNK]`. The model then returns a confident, correctly-shaped
+//! embedding of the wrong length. Nothing raises.
+//!
+//! So the whitespace convention is treated here as an artifact of the upstream
+//! tokenizer, not as part of this crate's contract. [`encode`][Self::encode]
+//! ignores whitespace entirely and reads one residue per character, which makes
+//! `"MLKLRV"` and `"M L K L R V"` the same six residues. Callers pass sequences
+//! in the same form as for every other model in the registry.
+//!
+//! # Why not `tokenizers::Tokenizer`
+//!
+//! Neither `Rostlab/prot_bert` nor `Rostlab/prot_bert_bfd` ships a
+//! `tokenizer.json` — only a 30-line `vocab.txt`. Reconstructing an HF
+//! tokenizer would mean assembling a `WordPiece` model plus a whitespace
+//! pre-tokenizer in order to reproduce, at more cost, the behaviour this file
+//! states directly: a lookup table over single characters.
+//!
+//! # Vocabulary layout
+//!
+//! ```text
+//! 0  [PAD]
+//! 1  [UNK]
+//! 2  [CLS]
+//! 3  [SEP]
+//! 4  [MASK]
+//! 5+ L A G V E S I K R D T P N Q F Y M H C W X U B Z O
+//! ```
+
+use anyhow::{Result, bail};
+use std::collections::HashMap;
+
+/// The token an unrecognised residue becomes.
+///
+/// `X` — "any amino acid" — rather than `[UNK]`. Rostlab's own usage
+/// documentation preprocesses sequences with `re.sub(r"[UZOB]", "X", seq)`
+/// before tokenizing, so `X` is the symbol this checkpoint was actually
+/// trained to read for an uninformative residue. `[UNK]` exists in the
+/// vocabulary but denotes a token outside the alphabet altogether, which is a
+/// different statement and one the model saw far less of.
+pub const UNKNOWN_RESIDUE: &str = "X";
+
+/// A tokenizer built from ProtBert's `vocab.txt`.
+#[derive(Debug, Clone)]
+pub struct ProtBertTokenizer {
+    ids: HashMap<String, u32>,
+    vocab: Vec<String>,
+}
+
+impl ProtBertTokenizer {
+    /// Parse a `vocab.txt`: one token per line, the line number being the id.
+    ///
+    /// The special-token ids are checked against `config.json`'s declared
+    /// values rather than trusted, because they are used positionally:
+    /// `[CLS]`/`[SEP]` wrap every sequence and `[PAD]` id 0 is what a batched
+    /// attention mask is built against. A vocab whose order differs would
+    /// otherwise load cleanly and be wrong.
+    pub fn from_vocab_txt(contents: &str) -> Result<Self> {
+        let vocab: Vec<String> = contents
+            .lines()
+            .map(|l| l.trim_end_matches('\r').to_string())
+            .filter(|l| !l.is_empty())
+            .collect();
+
+        if vocab.is_empty() {
+            bail!("ProtBert vocab.txt is empty");
+        }
+
+        let ids: HashMap<String, u32> = vocab
+            .iter()
+            .enumerate()
+            .map(|(i, t)| (t.clone(), i as u32))
+            .collect();
+
+        for (expected_id, token) in [
+            (0u32, "[PAD]"),
+            (1, "[UNK]"),
+            (2, "[CLS]"),
+            (3, "[SEP]"),
+            (4, "[MASK]"),
+        ] {
+            match ids.get(token) {
+                Some(&id) if id == expected_id => {}
+                Some(&id) => bail!(
+                    "ProtBert vocab.txt has {token} at id {id}, expected {expected_id}; \
+                     the special-token ids are load-bearing"
+                ),
+                None => bail!("ProtBert vocab.txt is missing {token}"),
+            }
+        }
+
+        if !ids.contains_key(UNKNOWN_RESIDUE) {
+            bail!(
+                "ProtBert vocab.txt has no {UNKNOWN_RESIDUE} token to map \
+                 unrecognised residues onto"
+            );
+        }
+
+        Ok(Self { ids, vocab })
+    }
+
+    /// Number of tokens in the vocabulary.
+    pub fn len(&self) -> usize {
+        self.vocab.len()
+    }
+
+    /// Whether the vocabulary is empty. Never true for a valid vocab.
+    pub fn is_empty(&self) -> bool {
+        self.vocab.is_empty()
+    }
+
+    /// Look up a token's id.
+    pub fn token_to_id(&self, token: &str) -> Option<u32> {
+        self.ids.get(token).copied()
+    }
+
+    /// How many residues `sequence` encodes.
+    ///
+    /// Whitespace is separator, not content, so `"M L K"` and `"MLK"` both
+    /// count three.
+    pub fn residue_count(&self, sequence: &str) -> usize {
+        sequence.chars().filter(|c| !c.is_whitespace()).count()
+    }
+
+    /// Encode a sequence to token ids, **without** `[CLS]`/`[SEP]`.
+    ///
+    /// Accepts spaced and unspaced input identically; unrecognised residues
+    /// become [`UNKNOWN_RESIDUE`].
+    pub fn encode(&self, sequence: &str) -> Vec<u32> {
+        let unknown = self.ids[UNKNOWN_RESIDUE];
+        sequence
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .map(|c| {
+                self.ids
+                    .get(c.to_ascii_uppercase().to_string().as_str())
+                    .copied()
+                    .unwrap_or(unknown)
+            })
+            .collect()
+    }
+
+    /// Wrap encoded ids in `[CLS]` … `[SEP]`, the form the model expects.
+    pub fn encode_with_specials(&self, sequence: &str) -> Vec<u32> {
+        let mut ids = Vec::with_capacity(self.residue_count(sequence) + 2);
+        ids.push(self.ids["[CLS]"]);
+        ids.extend(self.encode(sequence));
+        ids.push(self.ids["[SEP]"]);
+        ids
+    }
+
+    /// Decode ids back to a sequence, skipping special tokens.
+    pub fn decode(&self, ids: &[u32]) -> String {
+        ids.iter()
+            .filter_map(|&id| self.vocab.get(id as usize))
+            .filter(|t| !(t.starts_with('[') && t.ends_with(']')))
+            .map(String::as_str)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The real ProtBert vocab.txt: 5 specials then 25 residue symbols.
+    fn vocab() -> &'static str {
+        "[PAD]\n[UNK]\n[CLS]\n[SEP]\n[MASK]\nL\nA\nG\nV\nE\nS\nI\nK\nR\nD\nT\nP\nN\nQ\nF\nY\nM\nH\nC\nW\nX\nU\nB\nZ\nO\n"
+    }
+
+    #[test]
+    fn test_special_token_ids_match_the_config() {
+        let t = ProtBertTokenizer::from_vocab_txt(vocab()).unwrap();
+        assert_eq!(t.token_to_id("[PAD]"), Some(0));
+        assert_eq!(t.token_to_id("[UNK]"), Some(1));
+        assert_eq!(t.token_to_id("[CLS]"), Some(2));
+        assert_eq!(t.token_to_id("[SEP]"), Some(3));
+        assert_eq!(t.token_to_id("[MASK]"), Some(4));
+        assert_eq!(t.len(), 30, "config.json declares vocab_size 30");
+    }
+
+    /// The property the whole module exists for: the spacing ProtBert's own
+    /// tokenizer requires is not part of this crate's contract, so both forms
+    /// give the same residues.
+    #[test]
+    fn test_spaced_and_unspaced_input_are_identical() {
+        let t = ProtBertTokenizer::from_vocab_txt(vocab()).unwrap();
+        assert_eq!(t.encode("MLKLRV"), t.encode("M L K L R V"));
+        assert_eq!(t.residue_count("MLKLRV"), 6);
+        assert_eq!(t.residue_count("M L K L R V"), 6);
+    }
+
+    /// Upstream, an unspaced sequence collapses to one `[UNK]`. If that ever
+    /// starts happening here, every downstream embedding is silently the wrong
+    /// length — so pin the token count explicitly.
+    #[test]
+    fn test_unspaced_sequence_is_not_one_unknown_token() {
+        let t = ProtBertTokenizer::from_vocab_txt(vocab()).unwrap();
+        let ids = t.encode("MLKLRV");
+        assert_eq!(ids.len(), 6, "one token per residue, not one per word");
+        assert!(
+            !ids.contains(&t.token_to_id("[UNK]").unwrap()),
+            "every residue here is in the vocabulary"
+        );
+    }
+
+    #[test]
+    fn test_unknown_residues_become_x_not_unk() {
+        let t = ProtBertTokenizer::from_vocab_txt(vocab()).unwrap();
+        // 'J' is not an amino-acid symbol in this alphabet.
+        let ids = t.encode("MJL");
+        assert_eq!(ids, vec![21, 25, 5], "J maps to X (25), not [UNK] (1)");
+    }
+
+    /// U, B, Z and O are rare but genuinely in the alphabet — they must survive
+    /// rather than being folded into X.
+    #[test]
+    fn test_rare_residues_are_not_folded_into_x() {
+        let t = ProtBertTokenizer::from_vocab_txt(vocab()).unwrap();
+        let x = t.token_to_id("X").unwrap();
+        for residue in ["U", "B", "Z", "O"] {
+            let ids = t.encode(residue);
+            assert_ne!(ids[0], x, "{residue} is in the vocabulary in its own right");
+        }
+    }
+
+    #[test]
+    fn test_specials_wrap_the_sequence() {
+        let t = ProtBertTokenizer::from_vocab_txt(vocab()).unwrap();
+        let ids = t.encode_with_specials("MLK");
+        assert_eq!(ids.first(), Some(&2), "[CLS] leads");
+        assert_eq!(ids.last(), Some(&3), "[SEP] trails");
+        assert_eq!(ids.len(), 5, "three residues plus two specials");
+    }
+
+    #[test]
+    fn test_decode_round_trips_and_drops_specials() {
+        let t = ProtBertTokenizer::from_vocab_txt(vocab()).unwrap();
+        assert_eq!(t.decode(&t.encode_with_specials("MLKLRV")), "MLKLRV");
+    }
+
+    #[test]
+    fn test_rejects_misplaced_special_tokens() {
+        let bad = "[UNK]\n[PAD]\n[CLS]\n[SEP]\n[MASK]\nL\nX\n";
+        let err = ProtBertTokenizer::from_vocab_txt(bad)
+            .map(|_| ())
+            .expect_err("swapped pad/unk must be rejected");
+        assert!(err.to_string().contains("load-bearing"), "got: {err}");
+    }
+
+    #[test]
+    fn test_rejects_a_vocab_missing_specials() {
+        let err = ProtBertTokenizer::from_vocab_txt("L\nA\nG\n")
+            .map(|_| ())
+            .expect_err("a vocab without [PAD] is not a ProtBert vocab");
+        assert!(err.to_string().contains("missing"), "got: {err}");
+    }
+}

--- a/crates/ferritin-plms/src/registry.rs
+++ b/crates/ferritin-plms/src/registry.rs
@@ -51,6 +51,8 @@ pub enum Family {
     Esmfold2,
     /// ProteinMPNN / LigandMPNN — inverse folding, not an embedding model.
     Mpnn,
+    /// ProtBert — plain BERT over an amino-acid alphabet.
+    Bert,
 }
 
 // ── TokenizerSpec ─────────────────────────────────────────────────────────────
@@ -69,10 +71,29 @@ pub enum TokenizerSpec {
     /// A hand-written vocabulary table in Rust, named by its module path.
     BuiltinVocab(&'static str),
     /// A bare `vocab.txt` from the model's repo — one token per line, the line
-    /// number being the id. SaProt ships this instead of a `tokenizer.json`.
-    HfVocabTxt,
+    /// number being the id. SaProt and ProtBert both ship this instead of a
+    /// `tokenizer.json`, over completely different alphabets, so the file
+    /// format alone does not say how to read a sequence.
+    HfVocabTxt(VocabAlphabet),
     /// No tokenizer: the model consumes structure, not sequence.
     None,
+}
+
+/// How to read a sequence against a bare `vocab.txt`.
+///
+/// Split out from [`TokenizerSpec::HfVocabTxt`] because that variant used to
+/// mean "SaProt" in practice: both the runner and the conformance suite
+/// branched on it to pick SaProt's two-character alphabet. ProtBert ships the
+/// same kind of file over a one-character alphabet, so registering it would
+/// silently have fed it `M#Q#I#…` and asserted on the result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VocabAlphabet {
+    /// SaProt: two characters per residue over a 20x20 (amino acid, 3Di)
+    /// product alphabet, with `<cls>`/`<pad>`/`<eos>`/`<unk>` specials.
+    SaProtPairs,
+    /// ProtBert: one character per residue over the amino-acid alphabet, with
+    /// `[PAD]`/`[UNK]`/`[CLS]`/`[SEP]`/`[MASK]` specials.
+    SingleResidue,
 }
 
 // ── ParityStatus ──────────────────────────────────────────────────────────────
@@ -159,6 +180,7 @@ impl ModelCard {
             Family::Esm3 => "esm3",
             Family::Esmfold2 => "esmfold2",
             Family::Mpnn => "proteinmpnn",
+            Family::Bert => "protbert",
         }
     }
 }
@@ -401,7 +423,7 @@ pub const REGISTRY: &[ModelCard] = &[
         source: WeightSource::pth("westlake-repl/SaProt_35M_AF2", None),
         // No safetensors in this repo; weights are a PyTorch pickle.
         file: "pytorch_model.bin",
-        tokenizer: TokenizerSpec::HfVocabTxt,
+        tokenizer: TokenizerSpec::HfVocabTxt(VocabAlphabet::SaProtPairs),
         specials: SpecialTokenLayout::BOS_EOS,
         metadata: ModelMetadata {
             d_model: 480,
@@ -419,7 +441,7 @@ pub const REGISTRY: &[ModelCard] = &[
         family: Family::Esm2,
         source: WeightSource::pth("westlake-repl/SaProt_650M_AF2", None),
         file: "pytorch_model.bin",
-        tokenizer: TokenizerSpec::HfVocabTxt,
+        tokenizer: TokenizerSpec::HfVocabTxt(VocabAlphabet::SaProtPairs),
         specials: SpecialTokenLayout::BOS_EOS,
         metadata: ModelMetadata {
             d_model: 1280,
@@ -612,6 +634,56 @@ pub const REGISTRY: &[ModelCard] = &[
         parity: ParityStatus::Unverified,
         unsupported: None,
     },
+    // ── ProtBert: BERT over an amino-acid alphabet ───────────────────────────
+    //
+    // Both Rostlab repos ship their weights as a *legacy* (pre-torch-1.6)
+    // pickle rather than the zip-based format, so candle cannot read them at
+    // all — see the `unsupported` note. The rows are still registered because
+    // the tokenizer and config mapping are implemented and tested; only the
+    // weight container is missing.
+    ModelCard {
+        id: "prot-bert",
+        family: Family::Bert,
+        source: WeightSource::pth("Rostlab/prot_bert", None),
+        file: "pytorch_model.bin",
+        tokenizer: TokenizerSpec::HfVocabTxt(VocabAlphabet::SingleResidue),
+        specials: SpecialTokenLayout::BOS_EOS,
+        metadata: ModelMetadata {
+            d_model: 1024,
+            n_layers: 30,
+            vocab_size: 30,
+            // 40000 is what config.json declares; the learned position table
+            // really is that large, and is ~164 MB of the checkpoint on its own.
+            max_positions: Some(40000),
+        },
+        approx_bytes_f32: GB + 600 * MB,
+        parity: ParityStatus::Unverified,
+        unsupported: Some(
+            "pytorch_model.bin is a legacy pre-torch-1.6 pickle, not the zip-based format; \
+             candle's PthTensors is zip-only and fails with 'invalid Zip archive: Could not \
+             find EOCD'. No safetensors copy of the weights is published (ferritin-goh.10)",
+        ),
+    },
+    ModelCard {
+        id: "prot-bert-bfd",
+        family: Family::Bert,
+        source: WeightSource::pth("Rostlab/prot_bert_bfd", None),
+        file: "pytorch_model.bin",
+        tokenizer: TokenizerSpec::HfVocabTxt(VocabAlphabet::SingleResidue),
+        specials: SpecialTokenLayout::BOS_EOS,
+        metadata: ModelMetadata {
+            d_model: 1024,
+            n_layers: 30,
+            vocab_size: 30,
+            max_positions: Some(40000),
+        },
+        approx_bytes_f32: GB + 600 * MB,
+        parity: ParityStatus::Unverified,
+        unsupported: Some(
+            "same legacy pickle container as prot-bert, with a byte-identical config.json \
+             (ferritin-goh.10)",
+        ),
+    },
 ];
 
 // ── Support matrix ────────────────────────────────────────────────────────────
@@ -803,7 +875,15 @@ mod tests {
             .map(|c| c.id)
             .collect();
         unsupported.sort_unstable();
-        assert_eq!(unsupported, ["esm3-structure-encoder-v0", "esmfold2-fast"]);
+        assert_eq!(
+            unsupported,
+            [
+                "esm3-structure-encoder-v0",
+                "esmfold2-fast",
+                "prot-bert",
+                "prot-bert-bfd"
+            ]
+        );
 
         for card in REGISTRY.iter().filter(|c| !c.is_loadable()) {
             let reason = card.unsupported.unwrap();

--- a/crates/ferritin-plms/tests/test_conformance.rs
+++ b/crates/ferritin-plms/tests/test_conformance.rs
@@ -55,7 +55,7 @@ mod support;
 use anyhow::{Result, bail};
 use candle_core::DType;
 use ferritin_plms::plm_runner::PlmRunner;
-use ferritin_plms::registry::{ModelCard, ParityStatus, REGISTRY, TokenizerSpec};
+use ferritin_plms::registry::{ModelCard, ParityStatus, REGISTRY, TokenizerSpec, VocabAlphabet};
 use ferritin_plms::{
     AmplifyModels, AmplifyRunner, ESM2Models, ESM2Runner, ESM3Models, ESM3Runner, ESMCModels,
     ESMCRunner, device,
@@ -92,7 +92,9 @@ const SEQ: &str = "MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNI
 /// way to run it sequence-only (ferritin-goh.3).
 fn test_sequence(card: &ModelCard) -> String {
     match card.tokenizer {
-        TokenizerSpec::HfVocabTxt => SEQ.chars().flat_map(|c| [c, '#']).collect(),
+        TokenizerSpec::HfVocabTxt(VocabAlphabet::SaProtPairs) => {
+            SEQ.chars().flat_map(|c| [c, '#']).collect()
+        }
         _ => SEQ.to_string(),
     }
 }


### PR DESCRIPTION
## What this found

`ferritin-goh.7` scoped ProtBert as *"zero new architecture code — only a registry entry, a config mapping and a tokenizer."* That held for the code and not for the weights.

Both `Rostlab/prot_bert` and `Rostlab/prot_bert_bfd` publish `pytorch_model.bin` in PyTorch's **legacy** (pre-1.6) pickle container, not the zip-based one. The files open with the 10-byte legacy magic where SaProt's open with `PK`. candle's `PthTensors` is zip-only, so it rejects them outright — verified by running it, not by reading it:

```
PthTensors::new(prot_bert.bin, None)      -> Err(invalid Zip archive: Could not find EOCD)
read_pth_tensor_info(prot_bert.bin, ...)  -> Err(invalid Zip archive: Could not find EOCD)
```

Neither repo ships safetensors, and an HF search turns up no mirror of the base weights — only fine-tunes, which are not a sound base-weight source for a library. **ProtBert cannot be loaded today.** Filed as ferritin-goh.10, which goh.7 now depends on.

## What landed anyway

Everything that does not depend on the container is implemented and tested, so goh.10 is the only remaining step.

- **`protbert/tokenizer.rs`** over the published 30-line `vocab.txt`. Upstream ProtBert is driven by a WordPiece tokenizer that splits on whitespace, so `"MLKLRV"` collapses to a single `[UNK]` and the model returns a confident, correctly-shaped embedding of the wrong length. This treats that convention as an artifact of the upstream tokenizer rather than part of the crate's contract: spaced and unspaced input encode identically. Unknown residues map to `X` (Rostlab's own documented preprocessing) rather than `[UNK]`; `U`/`B`/`Z`/`O` stay themselves. 8 unit tests.
- **`protbert/config.rs`.** candle's `bert::Config` *cannot* deserialize the published `config.json` — Rostlab omits `layer_norm_eps`, `pad_token_id` and `model_type`. The wrapper supplies HuggingFace's documented defaults, and a test pins candle's inability to read the file so the wrapper can be deleted if that ever changes. 4 unit tests.
- **Registry rows** `prot-bert` and `prot-bert-bfd` under a new `Family::Bert`, carrying `unsupported: Some(..)` citing goh.10 — the mechanism `esm3-structure-encoder-v0` and `esmfold2-fast` already use.

## Latent bug fixed on the way

`TokenizerSpec::HfVocabTxt` was in practice a proxy for "SaProt". Both `esm2_runner.rs` and `tests/test_conformance.rs` branched on it — the latter to build SaProt's two-character `M#Q#I#…` alphabet. Registering ProtBert under it would have silently fed a one-character-alphabet model SaProt's sequence and asserted on the result. The variant is now `HfVocabTxt(VocabAlphabet)`, naming `SaProtPairs` and `SingleResidue`.

## Not verified

No tensor name in either checkpoint has been inspected, because the container cannot be opened. The assumption that `BertForMaskedLM::load`'s `bert.` / `cls.` prefixes match the real state dict is **untested**, and is recorded as such on goh.7.

## Gates

`cargo test -p ferritin-plms` 172 passed / 0 failed; `cargo test --workspace` no failures; `cargo clippy --workspace --all-targets -D warnings` clean; `cargo fmt --check` clean. Support matrix in `lib.rs` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)