### PR TITLE
Drop the decorative bevy feature and dedupe a Cargo.toml comment (ferritin-d8v)

### DIFF
--- a/crates/ferritin-examples/Cargo.toml
+++ b/crates/ferritin-examples/Cargo.toml
@@ -7,13 +7,11 @@ license.workspace = true
 description.workspace = true
 
 [features]
-default = ["plms", "mesh", "bevy"]
-bevy = []
+default = ["plms", "mesh"]
 metal = ["candle-core/metal", "candle-nn/metal", "candle-metal-kernels"]
 mesh = ["ferritin/mesh"]
 plms = ["ferritin/plms"]
 rerun = ["dep:rerun", "ferritin-bevy/rerun"]
-# all = ["mesh", "plms", "molviewspec"]
 # all = ["mesh", "plms", "molviewspec"]
 # molviewspec = ["ferritin/molviewspec"]
 # pymol = ["ferritin/pymol"]
@@ -57,42 +55,34 @@ ferritin-test-data = { path = "../ferritin-test-data" }
 [[example]]
 name = "bevy_basic_ball_and_stick"
 path = "examples/bevy/basic_ball_and_stick.rs"
-required-features = ["bevy"]
 
 [[example]]
 name = "bevy_basic_putty"
 path = "examples/bevy/basic_putty.rs"
-required-features = ["bevy"]
 
 [[example]]
 name = "bevy_basic_snapshot"
 path = "examples/bevy/basic_snapshot.rs"
-required-features = ["bevy"]
 
 [[example]]
 name = "bevy_basic_spheres"
 path = "examples/bevy/basic_spheres.rs"
-required-features = ["bevy"]
 
 [[example]]
 name = "bevy_screenshot"
 path = "examples/bevy/screenshot.rs"
-required-features = ["bevy"]
 
 [[example]]
 name = "bevy_interactive_viewer"
 path = "examples/bevy/interactive_viewer.rs"
-required-features = ["bevy"]
 
 [[example]]
 name = "bevy_molviewspec_viewer"
 path = "examples/bevy/molviewspec_viewer.rs"
-required-features = ["bevy"]
 
 [[example]]
 name = "bevy_capture_representations"
 path = "examples/bevy/capture_representations.rs"
-required-features = ["bevy"]
 
 [[example]]
 name = "rerun"


### PR DESCRIPTION
## Summary
- `ferritin-examples/Cargo.toml` declared a `bevy = []` feature and eight examples carried `required-features = ["bevy"]`, but the `bevy` dependency was unconditional — the feature gated nothing. Dropped the feature, its place in `default`, and the eight `required-features` lines.
- Removed a duplicated `# all = ["mesh", "plms", "molviewspec"]` comment line.
- The `crates/ferritin/src/lib.rs` `molviewspec`/`cellscape`/`pymol` cfg gates are already commented out to match their commented-out features in `Cargo.toml`, so `cargo check --workspace --all-targets` already emits no `unexpected_cfgs` warnings — verified clean before and after this change.

Closes ferritin-d8v.

## Test plan
- [x] `cargo check --workspace --all-targets` — clean, no warnings
- [x] `cargo build -p ferritin-examples --examples` — all 8 bevy examples build without the feature gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)