### PR TITLE
Port the ESM3 VQ-VAE structure encoder against the real checkpoint (ferritin-100.22)

### DIFF
--- a/crates/ferritin-plms/src/esm3/layers/blocks.rs
+++ b/crates/ferritin-plms/src/esm3/layers/blocks.rs
@@ -43,7 +43,8 @@ impl Module for SwiGLU {
 // ── ESM3 UnifiedTransformerBlock ─────────────────────────────────────────────
 
 pub struct UnifiedTransformerBlock {
-    attn: MultiHeadAttention,
+    /// Absent in the structure encoder, whose blocks are geometric-only.
+    attn: Option<MultiHeadAttention>,
     geom_attn: Option<GeometricReasoningOriginalImpl>,
     ffn: SwiGLU,
     scaling_factor: f64,
@@ -54,7 +55,7 @@ impl UnifiedTransformerBlock {
         // Build an ESMCConfig shim so we can reuse the existing load() implementations.
         let esmc_cfg = esmc_config_from_esm3(config);
 
-        let attn = MultiHeadAttention::load(vb.pp("attn"), &esmc_cfg)?;
+        let attn = Some(MultiHeadAttention::load(vb.pp("attn"), &esmc_cfg)?);
 
         let geom_attn = if layer_idx < config.n_layers_geom {
             // Checkpoints name this block "geom_attn", not "geometric"
@@ -77,6 +78,27 @@ impl UnifiedTransformerBlock {
         })
     }
 
+    /// A geometric-only block, as used by the ESM3 structure encoder.
+    ///
+    /// The released `esm3_structure_encoder_v0.pth` has no `attn.*` tensors at
+    /// all — its two blocks are `geom_attn` plus `ffn`. Loading it through
+    /// [`load`][Self::load] fails on `attn.layernorm_qkv.0.weight`, which is
+    /// how this difference was found (ferritin-100.22).
+    pub fn load_geometric(vb: VarBuilder, config: &ESM3Config) -> Result<Self> {
+        let esmc_cfg = esmc_config_from_esm3(config);
+        let geom_attn = Some(GeometricReasoningOriginalImpl::load(
+            vb.pp("geom_attn"),
+            &esmc_cfg,
+        )?);
+        let ffn = SwiGLU::load(vb.pp("ffn"), config)?;
+        Ok(Self {
+            attn: None,
+            geom_attn,
+            ffn,
+            scaling_factor: config.residue_scaling_factor(),
+        })
+    }
+
     pub fn forward(
         &self,
         x: &Tensor,
@@ -87,9 +109,11 @@ impl UnifiedTransformerBlock {
     ) -> Result<Tensor> {
         let mut x = x.clone();
 
-        // Standard multi-head attention residual
-        let r1 = self.attn.forward(&x, sequence_id)?;
-        x = (&x + (r1 / self.scaling_factor)?)?;
+        // Standard multi-head attention residual, when the block has one.
+        if let Some(attn) = &self.attn {
+            let r1 = attn.forward(&x, sequence_id)?;
+            x = (&x + (r1 / self.scaling_factor)?)?;
+        }
 
         // Geometric attention residual (only in layers where geom_attn is present)
         if let (Some(geom), Some(aff), Some(mask)) = (&self.geom_attn, affine, affine_mask) {

--- a/crates/ferritin-plms/src/esm3/layers/mod.rs
+++ b/crates/ferritin-plms/src/esm3/layers/mod.rs
@@ -3,5 +3,6 @@
 pub mod blocks;
 pub mod encode_inputs;
 pub mod output_heads;
+pub mod relative_position;
 pub mod transformer_stack;
 // VQ-VAE encoder/decoder layers tracked by ferritin-4kf

--- a/crates/ferritin-plms/src/esm3/layers/relative_position.rs
+++ b/crates/ferritin-plms/src/esm3/layers/relative_position.rs
@@ -1,0 +1,114 @@
+//! Relative position embeddings for the ESM3 structure encoder (ferritin-100.22).
+//!
+//! The structure encoder is *local*: each residue is encoded from its
+//! k-nearest neighbours in space, not from the whole chain. Those neighbours
+//! arrive in distance order, which throws away where they sat in the sequence
+//! — so the only thing telling the model that a spatial neighbour was also a
+//! sequence neighbour is this embedding.
+//!
+//! It is also the encoder's **initial hidden state**. There is no token
+//! embedding: the transformer starts from these relative offsets and lets all
+//! geometry enter through geometric attention.
+
+use candle_core::{DType, Result, Tensor};
+use candle_nn::{Embedding, Module, VarBuilder};
+
+/// Offsets are clamped to ±`BINS` before lookup.
+pub const BINS: i64 = 32;
+
+/// Table rows: `2 * BINS + 2`. The `+2` is one row per clamped extreme plus
+/// the padding index that shifts the range to be non-negative — which is why
+/// the checkpoint's table is 66 rows and not 65.
+pub const NUM_EMBEDDINGS: usize = (2 * BINS + 2) as usize;
+
+/// Embeds the signed sequence offset between a query residue and each of its
+/// spatial neighbours.
+#[derive(Debug)]
+pub struct RelativePositionEmbedding {
+    embedding: Embedding,
+}
+
+impl RelativePositionEmbedding {
+    /// Load the `(66, d_model)` table from `<prefix>.embedding.weight`.
+    pub fn load(vb: VarBuilder, d_model: usize) -> Result<Self> {
+        let weight = vb.get((NUM_EMBEDDINGS, d_model), "embedding.weight")?;
+        Ok(Self {
+            embedding: Embedding::new(weight, d_model),
+        })
+    }
+
+    /// `query`: `(N,)` centre residue indices. `key`: `(N, K)` neighbour
+    /// residue indices. Returns `(N, K, d_model)`.
+    ///
+    /// The offset is clamped to `±BINS` and then shifted by `BINS + 1`, so an
+    /// offset of `-BINS` lands on row 1 and row 0 stays reserved for padding.
+    pub fn forward(&self, query: &Tensor, key: &Tensor) -> Result<Tensor> {
+        let query = query.to_dtype(DType::I64)?.unsqueeze(1)?; // (N, 1)
+        let diff = key.to_dtype(DType::I64)?.broadcast_sub(&query)?;
+        let idx = diff.clamp(-BINS, BINS)?.affine(1.0, (BINS + 1) as f64)?;
+        self.embedding.forward(&idx.to_dtype(DType::U32)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::Device;
+
+    fn table(d: usize) -> Result<RelativePositionEmbedding> {
+        // Row i is filled with the value i, so a looked-up row reports its index.
+        let rows: Vec<f32> = (0..NUM_EMBEDDINGS)
+            .flat_map(|i| std::iter::repeat_n(i as f32, d))
+            .collect();
+        let w = Tensor::from_vec(rows, (NUM_EMBEDDINGS, d), &Device::Cpu)?;
+        Ok(RelativePositionEmbedding {
+            embedding: Embedding::new(w, d),
+        })
+    }
+
+    /// The checkpoint ships 66 rows; a 65-row table would mean the padding
+    /// offset was dropped and every lookup would be off by one.
+    #[test]
+    fn test_table_is_sixty_six_rows() {
+        assert_eq!(NUM_EMBEDDINGS, 66);
+    }
+
+    #[test]
+    fn test_zero_offset_lands_on_the_centre_row() -> Result<()> {
+        let t = table(1)?;
+        let q = Tensor::new(&[5i64], &Device::Cpu)?;
+        let k = Tensor::new(&[[5i64]], &Device::Cpu)?;
+        let out = t.forward(&q, &k)?.flatten_all()?.to_vec1::<f32>()?;
+        assert_eq!(out[0], (BINS + 1) as f32, "offset 0 -> row BINS+1");
+        Ok(())
+    }
+
+    /// Offsets beyond the window saturate rather than wrapping into a
+    /// different residue's row, and never reach the reserved padding row 0.
+    #[test]
+    fn test_offsets_clamp_and_never_hit_the_padding_row() -> Result<()> {
+        let t = table(1)?;
+        let q = Tensor::new(&[100i64], &Device::Cpu)?;
+        let k = Tensor::new(&[[0i64, 100 - 40, 100 + 40, 200]], &Device::Cpu)?;
+        let out = t.forward(&q, &k)?.flatten_all()?.to_vec1::<f32>()?;
+        assert_eq!(out[0], 1.0, "-100 clamps to -BINS -> row 1");
+        assert_eq!(out[1], 1.0, "-40 clamps to -BINS -> row 1");
+        assert_eq!(out[2], (2 * BINS + 1) as f32, "+40 clamps to +BINS");
+        assert_eq!(out[3], (2 * BINS + 1) as f32, "+100 clamps to +BINS");
+        for v in out {
+            assert_ne!(v, 0.0, "row 0 is reserved for padding");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_sign_is_preserved() -> Result<()> {
+        let t = table(1)?;
+        let q = Tensor::new(&[10i64], &Device::Cpu)?;
+        let k = Tensor::new(&[[9i64, 11]], &Device::Cpu)?;
+        let out = t.forward(&q, &k)?.flatten_all()?.to_vec1::<f32>()?;
+        assert_eq!(out[0], BINS as f32, "offset -1");
+        assert_eq!(out[1], (BINS + 2) as f32, "offset +1");
+        Ok(())
+    }
+}

--- a/crates/ferritin-plms/src/esm3/layers/transformer_stack.rs
+++ b/crates/ferritin-plms/src/esm3/layers/transformer_stack.rs
@@ -8,7 +8,8 @@ use candle_nn::{self as nn, VarBuilder};
 
 pub struct TransformerStack {
     blocks: Vec<UnifiedTransformerBlock>,
-    norm: nn::LayerNorm,
+    /// `None` for the structure encoder, which ends without a final norm.
+    norm: Option<nn::LayerNorm>,
 }
 
 impl TransformerStack {
@@ -24,9 +25,26 @@ impl TransformerStack {
 
         // Final LayerNorm: weight only, no bias.
         let norm_weight = vb.pp("norm").get((config.d_model,), "weight")?;
-        let norm = nn::LayerNorm::new_no_bias(norm_weight, 1e-5);
+        let norm = Some(nn::LayerNorm::new_no_bias(norm_weight, 1e-5));
 
         Ok(Self { blocks, norm })
+    }
+
+    /// The stack used by the ESM3 structure encoder.
+    ///
+    /// Two differences from [`load`][Self::load], both read off the released
+    /// checkpoint rather than assumed: every block is geometric-only (there
+    /// are no `attn.*` tensors), and there is no trailing `norm.weight` —
+    /// the encoder's final normalization is the identity.
+    pub fn load_geometric_encoder(vb: VarBuilder, config: &ESM3Config) -> Result<Self> {
+        let mut blocks = Vec::with_capacity(config.n_layers);
+        for i in 0..config.n_layers {
+            blocks.push(UnifiedTransformerBlock::load_geometric(
+                vb.pp(format!("blocks.{}", i)),
+                config,
+            )?);
+        }
+        Ok(Self { blocks, norm: None })
     }
 
     /// Forward pass through the full ESM3 transformer stack.
@@ -52,7 +70,11 @@ impl TransformerStack {
             x = block.forward(&x, sequence_id, affine, affine_mask, chain_id)?;
         }
 
-        let post_norm = self.norm.forward(&x)?;
+        // The structure encoder has no final norm, so this is the identity.
+        let post_norm = match &self.norm {
+            Some(norm) => norm.forward(&x)?,
+            None => x.clone(),
+        };
         Ok((post_norm, x))
     }
 }

--- a/crates/ferritin-plms/src/esm3/models/vqvae.rs
+++ b/crates/ferritin-plms/src/esm3/models/vqvae.rs
@@ -1,14 +1,18 @@
 //! ESM3 VQ-VAE structure token encoder and decoder (vqvae.py port).
 //!
-//! `StructureTokenEncoder` maps backbone coordinates to discrete structure tokens via a
-//! 2-layer geometric mini-transformer + nearest-neighbour VQ codebook lookup.
+//! `StructureTokenEncoder` maps backbone coordinates to discrete structure
+//! tokens. It is a *local* encoder: for every residue it runs a 2-layer
+//! geometric transformer over that residue's 16 nearest neighbours in space,
+//! then quantizes the query node's output against a 4096-entry VQ codebook
+//! (ferritin-100.22).
 //!
 //! `StructureTokenDecoder` is stubbed (not needed for ESM3 inference).
 
+use crate::esm3::layers::relative_position::RelativePositionEmbedding;
 use crate::esm3::layers::transformer_stack::TransformerStack;
 use crate::esm3::models::esm3::ESM3Config;
 use crate::esm3::utils::affine3d::Affine3D;
-use candle_core::{Module, Result, Tensor};
+use candle_core::{D, DType, Module, Result, Tensor};
 use candle_nn::{self as nn, VarBuilder};
 
 // ── VQ-VAE config ─────────────────────────────────────────────────────────────
@@ -56,7 +60,12 @@ impl VqVaeConfig {
             n_layers: self.enc_n_layers,
             n_layers_geom: self.enc_n_layers, // every layer uses geometric attention
             v_head_transformer: self.enc_v_heads,
-            expansion_ratio: 8.0 / 3.0,
+            // 4, not the main model's 8/3: with the 256-rounding correction
+            // this gives an FFN hidden width of exactly 4096, matching the
+            // checkpoint's ffn.1.weight [8192, 1024] (gated, so 2x4096) and
+            // ffn.3.weight [1024, 4096]. The 8/3 used here before produced
+            // 2816 and failed to load (ferritin-100.22).
+            expansion_ratio: 4.0,
             scale_residue: false,
             mask_and_zero_frameless: true,
             qk_layernorm: true,
@@ -114,6 +123,67 @@ impl VqCodebook {
     }
 }
 
+// ── k-nearest-neighbour graph ─────────────────────────────────────────────────
+
+/// Neighbours per residue in the structure encoder's local graph.
+pub const KNN: usize = 16;
+
+/// Distance used to push invalid residues to the end of every neighbour list.
+///
+/// Finite rather than infinite: these entries are still gathered and run
+/// through the transformer (they are masked there), and an infinity would
+/// propagate NaN through the frame arithmetic instead of being ignored.
+const FAR: f64 = 1e9;
+
+/// Build the k-nearest-neighbour edge list over CA positions.
+///
+/// * `ca`    — `(B, L, 3)` CA coordinates.
+/// * `valid` — `(B, L)` 1 where the residue has a usable backbone frame.
+///
+/// Returns `(B, L, KNN)` `u32` neighbour indices, sorted by increasing
+/// distance. Because a residue is at distance zero from itself, **index 0 of
+/// each row is the residue itself** — the encoder relies on this to pick the
+/// query node back out after the transformer.
+///
+/// Residues with no frame are pushed to the end of every list rather than
+/// removed, so the edge tensor stays rectangular.
+fn knn_edges(ca: &Tensor, valid: &Tensor, knn: usize) -> Result<Tensor> {
+    let (b, l, _) = ca.dims3()?;
+    let knn = knn.min(l);
+
+    // Squared distances via ||a||^2 - 2 a·b + ||b||^2.
+    let sq = ca.sqr()?.sum_keepdim(D::Minus1)?; // (B, L, 1)
+    let cross = ca.matmul(&ca.transpose(1, 2)?)?; // (B, L, L)
+    let d2 = (sq.broadcast_add(&sq.transpose(1, 2)?)? - cross.affine(2.0, 0.0)?)?;
+
+    // Invalid residues become unreachable columns.
+    let invalid = valid
+        .to_dtype(d2.dtype())?
+        .affine(-1.0, 1.0)? // 1 - valid
+        .reshape((b, 1, l))?
+        .broadcast_as((b, l, l))?;
+    let d2 = (d2 + invalid.affine(FAR, 0.0)?)?;
+
+    let order = d2.arg_sort_last_dim(true)?; // ascending
+    order.narrow(D::Minus1, 0, knn)?.contiguous()
+}
+
+/// Gather one value per edge.
+///
+/// `src` is `(B, L, D)` and `edges` is `(B, L, K)`; the result is
+/// `(B, L, K, D)` — for each residue, the `D`-vectors of its `K` neighbours.
+fn node_gather(src: &Tensor, edges: &Tensor) -> Result<Tensor> {
+    let (b, l, d) = src.dims3()?;
+    let k = edges.dim(D::Minus1)?;
+    // gather along the residue axis wants an index of the same rank as `src`,
+    // so flatten the (L, K) grid into one axis and widen it across D.
+    let idx = edges
+        .reshape((b, l * k, 1))?
+        .broadcast_as((b, l * k, d))?
+        .contiguous()?;
+    src.contiguous()?.gather(&idx, 1)?.reshape((b, l, k, d))
+}
+
 // ── StructureTokenEncoder ─────────────────────────────────────────────────────
 
 /// Encodes backbone coordinates into discrete structure tokens via a 2-layer geometric
@@ -125,20 +195,32 @@ impl VqCodebook {
 /// - `codebook.embeddings`— `(n_codes, d_codebook)`
 pub struct StructureTokenEncoder {
     transformer: TransformerStack,
+    relative_positional_embedding: RelativePositionEmbedding,
     pre_vq_proj: nn::Linear,
     codebook: VqCodebook,
     config: VqVaeConfig,
 }
 
 impl StructureTokenEncoder {
+    /// Load from `esm3_structure_encoder_v0.pth`.
+    ///
+    /// Every prefix here was read off the real checkpoint rather than inferred
+    /// from the reference source: it roots at `transformer` (not `encoder`),
+    /// and `pre_vq_proj` carries a bias. Both were wrong before, and both
+    /// would have failed loudly — unlike the missing relative position
+    /// embedding, which simply left the encoder computing from zeros.
     pub fn load(vb: VarBuilder, config: VqVaeConfig) -> Result<Self> {
         let enc_cfg = config.encoder_esm3_config();
-        let transformer = TransformerStack::load(vb.pp("encoder"), &enc_cfg)?;
-        let pre_vq_proj =
-            nn::linear_no_bias(config.enc_d_model, config.d_codebook, vb.pp("pre_vq_proj"))?;
+        let transformer = TransformerStack::load_geometric_encoder(vb.pp("transformer"), &enc_cfg)?;
+        let relative_positional_embedding = RelativePositionEmbedding::load(
+            vb.pp("relative_positional_embedding"),
+            config.enc_d_model,
+        )?;
+        let pre_vq_proj = nn::linear(config.enc_d_model, config.d_codebook, vb.pp("pre_vq_proj"))?;
         let codebook = VqCodebook::load(vb.pp("codebook"), config.n_codes, config.d_codebook)?;
         Ok(Self {
             transformer,
+            relative_positional_embedding,
             pre_vq_proj,
             codebook,
             config,
@@ -147,36 +229,76 @@ impl StructureTokenEncoder {
 
     /// Encode backbone coordinates into structure tokens.
     ///
-    /// - `coords`:      `(B, L, 3, 3)` backbone `(N, CA, C)` positions.
-    /// - `sequence_id`: optional `(B, L)` bin-packing IDs.
-    /// - `chain_id`:    optional `(B, L)` chain IDs.
+    /// * `coords` — `(B, L, 3, 3)` backbone `(N, CA, C)` positions.
+    /// * `sequence_id` — optional `(B, L)` bin-packing ids.
     ///
-    /// Returns `(B, L)` u32 structure token indices.
-    pub fn encode(
-        &self,
-        coords: &Tensor,
-        sequence_id: Option<&Tensor>,
-        chain_id: Option<&Tensor>,
-    ) -> Result<Tensor> {
-        let b = coords.dim(0)?;
-        let l = coords.dim(1)?;
+    /// Returns `(B, L)` `u32` structure token indices.
+    ///
+    /// # Why this is not a sequence transformer
+    ///
+    /// This encoder is **local**. It does not run the transformer over the
+    /// chain; it runs it over each residue's 16 nearest neighbours in space,
+    /// as `(B*L, 16, d_model)`. The earlier port ran a full-sequence pass from
+    /// a zero hidden state, which is a different computation entirely — the
+    /// weights would load (once the prefixes were right) and the output would
+    /// be quietly meaningless.
+    pub fn encode(&self, coords: &Tensor, sequence_id: Option<&Tensor>) -> Result<Tensor> {
+        let (b, l, _, _) = coords.dims4()?;
         let device = coords.device();
         let dtype = coords.dtype();
 
         let (affine, affine_mask) = Affine3D::build_affine3d_from_coordinates(coords)?;
 
-        // Initial hidden state: zeros (all structural info enters through geometric attention)
-        let x = Tensor::zeros((b, l, self.config.enc_d_model), dtype, device)?;
+        // Neighbourhoods, in distance order: column 0 is the residue itself.
+        let ca = coords.narrow(D::Minus2, 1, 1)?.squeeze(D::Minus2)?; // (B, L, 3)
+        let edges = knn_edges(&ca, &affine_mask, KNN)?; // (B, L, K)
+        let k = edges.dim(D::Minus1)?;
 
-        let (x, _pre_norm) = self.transformer.forward(
-            &x,
-            sequence_id,
-            Some(&affine),
-            Some(&affine_mask),
-            chain_id,
+        // Gather each neighbourhood's frames and masks, flattening the residue
+        // axis into the batch so the transformer sees B*L sequences of K.
+        let rot =
+            node_gather(&affine.rot.reshape((b, l, 9))?, &edges)?.reshape((b * l, k, 3, 3))?;
+        let trans = node_gather(&affine.trans, &edges)?.reshape((b * l, k, 3))?;
+        let knn_affine = Affine3D::new(rot, trans);
+
+        let knn_affine_mask =
+            node_gather(&affine_mask.to_dtype(dtype)?.unsqueeze(D::Minus1)?, &edges)?
+                .reshape((b * l, k))?
+                .to_dtype(affine_mask.dtype())?;
+
+        let knn_sequence_id = match sequence_id {
+            Some(sid) => node_gather(&sid.to_dtype(dtype)?.unsqueeze(D::Minus1)?, &edges)?
+                .reshape((b * l, k))?
+                .to_dtype(sid.dtype())?,
+            None => Tensor::zeros((b * l, k), DType::U32, device)?,
+        };
+        let chain_id = Tensor::zeros((b * l, k), DType::U32, device)?;
+
+        // The initial hidden state is the sequence offset to each neighbour —
+        // there is no token embedding in this encoder.
+        let res_idxs = edges.reshape((b * l, k))?;
+        let centre = res_idxs.narrow(D::Minus1, 0, 1)?.squeeze(D::Minus1)?;
+        let z = self
+            .relative_positional_embedding
+            .forward(&centre, &res_idxs)?
+            .to_dtype(dtype)?;
+
+        let (z, _pre_norm) = self.transformer.forward(
+            &z,
+            Some(&knn_sequence_id),
+            Some(&knn_affine),
+            Some(&knn_affine_mask),
+            Some(&chain_id),
         )?;
 
-        let z = self.pre_vq_proj.forward(&x)?;
+        // Take the query node back out: neighbours are distance-sorted, so it
+        // is column 0.
+        let z = z
+            .reshape((b, l, k, self.config.enc_d_model))?
+            .narrow(2, 0, 1)?
+            .squeeze(2)?;
+
+        let z = self.pre_vq_proj.forward(&z)?;
         self.codebook.quantize(&z)
     }
 }
@@ -253,5 +375,127 @@ mod tests {
         assert_eq!(enc.v_head_transformer, 128);
         assert!(!enc.scale_residue);
         assert!(enc.mask_and_zero_frameless);
+    }
+}
+
+#[cfg(test)]
+mod encoder_tests {
+    use super::*;
+    use candle_core::Device;
+
+    /// Ideal alpha-helix backbone: rise 1.5 A, 100 degrees per residue.
+    ///
+    /// Real secondary structure rather than a straight line, so the geometric
+    /// attention has something to distinguish.
+    fn helix(l: usize) -> Result<Tensor> {
+        let (r, rise, turn) = (2.3f64, 1.5f64, 100f64.to_radians());
+        let mut v: Vec<f32> = Vec::with_capacity(l * 9);
+        for i in 0..l {
+            for (k, off) in [(-1.0f64), 0.0, 1.0].iter().enumerate() {
+                let _ = k;
+                let t = (i as f64 + off * 0.35) * turn;
+                let z = (i as f64 + off * 0.35) * rise;
+                v.extend_from_slice(&[(r * t.cos()) as f32, (r * t.sin()) as f32, z as f32]);
+            }
+        }
+        Tensor::from_vec(v, (1, l, 3, 3), &Device::Cpu)
+    }
+
+    /// Column 0 of every neighbour list is the residue itself.
+    ///
+    /// The encoder pulls the query node back out by taking index 0 after the
+    /// transformer, so if this ordering broke, every residue would silently be
+    /// tokenized as one of its neighbours.
+    #[test]
+    fn test_first_neighbour_is_the_residue_itself() -> Result<()> {
+        let coords = helix(12)?;
+        let ca = coords.narrow(D::Minus2, 1, 1)?.squeeze(D::Minus2)?;
+        let valid = Tensor::ones((1, 12), DType::U8, &Device::Cpu)?;
+        let edges = knn_edges(&ca, &valid, KNN)?;
+        let first = edges
+            .narrow(D::Minus1, 0, 1)?
+            .flatten_all()?
+            .to_vec1::<u32>()?;
+        assert_eq!(
+            first,
+            (0..12).collect::<Vec<u32>>(),
+            "a residue is at distance zero from itself, so it must sort first"
+        );
+        Ok(())
+    }
+
+    /// Neighbour lists are ordered by increasing distance.
+    #[test]
+    fn test_neighbours_are_distance_sorted() -> Result<()> {
+        let coords = helix(20)?;
+        let ca = coords.narrow(D::Minus2, 1, 1)?.squeeze(D::Minus2)?;
+        let valid = Tensor::ones((1, 20), DType::U8, &Device::Cpu)?;
+        let edges = knn_edges(&ca, &valid, KNN)?
+            .flatten_all()?
+            .to_vec1::<u32>()?;
+        let ca_v = ca.flatten_all()?.to_vec1::<f32>()?;
+        let k = KNN.min(20);
+        for i in 0..20 {
+            let mut prev = -1.0f32;
+            for j in 0..k {
+                let n = edges[i * k + j] as usize;
+                let d: f32 = (0..3)
+                    .map(|c| (ca_v[i * 3 + c] - ca_v[n * 3 + c]).powi(2))
+                    .sum();
+                assert!(
+                    d >= prev - 1e-4,
+                    "neighbour {j} of residue {i} is out of order"
+                );
+                prev = d;
+            }
+        }
+        Ok(())
+    }
+
+    /// A residue with no valid backbone frame is pushed to the end of every
+    /// neighbour list rather than being chosen as a near neighbour.
+    #[test]
+    fn test_invalid_residues_are_not_selected_as_neighbours() -> Result<()> {
+        let coords = helix(20)?;
+        let ca = coords.narrow(D::Minus2, 1, 1)?.squeeze(D::Minus2)?;
+        // Mark residue 1 invalid; it is spatially adjacent to residue 0.
+        let mut mask = vec![1u8; 20];
+        mask[1] = 0;
+        let valid = Tensor::from_vec(mask, (1, 20), &Device::Cpu)?;
+        let edges = knn_edges(&ca, &valid, KNN)?
+            .flatten_all()?
+            .to_vec1::<u32>()?;
+        let k = KNN.min(20);
+        // Residue 0's nearest few neighbours should skip the invalid residue 1.
+        assert!(
+            !edges[0..k / 2].contains(&1),
+            "an invalid residue must not rank as a near neighbour: {:?}",
+            &edges[0..k]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_node_gather_selects_the_named_rows() -> Result<()> {
+        // (1, 4, 2): row i is [i, i*10].
+        let src = Tensor::from_vec(
+            vec![0f32, 0., 1., 10., 2., 20., 3., 30.],
+            (1, 4, 2),
+            &Device::Cpu,
+        )?;
+        // One row per residue: 4 residues, 2 neighbours each.
+        let edges = Tensor::from_vec(vec![2u32, 0, 3, 1, 0, 3, 1, 2], (1, 4, 2), &Device::Cpu)?;
+        let out = node_gather(&src, &edges)?;
+        assert_eq!(out.dims(), &[1, 4, 2, 2]);
+        assert_eq!(
+            out.flatten_all()?.to_vec1::<f32>()?,
+            vec![
+                2., 20., 0., 0., // residue 0 gathers rows 2 and 0
+                3., 30., 1., 10., // residue 1 gathers rows 3 and 1
+                0., 0., 3., 30., // residue 2 gathers rows 0 and 3
+                1., 10., 2., 20., // residue 3 gathers rows 1 and 2
+            ]
+        );
+        Ok(())
     }
 }

--- a/crates/ferritin-plms/src/esm3/pretrained.rs
+++ b/crates/ferritin-plms/src/esm3/pretrained.rs
@@ -28,12 +28,12 @@
 //! | `codebook.embeddings`   | `codebook.*`       |
 
 use crate::esm3::models::esm3::{ESM3, ESM3Config};
-use crate::esm3::models::vqvae::StructureTokenEncoder;
+use crate::esm3::models::vqvae::{StructureTokenEncoder, VqVaeConfig};
 use crate::esm3::tokenization::sequence::tokenize_sequence;
 use crate::loader::{LoadOptions, WeightSource};
 use crate::plm_runner::{ModelMetadata, PlmRunner, SpecialTokenLayout};
 use crate::registry::{self, ModelCard};
-use anyhow::{Result, bail};
+use anyhow::Result;
 use candle_core::{Device, Tensor};
 
 // ── ESM3Models enum ───────────────────────────────────────────────────────────
@@ -46,21 +46,6 @@ pub enum ESM3Models {
 
 /// The structure encoder's registry id.
 pub const STRUCTURE_ENCODER_ID: &str = "esm3-structure-encoder-v0";
-
-/// Why [`StructureEncoderRunner::from_pretrained`] refuses to load.
-///
-/// The main ESM3 model loads correctly (ferritin-100.21), but the VQ-VAE
-/// structure encoder is a different shape from the one ported here. Its
-/// [`ModelCard`] carries the same fact in machine-readable form.
-pub const STRUCTURE_ENCODER_MISMATCH: &str = "\
-ESM3 structure-encoder weights cannot be loaded: the ported VQ-VAE encoder does not match \
-data/weights/esm3_structure_encoder_v0.pth. The checkpoint roots its stack at 'transformer', \
-not 'encoder'; its two blocks contain only geom_attn and ffn, with no multi-head 'attn' \
-sub-module and no per-stack final 'norm.weight'; it carries a \
-relative_positional_embedding.embedding.weight that this port does not model; and its \
-pre_vq_proj has a bias that the port loads without. Loading is refused rather than patched, \
-because resolving the paths without porting the real encoder would emit structure tokens that \
-look plausible and are wrong (ferritin-100.22). ESM3Runner itself is unaffected and works.";
 
 impl ESM3Models {
     /// This variant's registry id.
@@ -219,26 +204,28 @@ pub struct StructureEncoderRunner {
 }
 
 impl StructureEncoderRunner {
-    /// Loading the structure encoder is **not supported** — this always
-    /// returns an error (ferritin-100.22).
+    /// Load the VQ-VAE structure encoder (ferritin-100.22).
     ///
-    /// The ported VQ-VAE encoder does not match
-    /// `data/weights/esm3_structure_encoder_v0.pth`. See
-    /// [`STRUCTURE_ENCODER_MISMATCH`].
+    /// This used to refuse: the port targeted a network the released
+    /// checkpoint does not contain. All of those differences are now modelled
+    /// — the stack roots at `transformer`, its blocks are geometric-only with
+    /// no `attn` and no trailing `norm`, `pre_vq_proj` carries its bias, and
+    /// the relative position embedding is loaded and used as the encoder's
+    /// initial hidden state.
     pub fn from_pretrained(device: Device) -> Result<Self> {
         Self::from_pretrained_with(&LoadOptions::new(device))
     }
 
-    /// Loading the structure encoder is **not supported** — this always
-    /// returns an error (ferritin-100.22).
-    pub fn from_pretrained_with(_opts: &LoadOptions) -> Result<Self> {
-        // The registry records the same refusal, so the two cannot drift:
-        // test_structure_encoder_refusal_matches_registry pins them together.
-        debug_assert!(
-            registry::lookup(STRUCTURE_ENCODER_ID).is_some_and(|c| !c.is_loadable()),
-            "the registry should agree that the structure encoder is unsupported"
-        );
-        bail!("{STRUCTURE_ENCODER_MISMATCH}");
+    /// Load with an explicit device and dtype.
+    pub fn from_pretrained_with(opts: &LoadOptions) -> Result<Self> {
+        let card = registry::lookup(STRUCTURE_ENCODER_ID)
+            .expect("the structure encoder must have a registry entry");
+        let vb = card.source.var_builder(card.file, opts)?;
+        let encoder = StructureTokenEncoder::load(vb, VqVaeConfig::default())?;
+        Ok(Self {
+            encoder,
+            device: opts.device.clone(),
+        })
     }
 
     /// Encode backbone coordinates to structure tokens.
@@ -247,6 +234,6 @@ impl StructureEncoderRunner {
     ///
     /// Returns `(B, L)` u32 structure token indices.
     pub fn encode(&self, coords: &Tensor) -> Result<Tensor> {
-        self.encoder.encode(coords, None, None).map_err(Into::into)
+        self.encoder.encode(coords, None).map_err(Into::into)
     }
 }

--- a/crates/ferritin-plms/src/lib.rs
+++ b/crates/ferritin-plms/src/lib.rs
@@ -44,7 +44,7 @@
 //! | `esmc-600m` | Esmc | `EvolutionaryScale/esmc-600m-2024-12` (pth) | **not checked** | supported |
 //! | `esmc-6b` | Esmc | `EvolutionaryScale/esmc-6b-2024-12` (safetensors) | **not checked** | supported |
 //! | `esm3-sm-open-v1` | Esm3 | `EvolutionaryScale/esm3-sm-open-v1` (pth) | **not checked** | supported |
-//! | `esm3-structure-encoder-v0` | Esm3 | `EvolutionaryScale/esm3-sm-open-v1` (pth) | **not checked** | **unsupported** — the ported VQ-VAE encoder is a different shape from the released checkpoint (ferritin-100.22) |
+//! | `esm3-structure-encoder-v0` | Esm3 | `EvolutionaryScale/esm3-sm-open-v1` (pth) | **not checked** | supported |
 //! | `esmfold2-fast` | Esmfold2 | `biohub/ESMFold2-Fast` (safetensors) | **not checked** | **unsupported** — the ported architecture does not match the released checkpoint (ferritin-100.17) |
 //! | `proteinmpnn-v48-020` | Mpnn | `zcpbx/ligandmpnn-weights` (pth) | **not checked** | supported |
 //! <!-- END SUPPORT MATRIX -->

--- a/crates/ferritin-plms/src/registry.rs
+++ b/crates/ferritin-plms/src/registry.rs
@@ -627,11 +627,7 @@ pub const REGISTRY: &[ModelCard] = &[
         },
         approx_bytes_f32: 30 * MB,
         parity: ParityStatus::Unverified,
-        unsupported: Some(
-            "the ported VQ-VAE encoder is a different shape from the released checkpoint: its \
-             blocks have no multi-head attn, it roots at 'transformer' not 'encoder', and it \
-             carries a relative positional embedding this port does not model (ferritin-100.22)",
-        ),
+        unsupported: None,
     },
     // ── ESMFold2 ─────────────────────────────────────────────────────────────
     ModelCard {
@@ -870,7 +866,7 @@ mod tests {
             .map(|c| c.id)
             .collect();
         unsupported.sort_unstable();
-        assert_eq!(unsupported, ["esm3-structure-encoder-v0", "esmfold2-fast"]);
+        assert_eq!(unsupported, ["esmfold2-fast"]);
 
         for card in REGISTRY.iter().filter(|c| !c.is_loadable()) {
             let reason = card.unsupported.unwrap();

--- a/crates/ferritin-plms/tests/test_plm_esm3.rs
+++ b/crates/ferritin-plms/tests/test_plm_esm3.rs
@@ -278,28 +278,58 @@ fn test_esm3_parity_vs_python_reference() -> Result<()> {
     Ok(())
 }
 
-/// The structure encoder refuses to load, with the mismatch named.
+/// The structure encoder loads from the released checkpoint and emits tokens.
 ///
-/// Nothing exercised `StructureEncoderRunner` before ferritin-100.21, which is
-/// how its loading defects went unnoticed. Fixing the main model's checkpoint
-/// path revealed that the ported VQ-VAE encoder is a different shape from the
-/// released one, so it refuses rather than half-loading (ferritin-100.22).
+/// This replaces a test that asserted the encoder *refuses* to load. It did,
+/// for good reason: the port targeted a network the checkpoint does not
+/// contain. Every one of those differences is now modelled, so the refusal is
+/// gone and this pins the behaviour that replaced it (ferritin-100.22).
 ///
-/// Needs no weights: the refusal precedes any download.
+/// What this does and does not establish: it proves all 34 tensors resolve and
+/// that the encoder emits in-range, deterministic tokens. It does **not**
+/// establish numerical parity — no Python reference has been run against it,
+/// so a subtly wrong geometry would still pass here.
 #[test]
-fn test_esm3_structure_encoder_refuses_with_reason() {
+#[ignore = "downloads esm3_structure_encoder_v0.pth (~60 MB)"]
+fn test_esm3_structure_encoder_loads_and_encodes() -> anyhow::Result<()> {
+    use candle_core::Tensor;
     use ferritin_plms::esm3::pretrained::StructureEncoderRunner;
 
-    let err = StructureEncoderRunner::from_pretrained(Device::Cpu)
-        .map(|_| ())
-        .expect_err("the structure encoder must refuse while the port is mismatched");
-    let msg = err.to_string();
+    let runner = StructureEncoderRunner::from_pretrained(Device::Cpu)?;
+
+    // An ideal alpha-helix: rise 1.5 A, 100 degrees per residue.
+    let l = 32usize;
+    let (r, rise, turn) = (2.3f64, 1.5f64, 100f64.to_radians());
+    let mut v: Vec<f32> = Vec::with_capacity(l * 9);
+    for i in 0..l {
+        for off in [-1.0f64, 0.0, 1.0] {
+            let t = (i as f64 + off * 0.35) * turn;
+            let z = (i as f64 + off * 0.35) * rise;
+            v.extend_from_slice(&[(r * t.cos()) as f32, (r * t.sin()) as f32, z as f32]);
+        }
+    }
+    let coords = Tensor::from_vec(v, (1, l, 3, 3), &Device::Cpu)?;
+
+    let tokens = runner.encode(&coords)?;
+    assert_eq!(tokens.dims(), &[1, l], "one structure token per residue");
+
+    let ids = tokens.flatten_all()?.to_vec1::<u32>()?;
     assert!(
-        msg.contains("does not match"),
-        "error should name the mismatch; got: {msg}"
+        ids.iter().all(|&i| i < 4096),
+        "tokens must index the 4096-entry codebook; got max {:?}",
+        ids.iter().max()
     );
+
+    // A helix is locally periodic, so its interior should not tokenize as 32
+    // distinct states — that would mean the geometry is not reaching the
+    // codebook.
+    let distinct: std::collections::HashSet<u32> = ids[4..l - 4].iter().copied().collect();
     assert!(
-        msg.contains("ESM3Runner itself is unaffected"),
-        "error should say the main model still works; got: {msg}"
+        distinct.len() < ids[4..l - 4].len(),
+        "a regular helix should reuse structure tokens; got {distinct:?}"
     );
+
+    let again = runner.encode(&coords)?.flatten_all()?.to_vec1::<u32>()?;
+    assert_eq!(ids, again, "encoding must be deterministic");
+    Ok(())
 }


### PR DESCRIPTION
The structure encoder refused to load, because the port targeted a network the released checkpoint does not contain. All **34 tensors** of `data/weights/esm3_structure_encoder_v0.pth` now resolve, and the encoder emits structure tokens.

## The issue recorded one defect; there were seven

Six are weight-loading mismatches, found by reading the checkpoint with candle rather than inferring:

| # | Expected by the port | Actually in the checkpoint |
|---|---|---|
| 1 | roots at `encoder` | roots at `transformer` |
| 2 | `pre_vq_proj` via `linear_no_bias` | has `pre_vq_proj.bias` [128] |
| 3 | — | `relative_positional_embedding.embedding.weight` [66, 1024], unmodelled |
| 4 | `attn.layernorm_qkv.*` | **no `attn.*` at all** — blocks are geometric-only |
| 5 | trailing `norm.weight` | **absent** — final norm is the identity |
| 6 | expansion ratio 8/3 → hidden 2816 | ratio 4 → hidden **4096** (`ffn.1` [8192,1024] gated, `ffn.3` [1024,4096]) |

`UnifiedTransformerBlock::attn` and `TransformerStack::norm` are now `Option`, with `load_geometric` / `load_geometric_encoder` constructors mirroring the reference's `GeometricEncoderStack`.

## The seventh is not a loading problem

`encode` was **the wrong algorithm**. It initialised the hidden state to zeros and ran the transformer across the whole chain. The real encoder is *local*:

1. build a kNN graph over CA positions (k=16)
2. gather each residue's neighbourhood → `(B*L, 16, 1024)`
3. **the initial hidden state is the relative position embedding** of each neighbour's sequence offset from the query residue — that's what tensor 3 is for; there is no token embedding
4. run the two geometric blocks over the neighbourhood
5. recover the query node as column 0 (neighbours are distance-sorted, and a residue is at distance zero from itself)
6. `pre_vq_proj` → quantize against the 4096-entry codebook

**This is why the previous refusal was the right call.** With only the path fixes, the weights would have loaded and the encoder would have emitted plausible, wrong tokens.

Adds `knn_edges`, `node_gather` and `RelativePositionEmbedding` — none existed in this crate.

## What is and isn't established

**Verified:** all 34 tensors resolve; a 32-residue ideal alpha-helix encodes to in-range (<4096), deterministic tokens that repeat across the helix interior, as a periodic structure should. Neighbour ordering, self-first selection, invalid-residue exclusion and gather indexing have unit tests needing no download.

**Not verified: numerical parity.** No Python reference has been run against this — there's no torch in the environment — so a subtly wrong geometry would still pass. The row keeps `ParityStatus::Unverified` and the integration test says so in its doc comment. A fixture belongs in `scripts/generate_esm3_fixtures.py` where a Python env exists.

## Gates

`cargo test -p ferritin-plms` 172 lib + integration, 0 failed; the ignored integration test was run explicitly and passes against the real checkpoint; `cargo test --workspace` clean; `cargo clippy --workspace --all-targets -D warnings` clean; `cargo fmt --check` clean. Support matrix regenerated — `esm3-structure-encoder-v0` moves to supported, leaving `esmfold2-fast` as the only unsupported row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)